### PR TITLE
fix kammerer cycling

### DIFF
--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
@@ -245,13 +245,15 @@ public abstract partial class SharedGunSystem
             if (component.Entities.Count > 0)
             {
                 var existingEnt = component.Entities[^1];
-                if (!component.AutoCycle) //  Goobstation - do not remove spent ammo from the gun it doesn't autocycle
-                    break;
-
-                component.Entities.RemoveAt(component.Entities.Count - 1);
-                DirtyField(uid, component, nameof(BallisticAmmoProviderComponent.Entities));
-                Containers.Remove(existingEnt, component.Container);
-                ammoEntity = existingEnt;
+                // <Goob> - check AutoCycle before removing spent ammo
+                if (component.AutoCycle)
+                {
+                    component.Entities.RemoveAt(component.Entities.Count - 1);
+                    DirtyField(uid, component, nameof(BallisticAmmoProviderComponent.Entities));
+                    Containers.Remove(existingEnt, component.Container);
+                    ammoEntity = existingEnt;
+                }
+                // </Goob>
             }
             else if (component.UnspawnedCount > 0)
             {
@@ -259,14 +261,14 @@ public abstract partial class SharedGunSystem
                 DirtyField(uid, component, nameof(BallisticAmmoProviderComponent.UnspawnedCount));
                 ammoEntity = Spawn(component.Proto, args.Coordinates);
 
-                // Goobstation - put spent ammo back in the gun if it doesn't autocycle
+                // <Goob> - put spent ammo back in the gun if it doesn't autocycle
                 if (!component.AutoCycle)
                 {
                     component.Entities.Add(ammoEntity.Value);
                     Containers.Insert(ammoEntity.Value, component.Container);
                     DirtyField(uid, component, nameof(BallisticAmmoProviderComponent.Entities));
                 }
-                // Goobstation - end
+                // </Goob>
             }
 
             if (ammoEntity is { } ent)


### PR DESCRIPTION
bad logic that changed when adding to the ammo was deferred so it broke out of the loop and prevented shooting for manual cycle guns

:cl:
- fix: Fixed not being able to use kammerer shotguns.