### PR TITLE
do shove effect even if you missed

### DIFF
--- a/Content.Shared/Mobs/Systems/MobStateSystem.cs
+++ b/Content.Shared/Mobs/Systems/MobStateSystem.cs
@@ -101,7 +101,7 @@ public partial class MobStateSystem : EntitySystem
     {
         if (!_mobStateQuery.Resolve(target, ref component, false))
             return false;
-        return component.CurrentState is MobState.Critical or MobState.Dead;
+        return component.CurrentState != MobState.Alive; // Trauma - include softcrit
     }
 
     /// <summary>

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -997,12 +997,12 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
         ICommonSession? session) // Goobstation - Shove Rework
     {
         if (!ev.Target.HasValue)
-            return false;
+            return true; // Trauma - still do the animation if you missed a shove
 
         var target = GetEntity(ev.Target.Value);
 
         if (Deleted(target))
-            return false;
+            return true; // Trauma - still do the animation
 
         if (user == target) // Goobstation
         {


### PR DESCRIPTION
if you try to shove without clicking anything, it still does the effect for user feedback and timing when fighting. previously your melee would go on cooldown with no feedback whatsoever so combat feels laggy as shit for no reason

also fixed an oversight with softcrit and IsIncapacitated

<img width="103" height="133" alt="15:49:30" src="https://github.com/user-attachments/assets/941e5a01-91c0-423c-b2a7-9a88f558fe73" />


:cl:
- tweak: Missing a shove still does the effect where you clicked anyway.