### PR TITLE
buff pitchfork damage

### DIFF
--- a/Resources/Prototypes/_Trauma/Entities/Objects/Weapons/Melee/revmelee.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Objects/Weapons/Melee/revmelee.yml
@@ -121,7 +121,7 @@
   - type: IncreaseDamageOnWield
     damage:
       types:
-        Piercing: 8
+        Piercing: 16
   - type: Wieldable
   - type: DamageOtherOnHit
     damage:


### PR DESCRIPTION
## About the PR
buffed pitchfork to 24 pierce per hit

## Why / Balance
<img width="378" height="259" src="https://github.com/user-attachments/assets/62543ad7-9617-4e10-afa5-a838b4ac72e5" />

<img width="367" height="262" src="https://github.com/user-attachments/assets/bcd62a8c-21f8-44d5-b72f-8b99b906bacd" />

it was weaker than a spear you can make in 5 seconds anywhere on the station

24 is same as plasma spear, which you can make anywhere but you need 1 (one) plasma

**Changelog**
:cl:
- tweak: Buffed rev pitchfork to not be worse than a random tider spear.
