### PR TITLE
make xenobio slimes zombie immune

### DIFF
--- a/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Mobs/NPCs/slimebase.yml
+++ b/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Mobs/NPCs/slimebase.yml
@@ -6,6 +6,7 @@
   description: It looks so much like jelly. I wonder what it tastes like?
   components:
   - type: Appearance
+  - type: ZombieImmune # xenobio II way too op
   - type: Hunger
     startingHunger: 40
     thresholds:


### PR DESCRIPTION
## About the PR
basic balance to not have 60 simplemob zombies

**Changelog**
:cl:
- tweak: Xenobio slimes can no longer become zombies.