### PR TITLE
Fix audio muffle.

### DIFF
--- a/Content.Trauma.Client/AudioMuffle/AudioMuffleSystem.Pathfinding.cs
+++ b/Content.Trauma.Client/AudioMuffle/AudioMuffleSystem.Pathfinding.cs
@@ -199,7 +199,7 @@ public sealed partial class AudioMuffleSystem
                     if (TileDataDict.ContainsKey(neighbor))
                         continue;
 
-                    if (ManhattanDistance(origin, neighbor) > amount)
+                    if (Vector2.Distance(origin, neighbor) > AudioRange)
                         continue;
 
                     var moveCost = 1f;
@@ -300,7 +300,7 @@ public sealed partial class AudioMuffleSystem
                     if (!invalidated.Contains(neighbor))
                         continue;
 
-                    if (ManhattanDistance(node.Indices, neighbor) > amount)
+                    if (Vector2.Distance(node.Indices, neighbor) > AudioRange)
                         continue;
 
                     invalidated.Remove(neighbor);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->

Removed audio length check from it, I managed to fix this.
Made it so pathfinding tree doesn't extend over audio range (it is now circle and not rectangle)
Removed check for looping audio (it seems to work now)
Removed sus return mid loop.

Known issue:
Holocigar sounds awful due to being shitcode - sound volume lowers when you walk away from active position and then pops back to original volume outside of pathfinding range, all other sounds work fine.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

It checks for PredictionNeedsResetting now instead of audio length, and ignores this check only when called from StateApplied or when audio entity is outside of audible range.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Aviu
- fix: Fix audio muffle being shitty in some scenarios.