### PR TITLE
disable test parallelism

### DIFF
--- a/Content.IntegrationTests/AssemblyInfo.cs
+++ b/Content.IntegrationTests/AssemblyInfo.cs
@@ -12,5 +12,5 @@
 // https://github.com/dotnet/runtime/issues/107197
 // So we can't really parallelize integration tests harder either until the runtime fixes that,
 // *or* we fix serv3 to not spam expression trees.
-// Goobstation - we hit these lockups due to higher entity counts. Lowering to 2.
-[assembly: LevelOfParallelism(2)]
+// Trauma - no parallelism because it keeps OOMing test runner
+[assembly: LevelOfParallelism(1)]


### PR DESCRIPTION
so the tests dont OOM 65% of the time