### PR TITLE
remove structural ammo from dt12

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -398,7 +398,7 @@
     - BulletEnergyGunExecute
     - BulletEnergyGunHotshot
     - BulletEnergyGunSleepshot
-    - BulletEnergyGunBigshot
+    #- BulletEnergyGunBigshot # Trauma - no chud anti-base instant win ammo
   - type: UserInterface
     interfaces:
       enum.AmmoSelectorUiKey.Key:


### PR DESCRIPTION
its extremely chuddy and ruins revs when you can just like 3 shot any wall to get into their base and bypass traps etc

:cl:
- remove: Removed DT-12 anti-structure firing mode.