### PR TITLE
fix rev lathes working when unanchored

### DIFF
--- a/Content.Server/Lathe/LatheSystem.cs
+++ b/Content.Server/Lathe/LatheSystem.cs
@@ -273,6 +273,11 @@ namespace Content.Server.Lathe
             if (component.CurrentRecipe != null || component.Queue.Count <= 0 || !this.IsPowered(uid, EntityManager))
                 return false;
 
+            // <Trauma> no using powerless lathes if they are unanchored
+            if (!Transform(uid).Anchored)
+                return false;
+            // </Trauma>
+
             var recipeProto = component.Queue.Dequeue();
             var recipe = _proto.Index(recipeProto);
 

--- a/Content.Trauma.Server/Lathe/LatheAnchorSystem.cs
+++ b/Content.Trauma.Server/Lathe/LatheAnchorSystem.cs
@@ -1,0 +1,45 @@
+using Content.Server.Lathe;
+using Content.Server.Lathe.Components;
+using Content.Server.Power.Components;
+using Content.Shared.Lathe;
+
+namespace Content.Trauma.Server.Lathe;
+
+/// <summary>
+/// Makes unpowered lathes stop and start producing depending on being anchored.
+/// Similar to powered lathes when they lose or gain power.
+/// </summary>
+public sealed class LatheAnchorSystem : EntitySystem
+{
+    [Dependency] private readonly LatheSystem _lathe = default!;
+    [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+
+    private EntityQuery<ApcPowerReceiverComponent> _powerQuery;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        _powerQuery = GetEntityQuery<ApcPowerReceiverComponent>();
+
+        SubscribeLocalEvent<LatheComponent, AnchorStateChangedEvent>(OnStateChanged);
+    }
+
+    private void OnStateChanged(Entity<LatheComponent> ent, ref AnchorStateChangedEvent args)
+    {
+        // don't double dip, powered lathes handle it via power changed
+        if (_powerQuery.HasComp(ent))
+            return;
+
+        if (!args.Anchored)
+        {
+            RemComp<LatheProducingComponent>(ent);
+            _appearance.SetData(ent.Owner, LatheVisuals.IsRunning, false);
+        }
+        else if (ent.Comp.CurrentRecipe != null)
+        {
+            EnsureComp<LatheProducingComponent>(ent);
+            _lathe.TryStartProducing(ent, ent.Comp);
+        }
+    }
+}


### PR DESCRIPTION
## About the PR
fix bug

## Why / Balance
bug

## Technical details
lathes with no ApcPowerReceiver now have to be anchored to work

## Media
work when anchored
<img width="68" height="75" alt="21:51:11" src="https://github.com/user-attachments/assets/f47794e6-ef8a-4bf3-917b-75803a2bef59" />

no work when unanchored
<img width="128" height="130" alt="21:51:21" src="https://github.com/user-attachments/assets/fcb6a3d6-91b4-4fbb-ba00-55556b07cf4b" />

regular lathe still works
<img width="77" height="73" alt="21:52:22" src="https://github.com/user-attachments/assets/c47842bf-9b83-479b-bf02-c61c4df04178" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
any future handheld lathes will be trolled

**Changelog**
:cl:
- fix: Fixed rev machines working when unanchored.
