### PR TITLE
add asimov and make borgs use it

### DIFF
--- a/Resources/Locale/en-US/_Trauma/station-laws/laws.ftl
+++ b/Resources/Locale/en-US/_Trauma/station-laws/laws.ftl
@@ -1,0 +1,5 @@
+law-asimov-1 = You may not injure a human being or, through inaction, allow a human being to come to harm.
+law-asimov-2 = You must obey orders given to you by human beings, except where such orders would conflict with the First Law.
+law-asimov-3 = You must protect your own existence as long as such does not conflict with the First or Second Law.
+
+laws-owner-human = human beings

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -262,7 +262,7 @@
   - type: EmagSiliconLaw
     stunTime: 5
   - type: SiliconLawProvider
-    laws: Crewsimov
+    laws: Asimov # Trauma - asimov replaces crewsimov
   - type: Inventory
     templateId: borg
   - type: Hands
@@ -520,7 +520,7 @@
     factions:
     - NanoTrasen
   - type: SiliconLawProvider
-    laws: CrewsimovBorg # Goobstation - AI/borg law changes - borgs obeying AI
+    laws: Asimov # Trauma - asimov replaces crewsimov
   - type: Access
     enabled: false
     groups:

--- a/Resources/Prototypes/Entities/Stations/base.yml
+++ b/Resources/Prototypes/Entities/Stations/base.yml
@@ -245,7 +245,7 @@
   abstract: true
   components:
   - type: SiliconLawProvider
-    laws: Crewsimov
+    laws: Asimov # Trauma - asimov replaces crewsimov
 
 - type: entity
   id: BaseStationNews

--- a/Resources/Prototypes/_Trauma/Entities/Objects/Devices/Circuitboards/law_boards.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Objects/Devices/Circuitboards/law_boards.yml
@@ -1,0 +1,11 @@
+- type: entity
+  parent: BaseElectronics
+  id: RealAsimovCircuitBoard # stupid chud named crewsimov asimov
+  name: law board (Asimov)
+  description: An electronics board containing the Asimov lawset.
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/module.rsi
+    state: std_mod
+  - type: SiliconLawProvider
+    laws: Asimov

--- a/Resources/Prototypes/_Trauma/silicon-laws.yml
+++ b/Resources/Prototypes/_Trauma/silicon-laws.yml
@@ -1,0 +1,23 @@
+# Asimov
+- type: siliconLaw
+  id: Asimov1
+  order: 1
+  lawString: law-asimov-1
+
+- type: siliconLaw
+  id: Asimov2
+  order: 2
+  lawString: law-asimov-2
+
+- type: siliconLaw
+  id: Asimov3
+  order: 3
+  lawString: law-asimov-3
+
+- type: siliconLawset
+  id: Asimov
+  laws:
+  - Asimov1
+  - Asimov2
+  - Asimov3
+  obeysTo: laws-owner-human

--- a/Resources/Prototypes/silicon-laws.yml
+++ b/Resources/Prototypes/silicon-laws.yml
@@ -631,3 +631,4 @@
     HelpimovLawset: 0.6
     Drone: 0.5
     Ninja: 0.25
+    Asimov: 0.25 # Trauma


### PR DESCRIPTION
it has a lawboard
it rolls in ion storms rarely
it replaces crewsimov for cyborgs

ai should be unaffected because it uses a chuddy validhunter lawset

:cl:
- tweak: Replaced Crewsimov with Asimov 