### PR TITLE
add chokehold to cqc for sleeping

### DIFF
--- a/Resources/ServerInfo/_Goobstation/Guidebook/MartialArts/CQC.xml
+++ b/Resources/ServerInfo/_Goobstation/Guidebook/MartialArts/CQC.xml
@@ -28,6 +28,13 @@
   There is no escape from a choke grab of a CQC master. With a single Harm action to the head, the victim's neck breaks,
   killing them instantly. No armor can shield against this deadly precision. The end comes swiftly, and without mercy.
 
+  <!-- <Trauma> -->
+  ### Chokehold
+
+  The pacifist's alternative to the Neck Snap, a chokehold takes a Disarm instead of Harm action to the head.
+  This will knock the victim out for 40 seconds, but don't use it too much or they'll suffocate.
+  <!-- </Trauma> -->
+
   ## Combo attacks
 
   ### Slam


### PR DESCRIPTION
## About the PR
choke and stamcrit someone then disarm to chokehold, 40s sleep

if you spam it over and over they will eventually choke to crit :(

## Why / Balance
it was missing
no actual balance change since you can just necksnap to instakill, this is for stealing people and other evil things

tg and mgs parity

## Technical details
evil pre refactor martial arts

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- add: CQC now has the Chokehold move to put someone to sleep, like Neck Snap but disarm instead of punching.