### PR TITLE
add cqc for traitors 100tc

### DIFF
--- a/Resources/Locale/en-US/_Trauma/store/uplink/weaponry.ftl
+++ b/Resources/Locale/en-US/_Trauma/store/uplink/weaponry.ftl
@@ -1,0 +1,2 @@
+uplink-cqc-box-name = old CQC box
+uplink-cqc-box-desc = The belongings of a legendary soldier, it'll cost a fortune to buy from its collector. Weapons are to be procured on-site.

--- a/Resources/Prototypes/_Trauma/Catalog/Fills/Boxes/cqc.yml
+++ b/Resources/Prototypes/_Trauma/Catalog/Fills/Boxes/cqc.yml
@@ -1,0 +1,12 @@
+- type: entity
+  parent: BigBox
+  id: BigBoxCQC
+  suffix: Filled, CQC
+  components:
+  - type: ContainerFill
+    containers:
+      entity_storage:
+      - CQCManual # only real reason to buy it, the rest is fluff
+      - ClothingHeadHatSolidHeadband
+      - ClothingUniformJumpsuitMilitaryTurtleneckRev
+      - ClothingShoesBootsCombatFilled

--- a/Resources/Prototypes/_Trauma/Catalog/Uplink/weaponry.yml
+++ b/Resources/Prototypes/_Trauma/Catalog/Uplink/weaponry.yml
@@ -1,0 +1,14 @@
+- type: listing
+  id: UplinkCQCBox
+  name: uplink-cqc-box-name
+  description: uplink-cqc-box-desc
+  productEntity: BigBoxCQC
+  cost:
+    Telecrystal: 100
+  categories:
+  - UplinkWeaponry
+  conditions:
+  - !type:StoreWhitelistCondition # nukies get cheaper cqc manual and can just steal the drip
+    blacklist:
+      tags:
+      - NukeOpsUplink


### PR DESCRIPTION
## About the PR
traitors can buy cqc without needing to gamble for hitman bundle
it comes with some clothes for playing dress up

## Why / Balance
buy surplus for gamba, cqc shouldnt need gamba
you can still get shot with it, so scarp is generally more powerful anyway

## Media

<img width="506" height="134" alt="16:31:47" src="https://github.com/user-attachments/assets/5f199df5-3214-4add-a0c1-7d03d03e09e5" />

naked urist
<img width="369" height="83" alt="16:32:01" src="https://github.com/user-attachments/assets/bde0fa48-0251-4ed4-a757-804ed0ff4a23" />


**Changelog**
:cl:
- add: Added the old CQC box to traitor uplinks for 100TC.
