### PR TITLE
make omnitool not available 5 seconds into the round

### DIFF
--- a/Resources/Prototypes/_Shitmed/Research/civilianservices.yml
+++ b/Resources/Prototypes/_Shitmed/Research/civilianservices.yml
@@ -33,7 +33,7 @@
   cost: 10000
   recipeUnlocks:
   - DefibrillatorCompact # Goob
-  - OmnimedTool # Shitmed
+  # - OmnimedTool # Trauma - slop no reason to be in same tech as other tools if you never use them
   - EnergyScalpel # Shitmed
   - AdvancedRetractor # Shitmed
   - EnergyCautery # Shitmed
@@ -176,6 +176,7 @@
   recipeUnlocks:
   - ClothingHandsGlovesSurgical
   - AutodocUpgradeKitBluespace # Goobstation
+  - OmnimedTool # Trauma - moved out of the 5m in tech
   technologyPrerequisites:
   - AdvancedCybernetics
   position: -2,9


### PR DESCRIPTION
lazy chuds never make the "upgraded" tools in the same tech because omnitool is in the same fucking tech it makes no sense

moved it into the bluespace surgery tech thats all

:cl:
- tweak: Surgical omnitools are no longer available 5 seconds into the round.