### PR TITLE
Description Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ SPDX-FileCopyrightText: 2024 router <messagebus@vk.com>
 SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 SPDX-FileCopyrightText: 2025 Piras314 <p1r4s@proton.me>
 
+Edited for Trauma Station by @Paradoxum on Discord :P
+
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
@@ -34,7 +36,7 @@ If you want to host or create content for SS14, go to the [Space Station 14 repo
 
 ## Documentation/Wiki
 
-The Trauma Station document\[WIP] has documentation on GS14's content, engine, game design, and more. It also has lots of resources for new contributors to the project.
+The Trauma Station document \[WIP] has documentation on GS14's content, engine, game design, and more. It also has lots of resources for new contributors to the project.
 
 ## Contributing
 


### PR DESCRIPTION
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
The Github Description.  To have Trauma station info rather than Goob Station info

## Media
<img width="970" height="850" alt="aaaaa" src="https://github.com/user-attachments/assets/fbf82788-4f56-4c5a-8d14-f467fdcd6551" />
<img width="854" height="451" alt="aaaaa2" src="https://github.com/user-attachments/assets/80801b6d-f110-470c-ad57-5ad38bfa3b4f" />

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Updated Github Description lmfao