### PR TITLE
make duo abductor's agent not a cuck

### DIFF
--- a/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
@@ -482,6 +482,7 @@
       - type: Tag
         tags:
           - Abductor
+          - AbductorScientist # Trauma - stop agent being a cuck
           - CanPilot
           - FootstepSound
           - DoorBumpOpener

--- a/Resources/Prototypes/_Shitmed/Entities/Mobs/Player/abductor.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Mobs/Player/abductor.yml
@@ -153,7 +153,7 @@
     head: ClothingHeadMirror
     outerClothing: ClothingOuterCoatAbductor
     back: ClothingBackpackDuffelAbductor
-    pocket1: AbductorGizmo
+    pocket1: Silencer # Trauma - swapped silencer and gizmo
     suitstorage: WeaponDecloner
     id: AgentIDCard
 
@@ -167,7 +167,7 @@
     head: ClothingHeadHelmetAbductor
     outerClothing: ClothingOuterArmorAbductor
     back: ClothingBackpackAbductor
-    pocket1: Silencer
+    pocket1: AbductorGizmo # Trauma - swapped silencer and gizmo
     pocket2: WeaponAlien
     suitstorage: Wonderprod
     id: AgentIDCard

--- a/Resources/Prototypes/_Shitmed/GameRules/events.yml
+++ b/Resources/Prototypes/_Shitmed/GameRules/events.yml
@@ -233,6 +233,7 @@
       - type: Tag
         tags:
           - Abductor
+          - AbductorScientist # Trauma - stop agent being a cuck
           - CanPilot
           - FootstepSound
           - DoorBumpOpener


### PR DESCRIPTION
## About the PR
for duo abductors only (not lone)
- both abductors can use gizmo
- the gizmo is given to agent instead of scientist since that makes sense

## Why / Balance
agent has literally nothing to do besides powergame / murderbone unless the scientist gets himself killed, at which point agent cant do anything because if he manages to get the gizmo back he gets cucked by it using scientist tag.

now theres an actual pipeline of agent goes and steals people alone and scientist operates while agent is out in the field getting caps
they can still teleport to eachother if in danger of course

## Media

**Changelog**
:cl:
- tweak: For abductor duos, the agent can now use gizmos as well, which he gets instead of the scientist.
