### PR TITLE
add pirate clothes to hacked autodrobe

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/theater.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/theater.yml
@@ -133,10 +133,14 @@
     ClothingHeadHatCowboyBountyHunter: 1
     ToyFigurineBoxer: 1
     ToyFigurineMusician: 1
-    # <Goob>
+    # <Trauma>
     WeaponLauncherTaiwanPond: 1
     GrenadeToy: 5
     ClothingShoesResonant: 1
     ClothingNeckCloakResonant: 1
     ClothingUniformJumpsuitResonant: 1
-    # </Goob>
+    ClothingHeadHatPirate: 2
+    ClothingOuterCoatPirate: 2
+    ClothingUniformJumpsuitPirate: 2
+    ClothingEyesEyepatch: 2
+    # </Trauma>


### PR DESCRIPTION
add some pirate clothes, notably eyepatch which was virtually unobtainable outside of mapping or extremely good rng in random dressers

boots arent included so you have a reason to buy the crate at cargo

:cl:
- add: Added pirate clothes to hacked autodrobes.