### PR TITLE
leonid gun safes and areas update

### DIFF
--- a/Resources/Maps/_Trauma/leonid.yml
+++ b/Resources/Maps/_Trauma/leonid.yml
@@ -1,11 +1,11 @@
 meta:
   format: 7
   category: Map
-  engineVersion: 264.0.0
+  engineVersion: 270.1.0
   forkId: ""
   forkVersion: ""
-  time: 12/20/2025 16:15:19
-  entityCount: 35924
+  time: 01/12/2026 15:32:49
+  entityCount: 36104
 maps:
 - 1
 grids:
@@ -14509,155 +14509,35 @@ entities:
         - volume: 2500
           temperature: 293.15
           moles:
-          - 21.824879
-          - 82.10312
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
+            Oxygen: 21.824879
+            Nitrogen: 82.10312
         - volume: 2500
           immutable: True
-          moles:
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
+          moles: {}
         - volume: 2500
           temperature: 235
           moles:
-          - 27.225372
-          - 102.419266
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
+            Oxygen: 27.225372
+            Nitrogen: 102.419266
+        - volume: 2500
+          temperature: 293.15
+          moles: {}
         - volume: 2500
           temperature: 293.15
           moles:
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
+            Nitrogen: 103.92799
         - volume: 2500
           temperature: 293.15
           moles:
-          - 0
-          - 103.92799
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
+            Oxygen: 6666.982
         - volume: 2500
           temperature: 293.15
           moles:
-          - 6666.982
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
+            Nitrogen: 6666.982
         - volume: 2500
           temperature: 293.15
           moles:
-          - 0
-          - 6666.982
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-        - volume: 2500
-          temperature: 293.15
-          moles:
-          - 0
-          - 0
-          - 0
-          - 6666.982
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
+            Plasma: 6666.982
         chunkSize: 4
     - type: GasTileOverlay
     - type: RadiationGridResistance
@@ -14665,6 +14545,7 @@ entities:
       id: Leonid
     - type: ImplicitRoof
     - type: FTLDrive
+    - type: ExplosionAirtightGrid
   - uid: 4
     components:
     - type: MetaData
@@ -14706,9 +14587,6 @@ entities:
     - type: Transform
       pos: -12.45431,33.673824
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 9
     components:
     - type: Transform
@@ -16335,14 +16213,6 @@ entities:
     - type: Transform
       pos: 3.5,12.5
       parent: 2
-- proto: AirlockBlueshieldOfficerCommandLocked
-  entities:
-  - uid: 171
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -30.5,-21.5
-      parent: 2
 - proto: AirlockBrigGlassLocked
   entities:
   - uid: 172
@@ -16430,6 +16300,14 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -35.5,-19.5
+      parent: 2
+- proto: AirlockCentralCommandLocked
+  entities:
+  - uid: 171
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -30.5,-21.5
       parent: 2
 - proto: AirlockChapelLocked
   entities:
@@ -17919,6 +17797,7 @@ entities:
       pos: -44.5,-37.5
       parent: 2
     - type: StepTriggerCleanup
+      stepTrigger: 24464
   - uid: 407
     components:
     - type: Transform
@@ -19786,8 +19665,6 @@ entities:
     - type: Transform
       parent: 642
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 644
@@ -19795,8 +19672,6 @@ entities:
     - type: Transform
       parent: 642
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
 - proto: AmePartFlatpack
@@ -19806,65 +19681,41 @@ entities:
     - type: Transform
       pos: -8.485472,47.190105
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 646
     components:
     - type: Transform
       pos: -9.6449795,45.409748
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 647
     components:
     - type: Transform
       pos: -7.6938043,46.450005
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 648
     components:
     - type: Transform
       pos: -10.402139,46.126865
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 649
     components:
     - type: Transform
       pos: -8.704222,46.61679
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 650
     components:
     - type: Transform
       pos: -8.058389,46.251953
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 651
     components:
     - type: Transform
       pos: -9.131305,46.606365
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 652
     components:
     - type: Transform
       pos: -9.412555,46.231106
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 653
     components:
     - type: Transform
@@ -19875,49 +19726,31 @@ entities:
     - type: Transform
       pos: -8.079222,46.814842
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 655
     components:
     - type: Transform
       pos: -9.766722,47.429855
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 656
     components:
     - type: Transform
       pos: -8.495889,46.22068
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 657
     components:
     - type: Transform
       pos: -9.133439,45.165462
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 658
     components:
     - type: Transform
       pos: -8.591772,45.68666
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 659
     components:
     - type: Transform
       pos: -9.641722,46.710606
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: AnomalyLocator
   entities:
   - uid: 660
@@ -20332,9 +20165,6 @@ entities:
     - type: Transform
       pos: 17.488571,88.67443
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: APCHighCapacity
   entities:
   - uid: 724
@@ -20376,6 +20206,1152 @@ entities:
     components:
     - type: Transform
       pos: -11.447147,-32.344425
+      parent: 2
+- proto: AreaCafeteria
+  entities:
+  - uid: 18093
+    components:
+    - type: Transform
+      pos: -6.5,-1.5
+      parent: 2
+  - uid: 23949
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 2
+  - uid: 24242
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 2
+  - uid: 30875
+    components:
+    - type: Transform
+      pos: -6.5,-0.5
+      parent: 2
+  - uid: 35925
+    components:
+    - type: Transform
+      pos: -6.5,0.5
+      parent: 2
+  - uid: 35926
+    components:
+    - type: Transform
+      pos: -5.5,-1.5
+      parent: 2
+  - uid: 35927
+    components:
+    - type: Transform
+      pos: -5.5,-0.5
+      parent: 2
+  - uid: 35928
+    components:
+    - type: Transform
+      pos: -5.5,0.5
+      parent: 2
+  - uid: 35929
+    components:
+    - type: Transform
+      pos: -4.5,-1.5
+      parent: 2
+  - uid: 35930
+    components:
+    - type: Transform
+      pos: -4.5,-0.5
+      parent: 2
+  - uid: 35931
+    components:
+    - type: Transform
+      pos: -4.5,0.5
+      parent: 2
+  - uid: 35932
+    components:
+    - type: Transform
+      pos: -3.5,-0.5
+      parent: 2
+  - uid: 35933
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 2
+  - uid: 35934
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 2
+  - uid: 35935
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 2
+  - uid: 35936
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 2
+  - uid: 35937
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 2
+  - uid: 35938
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 2
+  - uid: 35939
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 2
+  - uid: 35940
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 2
+  - uid: 35941
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 2
+  - uid: 35942
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 2
+  - uid: 35943
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 2
+  - uid: 35944
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 2
+  - uid: 35945
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 2
+  - uid: 35946
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 2
+  - uid: 35947
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
+      parent: 2
+  - uid: 35948
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 2
+  - uid: 35949
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 2
+  - uid: 35950
+    components:
+    - type: Transform
+      pos: 2.5,-0.5
+      parent: 2
+  - uid: 35951
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 2
+  - uid: 35952
+    components:
+    - type: Transform
+      pos: 2.5,-3.5
+      parent: 2
+  - uid: 35953
+    components:
+    - type: Transform
+      pos: 2.5,-4.5
+      parent: 2
+  - uid: 35954
+    components:
+    - type: Transform
+      pos: 2.5,-5.5
+      parent: 2
+  - uid: 35955
+    components:
+    - type: Transform
+      pos: 2.5,-6.5
+      parent: 2
+  - uid: 35956
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 2
+  - uid: 35957
+    components:
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 2
+  - uid: 35958
+    components:
+    - type: Transform
+      pos: 1.5,-4.5
+      parent: 2
+  - uid: 35959
+    components:
+    - type: Transform
+      pos: 1.5,-5.5
+      parent: 2
+  - uid: 35960
+    components:
+    - type: Transform
+      pos: -1.5,-6.5
+      parent: 2
+  - uid: 35961
+    components:
+    - type: Transform
+      pos: -0.5,-2.5
+      parent: 2
+  - uid: 35962
+    components:
+    - type: Transform
+      pos: 1.5,-6.5
+      parent: 2
+  - uid: 35963
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 2
+  - uid: 35964
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 2
+  - uid: 35965
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 2
+  - uid: 35966
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 2
+  - uid: 35967
+    components:
+    - type: Transform
+      pos: 0.5,-6.5
+      parent: 2
+  - uid: 35968
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 2
+  - uid: 35969
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 2
+  - uid: 35970
+    components:
+    - type: Transform
+      pos: -0.5,-5.5
+      parent: 2
+  - uid: 35971
+    components:
+    - type: Transform
+      pos: -0.5,-6.5
+      parent: 2
+  - uid: 35972
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 2
+  - uid: 35973
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 2
+  - uid: 35974
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 2
+  - uid: 35975
+    components:
+    - type: Transform
+      pos: -1.5,-5.5
+      parent: 2
+  - uid: 35976
+    components:
+    - type: Transform
+      pos: 4.5,-3.5
+      parent: 2
+  - uid: 35977
+    components:
+    - type: Transform
+      pos: 4.5,-4.5
+      parent: 2
+  - uid: 35978
+    components:
+    - type: Transform
+      pos: 4.5,-5.5
+      parent: 2
+  - uid: 35979
+    components:
+    - type: Transform
+      pos: 3.5,-3.5
+      parent: 2
+  - uid: 35980
+    components:
+    - type: Transform
+      pos: 3.5,-4.5
+      parent: 2
+  - uid: 35981
+    components:
+    - type: Transform
+      pos: 3.5,-5.5
+      parent: 2
+  - uid: 35982
+    components:
+    - type: Transform
+      pos: 5.5,-3.5
+      parent: 2
+  - uid: 35983
+    components:
+    - type: Transform
+      pos: 5.5,-2.5
+      parent: 2
+  - uid: 35984
+    components:
+    - type: Transform
+      pos: 5.5,-4.5
+      parent: 2
+  - uid: 35985
+    components:
+    - type: Transform
+      pos: 3.5,-0.5
+      parent: 2
+  - uid: 35986
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 2
+  - uid: 35987
+    components:
+    - type: Transform
+      pos: 7.5,0.5
+      parent: 2
+  - uid: 35988
+    components:
+    - type: Transform
+      pos: 7.5,-0.5
+      parent: 2
+  - uid: 35989
+    components:
+    - type: Transform
+      pos: 7.5,-1.5
+      parent: 2
+  - uid: 35990
+    components:
+    - type: Transform
+      pos: 6.5,0.5
+      parent: 2
+  - uid: 35991
+    components:
+    - type: Transform
+      pos: 6.5,-0.5
+      parent: 2
+  - uid: 35992
+    components:
+    - type: Transform
+      pos: 6.5,-1.5
+      parent: 2
+  - uid: 35993
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 2
+  - uid: 35994
+    components:
+    - type: Transform
+      pos: 5.5,-0.5
+      parent: 2
+  - uid: 35995
+    components:
+    - type: Transform
+      pos: 5.5,-1.5
+      parent: 2
+  - uid: 35996
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 2
+  - uid: 35997
+    components:
+    - type: Transform
+      pos: 4.5,-0.5
+      parent: 2
+  - uid: 35998
+    components:
+    - type: Transform
+      pos: 4.5,-1.5
+      parent: 2
+  - uid: 35999
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 2
+  - uid: 36000
+    components:
+    - type: Transform
+      pos: 4.5,-2.5
+      parent: 2
+  - uid: 36001
+    components:
+    - type: Transform
+      pos: 3.5,-2.5
+      parent: 2
+  - uid: 36002
+    components:
+    - type: Transform
+      pos: 6.5,-2.5
+      parent: 2
+  - uid: 36003
+    components:
+    - type: Transform
+      pos: 6.5,-3.5
+      parent: 2
+  - uid: 36094
+    components:
+    - type: Transform
+      pos: 7.5,2.5
+      parent: 2
+  - uid: 36095
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 2
+  - uid: 36096
+    components:
+    - type: Transform
+      pos: 7.5,1.5
+      parent: 2
+  - uid: 36097
+    components:
+    - type: Transform
+      pos: -6.5,2.5
+      parent: 2
+  - uid: 36098
+    components:
+    - type: Transform
+      pos: -6.5,1.5
+      parent: 2
+  - uid: 36099
+    components:
+    - type: Transform
+      pos: -5.5,2.5
+      parent: 2
+  - uid: 36100
+    components:
+    - type: Transform
+      pos: -5.5,1.5
+      parent: 2
+  - uid: 36101
+    components:
+    - type: Transform
+      pos: -4.5,2.5
+      parent: 2
+  - uid: 36102
+    components:
+    - type: Transform
+      pos: -4.5,1.5
+      parent: 2
+  - uid: 36103
+    components:
+    - type: Transform
+      pos: -3.5,2.5
+      parent: 2
+  - uid: 36104
+    components:
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 2
+  - uid: 36105
+    components:
+    - type: Transform
+      pos: -2.5,2.5
+      parent: 2
+  - uid: 36106
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 2
+  - uid: 36107
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 2
+  - uid: 36108
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 2
+  - uid: 36109
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 2
+  - uid: 36110
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 2
+  - uid: 36111
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 2
+  - uid: 36112
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 2
+  - uid: 36113
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 2
+  - uid: 36114
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 2
+  - uid: 36115
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 2
+  - uid: 36116
+    components:
+    - type: Transform
+      pos: 3.5,2.5
+      parent: 2
+  - uid: 36117
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 2
+  - uid: 36118
+    components:
+    - type: Transform
+      pos: 4.5,2.5
+      parent: 2
+  - uid: 36119
+    components:
+    - type: Transform
+      pos: 4.5,1.5
+      parent: 2
+  - uid: 36120
+    components:
+    - type: Transform
+      pos: 5.5,2.5
+      parent: 2
+  - uid: 36121
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 2
+  - uid: 36122
+    components:
+    - type: Transform
+      pos: 6.5,2.5
+      parent: 2
+  - uid: 36123
+    components:
+    - type: Transform
+      pos: 6.5,1.5
+      parent: 2
+  - uid: 36124
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 2
+  - uid: 36125
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 2
+  - uid: 36126
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 2
+  - uid: 36127
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 2
+  - uid: 36128
+    components:
+    - type: Transform
+      pos: -0.5,7.5
+      parent: 2
+  - uid: 36129
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 2
+  - uid: 36130
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 2
+  - uid: 36131
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 2
+  - uid: 36132
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 2
+  - uid: 36133
+    components:
+    - type: Transform
+      pos: 0.5,7.5
+      parent: 2
+  - uid: 36134
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 2
+  - uid: 36135
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 2
+  - uid: 36136
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 2
+  - uid: 36137
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 2
+  - uid: 36138
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 2
+  - uid: 36139
+    components:
+    - type: Transform
+      pos: 1.5,7.5
+      parent: 2
+  - uid: 36140
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 2
+  - uid: 36141
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 2
+  - uid: 36142
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 2
+  - uid: 36143
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 2
+  - uid: 36144
+    components:
+    - type: Transform
+      pos: 2.5,7.5
+      parent: 2
+  - uid: 36145
+    components:
+    - type: Transform
+      pos: 2.5,6.5
+      parent: 2
+  - uid: 36146
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 2
+  - uid: 36147
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 2
+  - uid: 36148
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 2
+- proto: AreaColdRoom
+  entities:
+  - uid: 36069
+    components:
+    - type: Transform
+      pos: -16.5,-3.5
+      parent: 2
+  - uid: 36070
+    components:
+    - type: Transform
+      pos: -16.5,-4.5
+      parent: 2
+  - uid: 36071
+    components:
+    - type: Transform
+      pos: -16.5,-5.5
+      parent: 2
+  - uid: 36072
+    components:
+    - type: Transform
+      pos: -16.5,-6.5
+      parent: 2
+  - uid: 36073
+    components:
+    - type: Transform
+      pos: -16.5,-7.5
+      parent: 2
+  - uid: 36074
+    components:
+    - type: Transform
+      pos: -15.5,-3.5
+      parent: 2
+  - uid: 36075
+    components:
+    - type: Transform
+      pos: -15.5,-4.5
+      parent: 2
+  - uid: 36076
+    components:
+    - type: Transform
+      pos: -15.5,-5.5
+      parent: 2
+  - uid: 36077
+    components:
+    - type: Transform
+      pos: -15.5,-6.5
+      parent: 2
+  - uid: 36078
+    components:
+    - type: Transform
+      pos: -15.5,-7.5
+      parent: 2
+  - uid: 36079
+    components:
+    - type: Transform
+      pos: -14.5,-3.5
+      parent: 2
+  - uid: 36080
+    components:
+    - type: Transform
+      pos: -14.5,-4.5
+      parent: 2
+  - uid: 36081
+    components:
+    - type: Transform
+      pos: -14.5,-5.5
+      parent: 2
+  - uid: 36082
+    components:
+    - type: Transform
+      pos: -14.5,-6.5
+      parent: 2
+  - uid: 36083
+    components:
+    - type: Transform
+      pos: -14.5,-7.5
+      parent: 2
+  - uid: 36084
+    components:
+    - type: Transform
+      pos: -17.5,-7.5
+      parent: 2
+  - uid: 36085
+    components:
+    - type: Transform
+      pos: -17.5,-4.5
+      parent: 2
+  - uid: 36086
+    components:
+    - type: Transform
+      pos: -13.5,-6.5
+      parent: 2
+  - uid: 36087
+    components:
+    - type: Transform
+      pos: -13.5,-5.5
+      parent: 2
+  - uid: 36088
+    components:
+    - type: Transform
+      pos: -13.5,-4.5
+      parent: 2
+  - uid: 36089
+    components:
+    - type: Transform
+      pos: -13.5,-3.5
+      parent: 2
+  - uid: 36090
+    components:
+    - type: Transform
+      pos: -17.5,-3.5
+      parent: 2
+  - uid: 36091
+    components:
+    - type: Transform
+      pos: -17.5,-5.5
+      parent: 2
+  - uid: 36092
+    components:
+    - type: Transform
+      pos: -17.5,-6.5
+      parent: 2
+  - uid: 36093
+    components:
+    - type: Transform
+      pos: -13.5,-7.5
+      parent: 2
+- proto: AreaKitchen
+  entities:
+  - uid: 36004
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 2
+  - uid: 36005
+    components:
+    - type: Transform
+      pos: -2.5,-3.5
+      parent: 2
+  - uid: 36006
+    components:
+    - type: Transform
+      pos: -2.5,-4.5
+      parent: 2
+  - uid: 36007
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 2
+  - uid: 36008
+    components:
+    - type: Transform
+      pos: -2.5,-6.5
+      parent: 2
+  - uid: 36009
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 2
+  - uid: 36010
+    components:
+    - type: Transform
+      pos: -3.5,-3.5
+      parent: 2
+  - uid: 36011
+    components:
+    - type: Transform
+      pos: -3.5,-4.5
+      parent: 2
+  - uid: 36012
+    components:
+    - type: Transform
+      pos: -3.5,-5.5
+      parent: 2
+  - uid: 36013
+    components:
+    - type: Transform
+      pos: -3.5,-6.5
+      parent: 2
+  - uid: 36014
+    components:
+    - type: Transform
+      pos: -4.5,-2.5
+      parent: 2
+  - uid: 36015
+    components:
+    - type: Transform
+      pos: -4.5,-3.5
+      parent: 2
+  - uid: 36016
+    components:
+    - type: Transform
+      pos: -4.5,-4.5
+      parent: 2
+  - uid: 36017
+    components:
+    - type: Transform
+      pos: -4.5,-5.5
+      parent: 2
+  - uid: 36018
+    components:
+    - type: Transform
+      pos: -4.5,-6.5
+      parent: 2
+  - uid: 36019
+    components:
+    - type: Transform
+      pos: -5.5,-2.5
+      parent: 2
+  - uid: 36020
+    components:
+    - type: Transform
+      pos: -5.5,-3.5
+      parent: 2
+  - uid: 36021
+    components:
+    - type: Transform
+      pos: -5.5,-4.5
+      parent: 2
+  - uid: 36022
+    components:
+    - type: Transform
+      pos: -5.5,-5.5
+      parent: 2
+  - uid: 36023
+    components:
+    - type: Transform
+      pos: -5.5,-6.5
+      parent: 2
+  - uid: 36024
+    components:
+    - type: Transform
+      pos: -6.5,-2.5
+      parent: 2
+  - uid: 36025
+    components:
+    - type: Transform
+      pos: -6.5,-3.5
+      parent: 2
+  - uid: 36026
+    components:
+    - type: Transform
+      pos: -6.5,-4.5
+      parent: 2
+  - uid: 36027
+    components:
+    - type: Transform
+      pos: -6.5,-5.5
+      parent: 2
+  - uid: 36028
+    components:
+    - type: Transform
+      pos: -6.5,-6.5
+      parent: 2
+  - uid: 36029
+    components:
+    - type: Transform
+      pos: -7.5,-3.5
+      parent: 2
+  - uid: 36030
+    components:
+    - type: Transform
+      pos: -7.5,-4.5
+      parent: 2
+  - uid: 36031
+    components:
+    - type: Transform
+      pos: -7.5,-5.5
+      parent: 2
+  - uid: 36032
+    components:
+    - type: Transform
+      pos: -7.5,-6.5
+      parent: 2
+  - uid: 36033
+    components:
+    - type: Transform
+      pos: -8.5,-2.5
+      parent: 2
+  - uid: 36034
+    components:
+    - type: Transform
+      pos: -7.5,-2.5
+      parent: 2
+  - uid: 36035
+    components:
+    - type: Transform
+      pos: -8.5,-3.5
+      parent: 2
+  - uid: 36036
+    components:
+    - type: Transform
+      pos: -8.5,-4.5
+      parent: 2
+  - uid: 36037
+    components:
+    - type: Transform
+      pos: -8.5,-5.5
+      parent: 2
+  - uid: 36038
+    components:
+    - type: Transform
+      pos: -9.5,-2.5
+      parent: 2
+  - uid: 36039
+    components:
+    - type: Transform
+      pos: -9.5,-3.5
+      parent: 2
+  - uid: 36040
+    components:
+    - type: Transform
+      pos: -9.5,-4.5
+      parent: 2
+  - uid: 36041
+    components:
+    - type: Transform
+      pos: -9.5,-5.5
+      parent: 2
+  - uid: 36042
+    components:
+    - type: Transform
+      pos: -9.5,-6.5
+      parent: 2
+  - uid: 36043
+    components:
+    - type: Transform
+      pos: -8.5,-6.5
+      parent: 2
+  - uid: 36044
+    components:
+    - type: Transform
+      pos: -10.5,-3.5
+      parent: 2
+  - uid: 36045
+    components:
+    - type: Transform
+      pos: -10.5,-4.5
+      parent: 2
+  - uid: 36046
+    components:
+    - type: Transform
+      pos: -10.5,-5.5
+      parent: 2
+  - uid: 36047
+    components:
+    - type: Transform
+      pos: -10.5,-6.5
+      parent: 2
+  - uid: 36048
+    components:
+    - type: Transform
+      pos: -10.5,-2.5
+      parent: 2
+  - uid: 36049
+    components:
+    - type: Transform
+      pos: -11.5,-2.5
+      parent: 2
+  - uid: 36050
+    components:
+    - type: Transform
+      pos: -11.5,-3.5
+      parent: 2
+  - uid: 36051
+    components:
+    - type: Transform
+      pos: -11.5,-4.5
+      parent: 2
+  - uid: 36052
+    components:
+    - type: Transform
+      pos: -11.5,-5.5
+      parent: 2
+  - uid: 36053
+    components:
+    - type: Transform
+      pos: -11.5,-6.5
+      parent: 2
+  - uid: 36054
+    components:
+    - type: Transform
+      pos: -12.5,-2.5
+      parent: 2
+  - uid: 36055
+    components:
+    - type: Transform
+      pos: -12.5,-3.5
+      parent: 2
+  - uid: 36056
+    components:
+    - type: Transform
+      pos: -12.5,-4.5
+      parent: 2
+  - uid: 36057
+    components:
+    - type: Transform
+      pos: -12.5,-5.5
+      parent: 2
+  - uid: 36058
+    components:
+    - type: Transform
+      pos: -12.5,-6.5
+      parent: 2
+  - uid: 36059
+    components:
+    - type: Transform
+      pos: -12.5,-7.5
+      parent: 2
+  - uid: 36060
+    components:
+    - type: Transform
+      pos: -11.5,-7.5
+      parent: 2
+  - uid: 36061
+    components:
+    - type: Transform
+      pos: -10.5,-7.5
+      parent: 2
+  - uid: 36062
+    components:
+    - type: Transform
+      pos: -9.5,-7.5
+      parent: 2
+  - uid: 36063
+    components:
+    - type: Transform
+      pos: -8.5,-7.5
+      parent: 2
+  - uid: 36064
+    components:
+    - type: Transform
+      pos: -7.5,-7.5
+      parent: 2
+  - uid: 36065
+    components:
+    - type: Transform
+      pos: -6.5,-7.5
+      parent: 2
+  - uid: 36066
+    components:
+    - type: Transform
+      pos: -5.5,-7.5
+      parent: 2
+  - uid: 36067
+    components:
+    - type: Transform
+      pos: -4.5,-7.5
+      parent: 2
+  - uid: 36068
+    components:
+    - type: Transform
+      pos: -3.5,-7.5
       parent: 2
 - proto: ArrivalsShuttleTimer
   entities:
@@ -20450,9 +21426,6 @@ entities:
     - type: Transform
       pos: -55.71245,7.421505
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 752
     components:
     - type: Transform
@@ -20490,9 +21463,6 @@ entities:
     - type: Transform
       pos: -88.01821,2.642246
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 758
     components:
     - type: Transform
@@ -38960,9 +39930,6 @@ entities:
     - type: Transform
       pos: 15.671751,-37.95095
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: AtmosDeviceFanDirectional
   entities:
   - uid: 4607
@@ -40218,9 +41185,7 @@ entities:
     - type: Transform
       pos: 14.510538,65.67405
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
+    - type: StepTriggerActive
 - proto: BananiumHorn
   entities:
   - uid: 4826
@@ -40235,9 +41200,6 @@ entities:
     - type: Transform
       pos: -56.501404,-66.55655
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: BannerBlue
   entities:
   - uid: 4828
@@ -40254,8 +41216,6 @@ entities:
       pos: -18.5,-39.5
       parent: 2
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       bodyType: Static
   - uid: 4830
     components:
@@ -40281,8 +41241,6 @@ entities:
       pos: -24.5,28.5
       parent: 2
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       bodyType: Static
 - proto: BannerMedical
   entities:
@@ -40293,8 +41251,6 @@ entities:
       pos: -40.5,-4.5
       parent: 2
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       bodyType: Static
 - proto: BannerNanotrasen
   entities:
@@ -40305,8 +41261,6 @@ entities:
       pos: -34.5,-20.5
       parent: 2
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       bodyType: Static
 - proto: BannerScience
   entities:
@@ -40317,8 +41271,6 @@ entities:
       pos: -45.5,-51.5
       parent: 2
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       bodyType: Static
   - uid: 4837
     components:
@@ -40327,8 +41279,6 @@ entities:
       pos: -47.5,-51.5
       parent: 2
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       bodyType: Static
 - proto: BannerSecurity
   entities:
@@ -40339,8 +41289,6 @@ entities:
       pos: -64.5,8.5
       parent: 2
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       bodyType: Static
 - proto: BannerSyndicate
   entities:
@@ -40531,17 +41479,11 @@ entities:
     - type: Transform
       pos: -53.64122,-4.2751365
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 4867
     components:
     - type: Transform
       pos: -53.428623,-4.229463
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: BaseComputerAiAccess
   entities:
   - uid: 4868
@@ -40584,8 +41526,6 @@ entities:
       containers:
       - beaker
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: ContainerContainer
       containers:
@@ -40602,33 +41542,21 @@ entities:
     - type: Transform
       pos: -7.343124,-4.3683753
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 4874
     components:
     - type: Transform
       pos: -7.686874,-4.4934616
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 4875
     components:
     - type: Transform
       pos: -25.773998,-10.4707
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 4876
     components:
     - type: Transform
       pos: 12.6009655,34.70292
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 4877
     components:
     - type: Transform
@@ -40697,6 +41625,8 @@ entities:
     - type: Transform
       pos: -81.5,15.5
       parent: 2
+    - type: StepTriggerCleanup
+      stepTrigger: 30857
   - uid: 4891
     components:
     - type: Transform
@@ -40978,9 +41908,6 @@ entities:
     - type: Transform
       pos: -28.5,-23.5
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: BedsheetOrange
   entities:
   - uid: 4939
@@ -41136,17 +42063,11 @@ entities:
     - type: Transform
       pos: 14.478028,64.88145
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 4966
     components:
     - type: Transform
       pos: 14.375056,64.601135
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 4967
     components:
     - type: Transform
@@ -41157,17 +42078,11 @@ entities:
     - type: Transform
       pos: 14.557205,64.70436
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 4969
     components:
     - type: Transform
       pos: 14.541805,64.61155
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 4970
     components:
     - type: Transform
@@ -41187,8 +42102,6 @@ entities:
     - type: Transform
       parent: 4972
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
 - proto: Biogenerator
@@ -41217,8 +42130,6 @@ entities:
     - type: Transform
       parent: 4982
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
   - uid: 4984
     components:
@@ -41403,25 +42314,16 @@ entities:
     - type: Transform
       pos: -46.57828,-26.277584
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 5016
     components:
     - type: Transform
       pos: -46.036617,-26.256737
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 5017
     components:
     - type: Transform
       pos: -33.4956,-41.54743
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: BoneGel
   entities:
   - uid: 5018
@@ -41476,9 +42378,6 @@ entities:
     - type: Transform
       pos: 8.491692,11.656855
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: BookChemicalCompendium
   entities:
   - uid: 5025
@@ -41486,9 +42385,6 @@ entities:
     - type: Transform
       pos: -58.496433,-11.392026
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: BookHowToCookForFortySpaceman
   entities:
   - uid: 5026
@@ -41503,9 +42399,6 @@ entities:
     - type: Transform
       pos: -35.483597,-6.530823
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: BookIanAntarctica
   entities:
   - uid: 5029
@@ -41513,8 +42406,6 @@ entities:
     - type: Transform
       parent: 5028
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
 - proto: BookIanArctic
   entities:
@@ -41523,8 +42414,6 @@ entities:
     - type: Transform
       parent: 5028
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
 - proto: BookIanCity
   entities:
@@ -41533,8 +42422,6 @@ entities:
     - type: Transform
       parent: 5028
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
 - proto: BookIanDesert
   entities:
@@ -41543,8 +42430,6 @@ entities:
     - type: Transform
       parent: 5028
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
 - proto: BookIanLostWolfPup
   entities:
@@ -41553,8 +42438,6 @@ entities:
     - type: Transform
       parent: 5028
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
 - proto: BookIanMountain
   entities:
@@ -41563,8 +42446,6 @@ entities:
     - type: Transform
       parent: 5028
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
 - proto: BookIanOcean
   entities:
@@ -41573,8 +42454,6 @@ entities:
     - type: Transform
       parent: 5028
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
 - proto: BookIanRanch
   entities:
@@ -41583,8 +42462,6 @@ entities:
     - type: Transform
       parent: 5028
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
 - proto: BookLeafLoversSecret
   entities:
@@ -41624,8 +42501,6 @@ entities:
     - type: Transform
       parent: 5042
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
 - proto: BookRandomStory
@@ -41635,9 +42510,6 @@ entities:
     - type: Transform
       pos: 7.5018888,41.09831
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 5045
     components:
     - type: Transform
@@ -41665,9 +42537,6 @@ entities:
     - type: Transform
       pos: 3.5321488,59.480255
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: Bookshelf
   entities:
   - uid: 5028
@@ -41819,9 +42688,6 @@ entities:
     - type: Transform
       pos: -55.57026,8.402508
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 5070
     components:
     - type: Transform
@@ -41848,8 +42714,6 @@ entities:
     - type: Transform
       parent: 5074
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 5076
@@ -41857,8 +42721,6 @@ entities:
     - type: Transform
       parent: 5074
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 5077
@@ -41866,8 +42728,6 @@ entities:
     - type: Transform
       parent: 5074
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 5078
@@ -41875,8 +42735,6 @@ entities:
     - type: Transform
       parent: 5074
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 5079
@@ -41884,8 +42742,6 @@ entities:
     - type: Transform
       parent: 5074
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 5080
@@ -41893,8 +42749,6 @@ entities:
     - type: Transform
       parent: 5074
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 5081
@@ -41902,8 +42756,6 @@ entities:
     - type: Transform
       parent: 5074
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 5082
@@ -41911,8 +42763,6 @@ entities:
     - type: Transform
       parent: 5074
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 5083
@@ -41920,8 +42770,6 @@ entities:
     - type: Transform
       parent: 5074
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 5084
@@ -41929,8 +42777,6 @@ entities:
     - type: Transform
       parent: 5074
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 5085
@@ -41938,8 +42784,6 @@ entities:
     - type: Transform
       parent: 5074
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 5086
@@ -41947,8 +42791,6 @@ entities:
     - type: Transform
       parent: 5074
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 5087
@@ -41956,8 +42798,6 @@ entities:
     - type: Transform
       parent: 5074
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 5088
@@ -41965,8 +42805,6 @@ entities:
     - type: Transform
       parent: 5074
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 5089
@@ -41974,8 +42812,6 @@ entities:
     - type: Transform
       parent: 5074
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 5090
@@ -41983,8 +42819,6 @@ entities:
     - type: Transform
       parent: 5074
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 5091
@@ -41992,8 +42826,6 @@ entities:
     - type: Transform
       parent: 5074
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 5092
@@ -42001,8 +42833,6 @@ entities:
     - type: Transform
       parent: 5074
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 5093
@@ -42010,8 +42840,6 @@ entities:
     - type: Transform
       parent: 5074
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 5094
@@ -42019,8 +42847,6 @@ entities:
     - type: Transform
       parent: 5074
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 5095
@@ -42028,8 +42854,6 @@ entities:
     - type: Transform
       parent: 5074
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 5096
@@ -42037,8 +42861,6 @@ entities:
     - type: Transform
       parent: 5074
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 5097
@@ -42046,8 +42868,6 @@ entities:
     - type: Transform
       parent: 5074
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 5098
@@ -42055,8 +42875,6 @@ entities:
     - type: Transform
       parent: 5074
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 5099
@@ -42064,8 +42882,6 @@ entities:
     - type: Transform
       parent: 5074
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 5100
@@ -42073,8 +42889,6 @@ entities:
     - type: Transform
       parent: 5074
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 5101
@@ -42082,8 +42896,6 @@ entities:
     - type: Transform
       parent: 5074
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 5102
@@ -42091,8 +42903,6 @@ entities:
     - type: Transform
       parent: 5074
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 5103
@@ -42100,8 +42910,6 @@ entities:
     - type: Transform
       parent: 5074
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 5104
@@ -42109,8 +42917,6 @@ entities:
     - type: Transform
       parent: 5074
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 5106
@@ -42124,9 +42930,6 @@ entities:
     - type: Transform
       pos: -54.560566,5.6384697
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 5108
     components:
     - type: Transform
@@ -42273,17 +43076,11 @@ entities:
     - type: Transform
       pos: -23.53069,-9.353997
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 5135
     components:
     - type: Transform
       pos: -99.53974,11.630012
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: BoxBeaker
   entities:
   - uid: 5136
@@ -42298,24 +43095,11 @@ entities:
       parent: 2
 - proto: BoxBeanbag
   entities:
-  - uid: 5137
-    components:
-    - type: Transform
-      pos: -79.7827,28.393803
-      parent: 2
-  - uid: 5138
-    components:
-    - type: Transform
-      pos: -79.829575,28.847242
-      parent: 2
   - uid: 5139
     components:
     - type: Transform
       pos: 7.4708586,13.646438
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: BoxBodyBag
   entities:
   - uid: 5140
@@ -42323,24 +43107,16 @@ entities:
     - type: Transform
       pos: -40.530903,-25.341867
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 5141
     components:
     - type: Transform
       pos: -69.46955,-53.387035
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 5143
     components:
     - type: Transform
       parent: 5142
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
 - proto: BoxCartridgeCap
@@ -42350,9 +43126,6 @@ entities:
     - type: Transform
       pos: -29.450209,-33.352573
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: BoxCleanerGrenades
   entities:
   - uid: 5148
@@ -42360,9 +43133,6 @@ entities:
     - type: Transform
       pos: -47.35826,-38.24647
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: BoxDonkSoftBox
   entities:
   - uid: 5149
@@ -42370,17 +43140,11 @@ entities:
     - type: Transform
       pos: -61.542824,38.490902
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 5150
     components:
     - type: Transform
       pos: -47.489098,8.537972
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: BoxEnvelope
   entities:
   - uid: 5151
@@ -42393,17 +43157,11 @@ entities:
     - type: Transform
       pos: -24.433386,-48.331646
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 5153
     components:
     - type: Transform
       pos: -24.17297,-48.37334
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: BoxEvidenceMarkers
   entities:
   - uid: 5154
@@ -42418,9 +43176,6 @@ entities:
     - type: Transform
       pos: -73.554184,29.670116
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: BoxFolderBlack
   entities:
   - uid: 5156
@@ -42433,9 +43188,6 @@ entities:
     - type: Transform
       pos: -27.65892,18.688177
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 5158
     components:
     - type: Transform
@@ -42446,9 +43198,6 @@ entities:
     - type: Transform
       pos: 18.513937,65.17973
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 5160
     components:
     - type: Transform
@@ -42461,17 +43210,11 @@ entities:
     - type: Transform
       pos: -17.327026,13.559696
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 5162
     components:
     - type: Transform
       pos: -32.474094,-9.363056
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 5163
     components:
     - type: Transform
@@ -42541,25 +43284,16 @@ entities:
     - type: Transform
       pos: -22.44458,13.599132
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 5175
     components:
     - type: Transform
       pos: -42.565723,-10.429891
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 5176
     components:
     - type: Transform
       pos: -79.490585,-29.364557
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: BoxFolderGreen
   entities:
   - uid: 5177
@@ -42567,9 +43301,6 @@ entities:
     - type: Transform
       pos: -33.096317,-21.4462
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: BoxFolderRed
   entities:
   - uid: 5178
@@ -42591,39 +43322,12 @@ entities:
     - type: Transform
       pos: -27.481836,18.531818
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: BoxForensicPad
   entities:
   - uid: 5181
     components:
     - type: Transform
       pos: -50.4081,3.5597954
-      parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-- proto: BoxGrenadesBaton
-  entities:
-  - uid: 16617
-    components:
-    - type: Transform
-      pos: -82.70176,28.733278
-      parent: 2
-- proto: BoxGrenadesFlash
-  entities:
-  - uid: 17
-    components:
-    - type: Transform
-      pos: -82.23301,28.743704
-      parent: 2
-- proto: BoxGrenadesTeargas
-  entities:
-  - uid: 16
-    components:
-    - type: Transform
-      pos: -82.71217,29.077269
       parent: 2
 - proto: BoxHandcuff
   entities:
@@ -42659,9 +43363,6 @@ entities:
     - type: Transform
       pos: -16.416445,-48.47981
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 5184
     components:
     - type: Transform
@@ -42689,31 +43390,6 @@ entities:
     - type: Transform
       pos: -52.4019,-28.504316
       parent: 2
-- proto: BoxLethalshot
-  entities:
-  - uid: 5189
-    components:
-    - type: Transform
-      pos: -80.81851,28.503254
-      parent: 2
-  - uid: 5190
-    components:
-    - type: Transform
-      pos: -81.75601,28.346895
-      parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-  - uid: 23504
-    components:
-    - type: Transform
-      pos: -81.74039,28.815971
-      parent: 2
-  - uid: 23506
-    components:
-    - type: Transform
-      pos: -80.80149,28.800335
-      parent: 2
 - proto: BoxLightbulb
   entities:
   - uid: 5191
@@ -42721,9 +43397,6 @@ entities:
     - type: Transform
       pos: 13.909181,75.53112
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: BoxLightMixed
   entities:
   - uid: 5192
@@ -42741,9 +43414,6 @@ entities:
     - type: Transform
       pos: 21.544847,72.613594
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: BoxLighttube
   entities:
   - uid: 5195
@@ -42751,19 +43421,6 @@ entities:
     - type: Transform
       pos: 14.513347,75.61452
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-- proto: BoxMagazinePistol
-  entities:
-  - uid: 5196
-    components:
-    - type: Transform
-      pos: -82.52893,31.50399
-      parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: BoxMailCapsulePrimed
   entities:
   - uid: 5198
@@ -42771,41 +43428,26 @@ entities:
     - type: Transform
       pos: -26.365648,-42.73745
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 5199
     components:
     - type: Transform
       pos: -26.657316,-42.487274
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 5200
     components:
     - type: Transform
       pos: -26.646898,-43.06059
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 5201
     components:
     - type: Transform
       pos: -26.313566,-43.394154
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 5202
     components:
     - type: Transform
       pos: -26.553148,-43.59221
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 5203
     components:
     - type: Transform
@@ -42823,17 +43465,11 @@ entities:
     - type: Transform
       pos: -47.86868,-38.329865
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 5206
     components:
     - type: Transform
       pos: -21.604279,-5.381434
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: BoxMouthSwab
   entities:
   - uid: 5207
@@ -42841,9 +43477,6 @@ entities:
     - type: Transform
       pos: -62.550243,-33.848114
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 5208
     components:
     - type: Transform
@@ -42875,26 +43508,6 @@ entities:
     - type: Transform
       pos: 25.545351,67.66858
       parent: 2
-- proto: BoxShotgunIncendiary
-  entities:
-  - uid: 5213
-    components:
-    - type: Transform
-      pos: -79.387596,28.463776
-      parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-- proto: BoxShotgunSlug
-  entities:
-  - uid: 5214
-    components:
-    - type: Transform
-      pos: -79.42926,28.76607
-      parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: BoxSterileMask
   entities:
   - uid: 5215
@@ -42921,9 +43534,6 @@ entities:
     - type: Transform
       pos: -62.341396,-38.48037
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 5219
     components:
     - type: Transform
@@ -42948,9 +43558,6 @@ entities:
     - type: Transform
       pos: -62.633064,-38.334435
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: BoxZiptie
   entities:
   - uid: 5222
@@ -42970,9 +43577,6 @@ entities:
     - type: Transform
       pos: -28.568638,16.324348
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 5225
     components:
     - type: Transform
@@ -42990,32 +43594,21 @@ entities:
     - type: Transform
       pos: 3.6675656,59.355167
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 5228
     components:
     - type: Transform
       pos: -79.87027,3.7543647
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 5229
     components:
     - type: Transform
       pos: -104.186874,5.63179
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 5231
     components:
     - type: Transform
       parent: 5230
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 5236
@@ -43114,17 +43707,11 @@ entities:
     - type: Transform
       pos: -55.5002,-20.974556
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 5251
     components:
     - type: Transform
       pos: -55.36478,-21.380806
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: Bucket
   entities:
   - uid: 5253
@@ -43132,8 +43719,6 @@ entities:
     - type: Transform
       parent: 5252
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
   - uid: 5263
     components:
@@ -43170,9 +43755,6 @@ entities:
     - type: Transform
       pos: -56.104588,66.056854
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 5270
     components:
     - type: Transform
@@ -61880,9 +62462,6 @@ entities:
     - type: Transform
       pos: -64.47346,-49.543373
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 8866
     components:
     - type: Transform
@@ -61943,9 +62522,6 @@ entities:
     - type: Transform
       pos: 19.470116,88.60173
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 8876
     components:
     - type: Transform
@@ -61975,9 +62551,6 @@ entities:
     - type: Transform
       pos: 12.052071,88.747345
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 8881
     components:
     - type: Transform
@@ -86591,9 +87164,6 @@ entities:
     - type: Transform
       pos: -107.53064,30.609055
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: CannedApplauseInstrument
   entities:
   - uid: 13831
@@ -86617,9 +87187,6 @@ entities:
     - type: Transform
       pos: -26.535957,5.7932878
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: CarbonDioxideCanister
   entities:
   - uid: 13834
@@ -86649,9 +87216,6 @@ entities:
     - type: Transform
       pos: -35.54651,-32.546425
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: CardDeckBlack
   entities:
   - uid: 13839
@@ -86659,9 +87223,6 @@ entities:
     - type: Transform
       pos: -35.061398,-33.30316
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: CardDeckNanotrasen
   entities:
   - uid: 13840
@@ -86675,6 +87236,13 @@ entities:
     components:
     - type: Transform
       pos: 2.9777935,68.47955
+      parent: 2
+- proto: CargoMailTeleporter
+  entities:
+  - uid: 24243
+    components:
+    - type: Transform
+      pos: -23.5,-45.5
       parent: 2
 - proto: CargoTechFab
   entities:
@@ -88458,17 +89026,11 @@ entities:
     - type: Transform
       pos: -18.309273,21.380093
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 14165
     components:
     - type: Transform
       pos: -18.705723,21.576954
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 14166
     components:
     - type: Transform
@@ -88480,9 +89042,6 @@ entities:
     - type: Transform
       pos: -18.43173,21.49362
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 14168
     components:
     - type: Transform
@@ -88519,9 +89078,6 @@ entities:
     - type: Transform
       pos: -77.877785,40.61159
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: Catwalk
   entities:
   - uid: 201
@@ -99007,8 +99563,6 @@ entities:
     - type: Transform
       parent: 16051
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 16053
@@ -99016,8 +99570,6 @@ entities:
     - type: Transform
       parent: 16051
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 16054
@@ -99025,8 +99577,6 @@ entities:
     - type: Transform
       parent: 16051
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 16055
@@ -99034,8 +99584,6 @@ entities:
     - type: Transform
       parent: 16051
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 16056
@@ -99043,8 +99591,6 @@ entities:
     - type: Transform
       parent: 16051
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 16057
@@ -99052,8 +99598,6 @@ entities:
     - type: Transform
       parent: 16051
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 16058
@@ -99061,8 +99605,6 @@ entities:
     - type: Transform
       parent: 16051
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 16059
@@ -99070,8 +99612,6 @@ entities:
     - type: Transform
       parent: 16051
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 16060
@@ -99079,8 +99619,6 @@ entities:
     - type: Transform
       parent: 16051
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 16061
@@ -99088,8 +99626,6 @@ entities:
     - type: Transform
       parent: 16051
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 16062
@@ -99181,6 +99717,8 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -42.481377,-41.22342
       parent: 2
+    - type: StepTriggerCleanup
+      stepTrigger: 15085
 - proto: ChairWood
   entities:
   - uid: 16077
@@ -99191,8 +99729,6 @@ entities:
       pos: 2.5,35.5
       parent: 2
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       bodyType: Static
   - uid: 16078
     components:
@@ -99238,8 +99774,6 @@ entities:
       pos: 5.5,37.5
       parent: 2
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       bodyType: Static
   - uid: 16085
     components:
@@ -99249,8 +99783,6 @@ entities:
       pos: 6.5,38.5
       parent: 2
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       bodyType: Static
   - uid: 16086
     components:
@@ -99259,8 +99791,6 @@ entities:
       pos: 2.5,41.5
       parent: 2
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       bodyType: Static
 - proto: CheapLighter
   entities:
@@ -99351,9 +99881,6 @@ entities:
     - type: Transform
       pos: -101.41643,14.445599
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ChessBoard
   entities:
   - uid: 16100
@@ -99418,8 +99945,6 @@ entities:
     - type: Transform
       parent: 752
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
   - uid: 16107
     components:
@@ -99483,9 +100008,6 @@ entities:
     - type: Transform
       pos: 16.113907,-56.609673
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 16119
     components:
     - type: Transform
@@ -99506,9 +100028,6 @@ entities:
     - type: Transform
       pos: -55.316616,7.577755
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 16124
     components:
     - type: Transform
@@ -99556,9 +100075,6 @@ entities:
     - type: Transform
       pos: -5.9683347,30.485678
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 16133
     components:
     - type: Transform
@@ -99586,9 +100102,6 @@ entities:
     - type: Transform
       pos: -74.458145,-40.25963
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: CigPackRed
   entities:
   - uid: 16138
@@ -99765,8 +100278,6 @@ entities:
       pos: 2.5,-30.5
       parent: 2
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       bodyType: Static
   - uid: 16171
     components:
@@ -99775,8 +100286,6 @@ entities:
       pos: 2.5,-29.5
       parent: 2
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       bodyType: Static
   - uid: 16172
     components:
@@ -99922,8 +100431,6 @@ entities:
       pos: 2.5,-28.5
       parent: 2
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       bodyType: Static
   - uid: 16200
     components:
@@ -100344,22 +100851,8 @@ entities:
         immutable: False
         temperature: 293.14673
         moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
     - type: ContainerContainer
       containers:
         entity_storage: !type:Container
@@ -100381,8 +100874,6 @@ entities:
       pos: -25.5,40.5
       parent: 2
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       bodyType: Static
   - uid: 16280
     components:
@@ -100482,22 +100973,8 @@ entities:
         immutable: False
         temperature: 293.14673
         moles:
-        - 1.8856695
-        - 7.0937095
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
+          Oxygen: 1.8856695
+          Nitrogen: 7.0937095
     - type: ContainerContainer
       containers:
         entity_storage: !type:Container
@@ -100536,22 +101013,8 @@ entities:
         immutable: False
         temperature: 293.14673
         moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
     - type: ContainerContainer
       containers:
         entity_storage: !type:Container
@@ -100577,8 +101040,6 @@ entities:
       pos: -25.5,43.5
       parent: 2
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       bodyType: Static
   - uid: 16305
     components:
@@ -100648,9 +101109,6 @@ entities:
     - type: Transform
       pos: -41.41668,-25.344084
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ClothingBackpackDuffelSyndicate
   entities:
   - uid: 16292
@@ -100658,8 +101116,6 @@ entities:
     - type: Transform
       parent: 16291
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
 - proto: ClothingBackpackSatchelLeather
@@ -100676,9 +101132,6 @@ entities:
     - type: Transform
       pos: -63.52039,-33.369904
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ClothingBeltHolster
   entities:
   - uid: 16314
@@ -100700,9 +101153,6 @@ entities:
     - type: Transform
       pos: -53.836575,-13.383679
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ClothingBeltMercWebbing
   entities:
   - uid: 16317
@@ -100710,9 +101160,6 @@ entities:
     - type: Transform
       pos: -97.47041,32.714195
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ClothingBeltPlant
   entities:
   - uid: 16318
@@ -100746,8 +101193,6 @@ entities:
     - type: Transform
       parent: 16322
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
 - proto: ClothingEyesGlasses
@@ -100757,9 +101202,6 @@ entities:
     - type: Transform
       pos: -33.28657,-53.410732
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ClothingEyesGlassesCheapSunglasses
   entities:
   - uid: 16326
@@ -100780,9 +101222,6 @@ entities:
       rot: 12.566370614359172 rad
       pos: -59.235004,-68.48819
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ClothingEyesGlassesGarOrange
   entities:
   - uid: 16329
@@ -100809,17 +101248,11 @@ entities:
     - type: Transform
       pos: -52.116524,30.492228
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 16333
     components:
     - type: Transform
       pos: -18.480204,31.75498
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ClothingEyesGlassesOutlawGlasses
   entities:
   - uid: 16334
@@ -100827,9 +101260,6 @@ entities:
     - type: Transform
       pos: -71.704796,-5.3940606
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ClothingEyesGlassesSunglasses
   entities:
   - uid: 16335
@@ -100874,9 +101304,6 @@ entities:
     - type: Transform
       pos: -64.39012,-49.199623
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 16342
     components:
     - type: Transform
@@ -100917,8 +101344,6 @@ entities:
     - type: Transform
       parent: 16291
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
 - proto: ClothingHandsGlovesColorBlue
@@ -100940,9 +101365,6 @@ entities:
     - type: Transform
       pos: -31.503563,-23.182379
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ClothingHandsGlovesColorYellowBudget
   entities:
   - uid: 16350
@@ -100969,9 +101391,6 @@ entities:
     - type: Transform
       pos: 12.61403,34.56727
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 35325
     components:
     - type: Transform
@@ -101005,9 +101424,6 @@ entities:
     - type: Transform
       pos: -61.617744,-17.526041
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ClothingHeadBandBotany
   entities:
   - uid: 16358
@@ -101022,9 +101438,6 @@ entities:
     - type: Transform
       pos: -46.530766,9.517819
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ClothingHeadHatBeretFrench
   entities:
   - uid: 16361
@@ -101039,9 +101452,6 @@ entities:
     - type: Transform
       pos: -40.584473,-12.8859625
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 16363
     components:
     - type: Transform
@@ -101054,9 +101464,6 @@ entities:
     - type: Transform
       pos: -97.605835,33.682945
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ClothingHeadHatBizarreSoft
   entities:
   - uid: 16365
@@ -101092,6 +101499,13 @@ entities:
     - type: Transform
       pos: -2.2993112,-37.93481
       parent: 2
+- proto: ClothingHeadHatCatEars
+  entities:
+  - uid: 24517
+    components:
+    - type: Transform
+      pos: -64.59338,72.61955
+      parent: 2
 - proto: ClothingHeadHatCentcomcap
   entities:
   - uid: 16370
@@ -101120,9 +101534,6 @@ entities:
     - type: Transform
       pos: -28.796324,-12.570902
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ClothingHeadHatFlowerWreath
   entities:
   - uid: 16374
@@ -101159,9 +101570,6 @@ entities:
     - type: Transform
       pos: -74.550514,-23.96152
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ClothingHeadHatSecsoft
   entities:
   - uid: 16378
@@ -101209,8 +101617,6 @@ entities:
     - type: Transform
       parent: 16291
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 16379
@@ -101228,8 +101634,6 @@ entities:
     - type: Transform
       parent: 16381
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
 - proto: ClothingHeadHatTacticalMaidHeadband
   entities:
@@ -101259,9 +101663,6 @@ entities:
     - type: Transform
       pos: -55.21543,66.11973
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ClothingHeadHatWelding
   entities:
   - uid: 16389
@@ -101269,9 +101670,6 @@ entities:
     - type: Transform
       pos: -31.513979,-23.328312
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 16390
     components:
     - type: Transform
@@ -101298,9 +101696,6 @@ entities:
     - type: Transform
       pos: -89.31366,-39.215363
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ClothingHeadHelmetAncient
   entities:
   - uid: 4492
@@ -101316,25 +101711,16 @@ entities:
     - type: Transform
       pos: -77.88043,34.57818
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 16396
     components:
     - type: Transform
       pos: -77.453354,34.57818
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 16397
     components:
     - type: Transform
       pos: -77.66168,34.484364
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ClothingHeadHelmetMerc
   entities:
   - uid: 16398
@@ -101349,25 +101735,16 @@ entities:
     - type: Transform
       pos: -79.16638,34.572247
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 16400
     components:
     - type: Transform
       pos: -79.65597,34.58267
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 16401
     components:
     - type: Transform
       pos: -79.40597,34.53055
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ClothingHeadHelmetSyndicate
   entities:
   - uid: 16402
@@ -101396,9 +101773,6 @@ entities:
     - type: Transform
       pos: -57.554237,28.407032
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ClothingHeadsetCargo
   entities:
   - uid: 16406
@@ -101448,9 +101822,6 @@ entities:
     - type: Transform
       pos: -49.004364,-64.47852
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ClothingHeadsetMining
   entities:
   - uid: 16414
@@ -101458,17 +101829,11 @@ entities:
     - type: Transform
       pos: 17.501411,89.58068
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 16415
     components:
     - type: Transform
       pos: 15.328001,-38.284283
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ClothingHeadsetScience
   entities:
   - uid: 16416
@@ -101490,9 +101855,6 @@ entities:
     - type: Transform
       pos: -25.359587,-9.472115
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 16419
     components:
     - type: Transform
@@ -101519,9 +101881,6 @@ entities:
     - type: Transform
       pos: -97.5225,33.182945
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ClothingMaskGasSecurity
   entities:
   - uid: 16424
@@ -101541,8 +101900,6 @@ entities:
     - type: Transform
       parent: 16291
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
 - proto: ClothingMaskItalianMoustache
@@ -101552,9 +101909,6 @@ entities:
     - type: Transform
       pos: -79.49164,-34.403248
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ClothingMaskMuzzle
   entities:
   - uid: 16427
@@ -101562,9 +101916,6 @@ entities:
     - type: Transform
       pos: -64.61955,23.543169
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ClothingMaskSexyClown
   entities:
   - uid: 16428
@@ -101577,8 +101928,6 @@ entities:
     - type: Transform
       parent: 16429
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
 - proto: ClothingMaskSexyMime
   entities:
@@ -101587,9 +101936,6 @@ entities:
     - type: Transform
       pos: 18.722374,65.83598
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ClothingMaskSterile
   entities:
   - uid: 16433
@@ -101597,9 +101943,6 @@ entities:
     - type: Transform
       pos: 12.70778,34.515186
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ClothingMultipleHeadphones
   entities:
   - uid: 16435
@@ -101628,9 +101971,6 @@ entities:
     - type: Transform
       pos: -23.332493,-10.482632
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ClothingNeckScarfStripedSyndieRed
   entities:
   - uid: 16438
@@ -101643,9 +101983,6 @@ entities:
     - type: Transform
       pos: 2.5978596,67.55819
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ClothingNeckScarfStripedZebra
   entities:
   - uid: 5232
@@ -101653,8 +101990,6 @@ entities:
     - type: Transform
       parent: 5230
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
 - proto: ClothingNeckStethoscope
@@ -101695,9 +102030,6 @@ entities:
     - type: Transform
       pos: -31.215916,-5.4228287
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 16445
     components:
     - type: Transform
@@ -101710,9 +102042,6 @@ entities:
     - type: Transform
       pos: -14.502625,-7.431493
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ClothingOuterArmorBulletproof
   entities:
   - uid: 16447
@@ -101737,9 +102066,6 @@ entities:
     - type: Transform
       pos: -78.491806,34.515434
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 16451
     components:
     - type: Transform
@@ -101779,9 +102105,6 @@ entities:
     - type: Transform
       pos: -62.550243,-34.338036
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ClothingOuterCoatSyndieCap
   entities:
   - uid: 16457
@@ -101789,9 +102112,6 @@ entities:
     - type: Transform
       pos: -64.54505,73.29399
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ClothingOuterCoatTrench
   entities:
   - uid: 16383
@@ -101799,8 +102119,6 @@ entities:
     - type: Transform
       parent: 16381
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
 - proto: ClothingOuterDameDane
   entities:
@@ -101809,9 +102127,6 @@ entities:
     - type: Transform
       pos: -96.1087,-28.645817
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ClothingOuterEVASuitSyndicate
   entities:
   - uid: 16460
@@ -101834,8 +102149,6 @@ entities:
     - type: Transform
       parent: 4972
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
 - proto: ClothingOuterHardsuitLuxury
@@ -101845,8 +102158,6 @@ entities:
     - type: Transform
       parent: 16322
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
 - proto: ClothingOuterHardsuitMime
@@ -101856,8 +102167,6 @@ entities:
     - type: Transform
       parent: 5230
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
 - proto: ClothingOuterRobesCult
@@ -101874,17 +102183,11 @@ entities:
     - type: Transform
       pos: -64.32605,23.463242
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 16463
     components:
     - type: Transform
       pos: -69.51689,-33.38898
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ClothingOuterVestTank
   entities:
   - uid: 16464
@@ -101915,9 +102218,6 @@ entities:
     - type: Transform
       pos: -24.376945,-18.546585
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ClothingOuterWinterCoat
   entities:
   - uid: 16469
@@ -101925,9 +102225,6 @@ entities:
     - type: Transform
       pos: -43.42249,-18.254889
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ClothingOuterWinterColorWhite
   entities:
   - uid: 16470
@@ -101935,9 +102232,6 @@ entities:
     - type: Transform
       pos: -30.435333,23.734434
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ClothingOuterWizard
   entities:
   - uid: 16471
@@ -101945,9 +102239,6 @@ entities:
     - type: Transform
       pos: -89.39699,-39.413414
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ClothingShoesBootsCombat
   entities:
   - uid: 16296
@@ -101955,8 +102246,6 @@ entities:
     - type: Transform
       parent: 16291
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
 - proto: ClothingShoesBootsLaceup
@@ -101966,8 +102255,6 @@ entities:
     - type: Transform
       parent: 16472
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 16474
@@ -101975,8 +102262,6 @@ entities:
     - type: Transform
       parent: 16472
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
 - proto: ClothingShoesBootsMag
@@ -102008,9 +102293,6 @@ entities:
     - type: Transform
       pos: -47.478683,9.434428
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ClothingShoesBootsSalvage
   entities:
   - uid: 16484
@@ -102039,9 +102321,6 @@ entities:
     - type: Transform
       pos: -95.57745,-27.807392
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ClothingShoesSkates
   entities:
   - uid: 16488
@@ -102057,9 +102336,6 @@ entities:
     - type: Transform
       pos: 5.197445,57.627396
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 16490
     components:
     - type: Transform
@@ -102077,9 +102353,6 @@ entities:
     - type: Transform
       pos: -88.93166,-39.444687
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ClothingUnderSocksBee
   entities:
   - uid: 16493
@@ -102108,8 +102381,6 @@ entities:
     - type: Transform
       parent: 16291
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
 - proto: ClothingUniformJumpsuitReporter
@@ -102119,8 +102390,6 @@ entities:
     - type: Transform
       parent: 16472
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 16476
@@ -102128,8 +102397,6 @@ entities:
     - type: Transform
       parent: 16472
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
 - proto: ClothingUniformJumpsuitSecGrey
@@ -102139,9 +102406,6 @@ entities:
     - type: Transform
       pos: -80.764496,44.57916
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: CluwneHorn
   entities:
   - uid: 16497
@@ -103834,9 +104098,6 @@ entities:
     - type: Transform
       pos: -42.055023,-38.49198
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: CrateArtifactContainer
   entities:
   - uid: 16616
@@ -103850,22 +104111,8 @@ entities:
         immutable: False
         temperature: 293.14673
         moles:
-        - 1.8856695
-        - 7.0937095
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
+          Oxygen: 1.8856695
+          Nitrogen: 7.0937095
   - uid: 16764
     components:
     - type: Transform
@@ -103879,22 +104126,8 @@ entities:
         immutable: False
         temperature: 293.14673
         moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
   - uid: 16765
     components:
     - type: Transform
@@ -103908,22 +104141,8 @@ entities:
         immutable: False
         temperature: 293.14673
         moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
 - proto: CrateBodyBags
   entities:
   - uid: 16766
@@ -103944,22 +104163,8 @@ entities:
         immutable: False
         temperature: 293.14673
         moles:
-        - 1.8856695
-        - 7.0937095
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
+          Oxygen: 1.8856695
+          Nitrogen: 7.0937095
     - type: ContainerContainer
       containers:
         entity_storage: !type:Container
@@ -103983,8 +104188,6 @@ entities:
       pos: -20.5,14.5
       parent: 2
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       bodyType: Static
 - proto: CrateContrabandStorageSecure
   entities:
@@ -104077,22 +104280,8 @@ entities:
         immutable: False
         temperature: 293.14673
         moles:
-        - 1.8856695
-        - 7.0937095
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
+          Oxygen: 1.8856695
+          Nitrogen: 7.0937095
 - proto: CrateEngineeringCableHV
   entities:
   - uid: 15119
@@ -104134,22 +104323,8 @@ entities:
         immutable: False
         temperature: 293.14673
         moles:
-        - 1.8977377
-        - 7.139109
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
+          Oxygen: 1.8977377
+          Nitrogen: 7.139109
     - type: ContainerContainer
       containers:
         entity_storage: !type:Container
@@ -104179,22 +104354,8 @@ entities:
         immutable: False
         temperature: 293.14673
         moles:
-        - 1.8856695
-        - 7.0937095
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
+          Oxygen: 1.8856695
+          Nitrogen: 7.0937095
     - type: ContainerContainer
       containers:
         entity_storage: !type:Container
@@ -104218,22 +104379,8 @@ entities:
         immutable: False
         temperature: 293.14673
         moles:
-        - 1.8977377
-        - 7.139109
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
+          Oxygen: 1.8977377
+          Nitrogen: 7.139109
     - type: ContainerContainer
       containers:
         entity_storage: !type:Container
@@ -104263,22 +104410,8 @@ entities:
         immutable: False
         temperature: 293.14673
         moles:
-        - 1.8977377
-        - 7.139109
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
+          Oxygen: 1.8977377
+          Nitrogen: 7.139109
     - type: ContainerContainer
       containers:
         entity_storage: !type:Container
@@ -104479,22 +104612,8 @@ entities:
         immutable: False
         temperature: 293.14673
         moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
     - type: ContainerContainer
       containers:
         entity_storage: !type:Container
@@ -104520,22 +104639,8 @@ entities:
         immutable: False
         temperature: 293.1465
         moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
     - type: ContainerContainer
       containers:
         entity_storage: !type:Container
@@ -104650,22 +104755,8 @@ entities:
         immutable: False
         temperature: 293.14673
         moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
 - proto: CrateSecurityTrackingMindshieldImplants
   entities:
   - uid: 16860
@@ -104729,22 +104820,8 @@ entities:
         immutable: False
         temperature: 293.14673
         moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
 - proto: CrateVendingMachineRestockChemVendFilled
   entities:
   - uid: 16869
@@ -104767,9 +104844,6 @@ entities:
     - type: Transform
       pos: -32.734524,-9.050556
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: CrayonBox
   entities:
   - uid: 5234
@@ -104777,8 +104851,6 @@ entities:
     - type: Transform
       parent: 5230
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
 - proto: CrayonWhite
@@ -104788,9 +104860,6 @@ entities:
     - type: Transform
       pos: -4.446312,37.63164
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 16873
     components:
     - type: Transform
@@ -104811,9 +104880,6 @@ entities:
     - type: Transform
       pos: 34.436104,-46.565277
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: Crematorium
   entities:
   - uid: 16876
@@ -104836,9 +104902,6 @@ entities:
     - type: Transform
       pos: -43.596878,-25.404411
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 16879
     components:
     - type: Transform
@@ -104851,9 +104914,6 @@ entities:
     - type: Transform
       pos: 16.146416,91.1882
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: CrowbarOrange
   entities:
   - uid: 16881
@@ -104861,9 +104921,6 @@ entities:
     - type: Transform
       pos: 2.922205,66.549484
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: CrowbarYellow
   entities:
   - uid: 16882
@@ -104927,17 +104984,11 @@ entities:
     - type: Transform
       pos: -43.39124,-18.47379
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 16892
     components:
     - type: Transform
       pos: -43.51624,-18.348703
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: CultAltarSpawner
   entities:
   - uid: 16893
@@ -105110,9 +105161,6 @@ entities:
     - type: Transform
       pos: 4.4104276,64.562546
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: DefaultStationBeacon
   entities:
   - uid: 35789
@@ -105800,9 +105848,6 @@ entities:
     - type: Transform
       pos: -56.504375,-67.53276
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: DiceBag
   entities:
   - uid: 17007
@@ -105810,17 +105855,11 @@ entities:
     - type: Transform
       pos: -99.70727,27.464415
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 17008
     components:
     - type: Transform
       pos: -95.82136,-18.533833
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: DiseaseDiagnoser
   entities:
   - uid: 17009
@@ -112108,9 +112147,6 @@ entities:
     - type: Transform
       pos: 19.540401,82.616554
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 18084
     components:
     - type: Transform
@@ -112121,9 +112157,6 @@ entities:
     - type: Transform
       pos: 19.45707,82.78333
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: DormNotifierMarker
   entities:
   - uid: 18086
@@ -112163,13 +112196,6 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -29.508211,-29.420246
-      parent: 2
-- proto: DresserBlueshieldOfficerFilled
-  entities:
-  - uid: 18093
-    components:
-    - type: Transform
-      pos: -27.5,-21.5
       parent: 2
 - proto: DresserCaptainFilled
   entities:
@@ -112316,9 +112342,6 @@ entities:
     - type: Transform
       pos: -75.67887,-40.077835
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: DrinkBeerCan
   entities:
   - uid: 18109
@@ -112347,9 +112370,6 @@ entities:
     - type: Transform
       pos: 25.374023,-74.56174
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 18114
     components:
     - type: Transform
@@ -112361,9 +112381,6 @@ entities:
     - type: Transform
       pos: -31.49704,-44.741936
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 18116
     components:
     - type: Transform
@@ -112478,9 +112495,6 @@ entities:
     - type: Transform
       pos: -30.798124,-45.237648
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: DrinkBloodGlass
   entities:
   - uid: 18137
@@ -112540,17 +112554,11 @@ entities:
     - type: Transform
       pos: -29.923124,-41.96454
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 18147
     components:
     - type: Transform
       pos: -29.443958,-42.17302
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 18148
     components:
     - type: Transform
@@ -112574,17 +112582,11 @@ entities:
     - type: Transform
       pos: -31.514254,-44.299408
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 18152
     components:
     - type: Transform
       pos: -32.04372,-44.414158
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 18153
     components:
     - type: Transform
@@ -112642,9 +112644,6 @@ entities:
     - type: Transform
       pos: 12.013016,56.50546
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: DrinkColaCan
   entities:
   - uid: 18162
@@ -112652,9 +112651,6 @@ entities:
     - type: Transform
       pos: -29.701622,37.58812
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 18163
     components:
     - type: Transform
@@ -112684,9 +112680,6 @@ entities:
       rot: 12.566370614359172 rad
       pos: -102.23423,27.887407
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 18168
     components:
     - type: Transform
@@ -112724,9 +112717,6 @@ entities:
     - type: Transform
       pos: -81.100784,3.7177737
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: DrinkFlask
   entities:
   - uid: 18174
@@ -112734,9 +112724,6 @@ entities:
     - type: Transform
       pos: -28.499922,8.764009
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: DrinkGinBottleFull
   entities:
   - uid: 18175
@@ -112744,17 +112731,11 @@ entities:
     - type: Transform
       pos: -54.205082,12.877615
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 18176
     components:
     - type: Transform
       pos: -75.707535,-24.326355
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: DrinkGinFizzGlass
   entities:
   - uid: 18177
@@ -112829,9 +112810,6 @@ entities:
     - type: Transform
       pos: -53.798557,12.888031
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 18191
     components:
     - type: Transform
@@ -112843,9 +112821,6 @@ entities:
       rot: 12.566370614359172 rad
       pos: -58.906307,-68.23819
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 18193
     components:
     - type: Transform
@@ -112876,17 +112851,11 @@ entities:
     - type: Transform
       pos: -75.3872,-40.202835
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 18199
     components:
     - type: Transform
       pos: -33.426785,-32.468693
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 18200
     components:
     - type: Transform
@@ -112971,9 +112940,6 @@ entities:
     - type: Transform
       pos: -11.466126,-48.35438
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: DrinkMugHeart
   entities:
   - uid: 18214
@@ -113010,9 +112976,6 @@ entities:
     - type: Transform
       pos: -75.3742,-24.326355
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: DrinkPremiumTequilaBottleFull
   entities:
   - uid: 18220
@@ -113020,9 +112983,6 @@ entities:
     - type: Transform
       pos: -75.34295,-24.513987
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: DrinkRootBeerCan
   entities:
   - uid: 18221
@@ -113057,9 +113017,6 @@ entities:
     - type: Transform
       pos: 13.304893,88.72809
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: DrinkShakeBlue
   entities:
   - uid: 18227
@@ -113102,9 +113059,6 @@ entities:
       rot: 12.566370614359172 rad
       pos: -58.48941,-68.279854
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: DrinkShotGlass
   entities:
   - uid: 18234
@@ -113147,9 +113101,6 @@ entities:
     - type: Transform
       pos: -75.501785,-40.53617
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: DrinkSolDryCan
   entities:
   - uid: 18242
@@ -113179,17 +113130,11 @@ entities:
     - type: Transform
       pos: 5.608927,53.71518
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 18246
     components:
     - type: Transform
       pos: 5.7652545,53.506847
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 18247
     components:
     - type: Transform
@@ -113200,9 +113145,6 @@ entities:
     - type: Transform
       pos: -31.729662,15.196752
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 18249
     components:
     - type: Transform
@@ -113243,9 +113185,6 @@ entities:
     - type: Transform
       pos: 14.256782,89.71994
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: DrinkWaterBottleFull
   entities:
   - uid: 1002
@@ -113277,9 +113216,6 @@ entities:
     - type: Transform
       pos: -71.373856,-5.3968253
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 18259
     components:
     - type: Transform
@@ -113295,9 +113231,6 @@ entities:
     - type: Transform
       pos: -64.48545,-7.2780056
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 18262
     components:
     - type: Transform
@@ -113318,9 +113251,6 @@ entities:
     - type: Transform
       pos: -38.33678,-68.75066
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 18266
     components:
     - type: Transform
@@ -113331,17 +113261,11 @@ entities:
     - type: Transform
       pos: -33.76293,-54.03602
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 18268
     components:
     - type: Transform
       pos: -33.57543,-54.0256
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: DrinkWaterCup
   entities:
   - uid: 18269
@@ -113369,17 +113293,11 @@ entities:
     - type: Transform
       pos: -34.530792,-47.334564
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 18274
     components:
     - type: Transform
       pos: -34.687042,-47.438732
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 18275
     components:
     - type: Transform
@@ -113397,9 +113315,6 @@ entities:
     - type: Transform
       pos: -0.3990201,-47.15626
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: DrinkWineBottleFull
   entities:
   - uid: 18278
@@ -113456,9 +113371,6 @@ entities:
     - type: Transform
       pos: 4.4624434,64.09745
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: DurandPeripheralsElectronics
   entities:
   - uid: 18287
@@ -113480,61 +113392,6 @@ entities:
     components:
     - type: Transform
       pos: 2.6291096,65.61935
-      parent: 2
-- proto: DVSmartFridgeMedical
-  entities:
-  - uid: 19177
-    components:
-    - type: Transform
-      pos: -64.5,-38.5
-      parent: 2
-    - type: EntityStorage
-      air:
-        volume: 200
-        temperature: 293.14673
-        moles:
-        - 1.8856695
-        - 7.0937095
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-      closeSound: !type:SoundPathSpecifier
-        path: /Audio/Effects/closetclose.ogg
-      openSound: !type:SoundPathSpecifier
-        path: /Audio/Effects/closetopen.ogg
-    - type: ContainerContainer
-      containers:
-        entity_storage: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 19179
-          - 19178
-  - uid: 28804
-    components:
-    - type: Transform
-      pos: -54.5,-26.5
-      parent: 2
-  - uid: 28805
-    components:
-    - type: Transform
-      pos: -13.5,-5.5
-      parent: 2
-  - uid: 28806
-    components:
-    - type: Transform
-      pos: -55.5,-12.5
       parent: 2
 - proto: EffectHearts
   entities:
@@ -114843,9 +114700,6 @@ entities:
     - type: Transform
       pos: -14.497142,86.45938
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: EvidenceMarkerOne
   entities:
   - uid: 18512
@@ -117351,9 +117205,6 @@ entities:
     - type: Transform
       pos: -27.754572,-69.44617
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: FireExtinguisher
   entities:
   - uid: 18780
@@ -119991,9 +119842,6 @@ entities:
     - type: Transform
       pos: -86.467674,29.517365
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: FlashlightLantern
   entities:
   - uid: 19022
@@ -120047,9 +119895,6 @@ entities:
     - type: Transform
       pos: -75.095535,-40.432003
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: Floodlight
   entities:
   - uid: 19030
@@ -120126,97 +119971,71 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -23.5,5.5
       parent: 2
-    - type: Fixtures
-      fixtures: {}
   - uid: 19041
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -53.5,-7.5
       parent: 2
-    - type: Fixtures
-      fixtures: {}
   - uid: 19042
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -42.5,-29.5
       parent: 2
-    - type: Fixtures
-      fixtures: {}
   - uid: 19043
     components:
     - type: Transform
       pos: -56.5,-35.5
       parent: 2
-    - type: Fixtures
-      fixtures: {}
   - uid: 19044
     components:
     - type: Transform
       pos: -20.5,-8.5
       parent: 2
-    - type: Fixtures
-      fixtures: {}
   - uid: 19045
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -39.5,-47.5
       parent: 2
-    - type: Fixtures
-      fixtures: {}
   - uid: 19046
     components:
     - type: Transform
       pos: -51.5,-41.5
       parent: 2
-    - type: Fixtures
-      fixtures: {}
   - uid: 19047
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -107.5,26.5
       parent: 2
-    - type: Fixtures
-      fixtures: {}
   - uid: 19048
     components:
     - type: Transform
       pos: -14.5,-7.5
       parent: 2
-    - type: Fixtures
-      fixtures: {}
   - uid: 19049
     components:
     - type: Transform
       pos: -103.5,-17.5
       parent: 2
-    - type: Fixtures
-      fixtures: {}
   - uid: 19050
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -22.5,87.5
       parent: 2
-    - type: Fixtures
-      fixtures: {}
   - uid: 34951
     components:
     - type: Transform
       pos: -13.5,-59.5
       parent: 2
-    - type: Fixtures
-      fixtures: {}
   - uid: 35788
     components:
     - type: Transform
       pos: -12.5,-59.5
       parent: 2
-    - type: Fixtures
-      fixtures: {}
 - proto: FloorTileItemCarpetClown
   entities:
   - uid: 19051
@@ -120239,9 +120058,6 @@ entities:
     - type: Transform
       pos: -87.757416,37.550007
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: FloorTileItemGym
   entities:
   - uid: 19055
@@ -120251,9 +120067,6 @@ entities:
       parent: 2
     - type: Stack
       count: 20
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: FloorTileItemWood
   entities:
   - uid: 19056
@@ -120345,9 +120158,6 @@ entities:
     - type: Transform
       pos: -46.548088,10.528938
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: FoamCutlass
   entities:
   - uid: 19070
@@ -120440,9 +120250,6 @@ entities:
     - type: Transform
       pos: -31.58129,-48.584282
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: FoodBakedCookieOatmeal
   entities:
   - uid: 19084
@@ -120464,9 +120271,6 @@ entities:
     - type: Transform
       pos: -31.529203,-48.646828
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: FoodBakedWaffleRoffle
   entities:
   - uid: 19087
@@ -120486,9 +120290,6 @@ entities:
     - type: Transform
       pos: -57.417187,37.73101
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 19090
     components:
     - type: Transform
@@ -120530,9 +120331,6 @@ entities:
     - type: Transform
       pos: -65.06727,-28.315979
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: FoodBoxDonkpocketStonk
   entities:
   - uid: 19097
@@ -120547,9 +120345,6 @@ entities:
     - type: Transform
       pos: -68.46402,33.645542
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: FoodBoxDonut
   entities:
   - uid: 19099
@@ -120574,9 +120369,6 @@ entities:
     - type: Transform
       pos: -9.825897,-47.823666
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: FoodBoxPizzaFilled
   entities:
   - uid: 19103
@@ -120663,8 +120455,6 @@ entities:
     - type: Transform
       parent: 19116
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 19118
@@ -120677,9 +120467,6 @@ entities:
     - type: Transform
       pos: -45.45667,-12.546153
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 19120
     components:
     - type: Transform
@@ -120739,9 +120526,6 @@ entities:
     - type: Transform
       pos: -100.95826,27.60712
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: FoodBurgerCat
   entities:
   - uid: 19131
@@ -120749,9 +120533,6 @@ entities:
     - type: Transform
       pos: -52.73443,50.70355
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: FoodBurgerClown
   entities:
   - uid: 19132
@@ -120766,9 +120547,6 @@ entities:
     - type: Transform
       pos: -12.480758,69.48377
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: FoodBurgerMcrib
   entities:
   - uid: 19134
@@ -120793,9 +120571,6 @@ entities:
     - type: Transform
       pos: -4.3347673,-2.3417032
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: FoodBurgerRobot
   entities:
   - uid: 19138
@@ -120824,9 +120599,6 @@ entities:
     - type: Transform
       pos: -42.607105,-38.30435
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: FoodCakeLemoon
   entities:
   - uid: 19142
@@ -120841,9 +120613,6 @@ entities:
     - type: Transform
       pos: -23.493732,47.449707
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: FoodCartCold
   entities:
   - uid: 19144
@@ -120874,8 +120643,6 @@ entities:
     - type: Transform
       parent: 19147
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 19155
@@ -120915,9 +120682,6 @@ entities:
       rot: -4.440892098500626E-16 rad
       pos: -64.592224,10.639721
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: FoodDonutJellyScurret
   entities:
   - uid: 19161
@@ -120995,9 +120759,6 @@ entities:
     - type: Transform
       pos: -50.52801,97.460434
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: FoodMealMilkape
   entities:
   - uid: 19175
@@ -121005,9 +120766,6 @@ entities:
     - type: Transform
       pos: -57.401703,69.797325
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: FoodMealRibs
   entities:
   - uid: 19176
@@ -121022,8 +120780,6 @@ entities:
     - type: Transform
       parent: 16819
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 16821
@@ -121031,8 +120787,6 @@ entities:
     - type: Transform
       parent: 16819
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 16822
@@ -121040,8 +120794,6 @@ entities:
     - type: Transform
       parent: 16819
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
 - proto: FoodMeatBacon
@@ -121051,8 +120803,6 @@ entities:
     - type: Transform
       parent: 19147
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 19150
@@ -121060,8 +120810,6 @@ entities:
     - type: Transform
       parent: 19147
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 19151
@@ -121069,8 +120817,6 @@ entities:
     - type: Transform
       parent: 19147
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 19152
@@ -121078,8 +120824,6 @@ entities:
     - type: Transform
       parent: 19147
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 19153
@@ -121087,8 +120831,6 @@ entities:
     - type: Transform
       parent: 19147
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 19154
@@ -121096,8 +120838,6 @@ entities:
     - type: Transform
       parent: 19147
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
 - proto: FoodMeatGondola
@@ -121107,8 +120847,6 @@ entities:
     - type: Transform
       parent: 19177
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 19179
@@ -121116,8 +120854,6 @@ entities:
     - type: Transform
       parent: 19177
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
 - proto: FoodMeatHuman
@@ -121127,8 +120863,6 @@ entities:
     - type: Transform
       parent: 16819
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 16824
@@ -121136,8 +120870,6 @@ entities:
     - type: Transform
       parent: 16819
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
 - proto: FoodMeatLizardCooked
@@ -121188,8 +120920,6 @@ entities:
     - type: Transform
       parent: 4972
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 4977
@@ -121197,8 +120927,6 @@ entities:
     - type: Transform
       parent: 4972
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 4978
@@ -121206,8 +120934,6 @@ entities:
     - type: Transform
       parent: 4972
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 4979
@@ -121215,8 +120941,6 @@ entities:
     - type: Transform
       parent: 4972
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
 - proto: FoodPizzaMoldySlice
@@ -121320,17 +121044,11 @@ entities:
     - type: Transform
       pos: 16.65855,28.32565
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 19203
     components:
     - type: Transform
       pos: 16.415886,27.942066
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: FoodPotato
   entities:
   - uid: 19204
@@ -121352,9 +121070,6 @@ entities:
     - type: Transform
       pos: -0.6386033,-46.81227
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: FoodSnackAncientPizza
   entities:
   - uid: 19207
@@ -121362,33 +121077,21 @@ entities:
     - type: Transform
       pos: -7.2499585,32.41463
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 19208
     components:
     - type: Transform
       pos: -6.145792,32.623108
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 19209
     components:
     - type: Transform
       pos: -5.7291255,33.832283
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 19210
     components:
     - type: Transform
       pos: -5.5624585,32.091488
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: FoodSnackChips
   entities:
   - uid: 19211
@@ -121396,9 +121099,6 @@ entities:
     - type: Transform
       pos: -96.66723,-18.467632
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: FoodSnackChocolate
   entities:
   - uid: 19212
@@ -121413,9 +121113,6 @@ entities:
     - type: Transform
       pos: -83.378746,-22.464964
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: FoodSnackEnergy
   entities:
   - uid: 19215
@@ -121522,9 +121219,6 @@ entities:
     - type: Transform
       pos: -62.50117,92.48823
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: FoodSnackVenusianhotcakes
   entities:
   - uid: 19232
@@ -121565,9 +121259,6 @@ entities:
     - type: Transform
       pos: -12.307397,-48.331413
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: FoodSpacemansTrumpet
   entities:
   - uid: 1309
@@ -121731,9 +121422,6 @@ entities:
     - type: Transform
       pos: -48.72117,62.564762
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 19266
     components:
     - type: Transform
@@ -149275,9 +148963,6 @@ entities:
     - type: Transform
       pos: -55.479362,-20.568306
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 22554
     components:
     - type: Transform
@@ -149304,9 +148989,6 @@ entities:
       parent: 2
     - type: Geiger
       isEnabled: True
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
     - type: RadiationReceiver
   - uid: 22558
     components:
@@ -149436,9 +149118,6 @@ entities:
     - type: Transform
       pos: -56.519306,-68.38942
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: GrassBattlemap
   entities:
   - uid: 22579
@@ -149446,9 +149125,6 @@ entities:
     - type: Transform
       pos: 19.473467,62.581665
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: GravityGenerator
   entities:
   - uid: 22580
@@ -156464,93 +156140,60 @@ entities:
     - type: Transform
       pos: -48.28767,9.934775
       parent: 2
-- proto: GunSafeBaseSecure
+- proto: GunSafeDisabler
+  entities:
+  - uid: 5189
+    components:
+    - type: Transform
+      pos: -79.5,28.5
+      parent: 2
+- proto: GunSafeJudo
+  entities:
+  - uid: 17
+    components:
+    - type: Transform
+      pos: -81.5,34.5
+      parent: 2
+- proto: GunSafeLaserCarbine
+  entities:
+  - uid: 16
+    components:
+    - type: Transform
+      pos: -82.5,32.5
+      parent: 2
+  - uid: 27
+    components:
+    - type: Transform
+      pos: -82.5,31.5
+      parent: 2
+- proto: GunSafeLaserSpec
+  entities:
+  - uid: 20
+    components:
+    - type: Transform
+      pos: -82.5,30.5
+      parent: 2
+- proto: GunSafeMelee
   entities:
   - uid: 19
     components:
-    - type: MetaData
-      name: torrent safe
     - type: Transform
-      anchored: True
-      pos: -82.5,32.5
-      parent: 2
-    - type: Physics
-      bodyType: Static
-    - type: EntityStorage
-      air:
-        volume: 200
-        immutable: False
-        temperature: 293.14673
-        moles:
-        - 1.8856695
-        - 7.0937095
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-    - type: ContainerContainer
-      containers:
-        entity_storage: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 23500
-          - 27
-          - 22
-          - 23498
-          - 25
-          - 20
-          - 23499
-        paper_label: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
-- proto: GunSafeLaserCarbine
-  entities:
-  - uid: 23848
-    components:
-    - type: Transform
-      anchored: True
       pos: -80.5,34.5
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      bodyType: Static
-- proto: GunSafeRifleLecter
+- proto: GunSafeRiotLauncher
   entities:
-  - uid: 23849
+  - uid: 5137
     components:
     - type: Transform
-      anchored: True
       pos: -82.5,34.5
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      bodyType: Static
-- proto: GunSafeSubMachineGunDrozd
+- proto: GunSafeShotgunEnforcer
   entities:
-  - uid: 23850
+  - uid: 5190
     components:
     - type: Transform
-      anchored: True
-      pos: -81.5,34.5
+      pos: -82.5,29.5
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      bodyType: Static
 - proto: GygaxChassis
   entities:
   - uid: 23851
@@ -156590,9 +156233,6 @@ entities:
       rot: 6.283185307179586 rad
       pos: -21.576616,-18.354193
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: HandLabeler
   entities:
   - uid: 23857
@@ -156624,9 +156264,6 @@ entities:
     - type: Transform
       pos: -88.442085,-37.432873
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: HarmonicaInstrument
   entities:
   - uid: 23862
@@ -157263,13 +156900,6 @@ entities:
     - type: Transform
       pos: -81.5,-28.5
       parent: 2
-- proto: HonkerChassis
-  entities:
-  - uid: 23949
-    components:
-    - type: Transform
-      pos: 12.5,67.5
-      parent: 2
 - proto: HospitalCurtainsOpen
   entities:
   - uid: 23950
@@ -157340,9 +156970,6 @@ entities:
       rot: 12.566370614359172 rad
       pos: -107.61278,23.667309
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 23961
     components:
     - type: Transform
@@ -157373,9 +157000,6 @@ entities:
       rot: 12.566370614359172 rad
       pos: -107.413216,21.546247
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 23966
     components:
     - type: Transform
@@ -157389,9 +157013,6 @@ entities:
       rot: 12.566370614359172 rad
       pos: -107.505394,21.647593
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 23968
     components:
     - type: Transform
@@ -157603,9 +157224,6 @@ entities:
     - type: Transform
       pos: 22.486856,34.631237
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: InflatableDoor
   entities:
   - uid: 2132
@@ -157637,9 +157255,6 @@ entities:
     - type: Transform
       pos: -41.740845,11.554671
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: IngotGold1
   entities:
   - uid: 24011
@@ -157654,9 +157269,6 @@ entities:
     - type: Transform
       pos: -41.397095,11.565095
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: Intellicard
   entities:
   - uid: 24013
@@ -157916,9 +157528,6 @@ entities:
     - type: Transform
       pos: -74.32136,-40.520317
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: Jukebox
   entities:
   - uid: 24043
@@ -158263,8 +157872,6 @@ entities:
     - type: Transform
       parent: 5252
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
   - uid: 24092
     components:
@@ -158540,22 +158147,8 @@ entities:
         immutable: False
         temperature: 293.14673
         moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
     - type: ContainerContainer
       containers:
         entity_storage: !type:Container
@@ -158596,8 +158189,6 @@ entities:
       pos: -7.5,30.5
       parent: 2
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       bodyType: Static
 - proto: LockerChiefMedicalOfficerFilled
   entities:
@@ -158608,8 +158199,6 @@ entities:
       pos: -69.5,-17.5
       parent: 2
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       bodyType: Static
 - proto: LockerClown
   entities:
@@ -158624,22 +158213,8 @@ entities:
         immutable: False
         temperature: 293.14673
         moles:
-        - 1.8978093
-        - 7.139378
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
+          Oxygen: 1.8978093
+          Nitrogen: 7.139378
     - type: ContainerContainer
       containers:
         entity_storage: !type:Container
@@ -158682,8 +158257,6 @@ entities:
       pos: -25.5,41.5
       parent: 2
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       bodyType: Static
   - uid: 24120
     components:
@@ -158729,8 +158302,6 @@ entities:
       pos: -29.5,40.5
       parent: 2
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       bodyType: Static
   - uid: 24128
     components:
@@ -158739,8 +158310,6 @@ entities:
       pos: -29.5,41.5
       parent: 2
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       bodyType: Static
   - uid: 24129
     components:
@@ -158749,8 +158318,6 @@ entities:
       pos: -29.5,42.5
       parent: 2
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       bodyType: Static
   - uid: 24130
     components:
@@ -158759,8 +158326,6 @@ entities:
       pos: -29.5,43.5
       parent: 2
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       bodyType: Static
   - uid: 24131
     components:
@@ -158769,8 +158334,6 @@ entities:
       pos: -23.5,40.5
       parent: 2
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       bodyType: Static
   - uid: 24132
     components:
@@ -158779,8 +158342,6 @@ entities:
       pos: -23.5,43.5
       parent: 2
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       bodyType: Static
   - uid: 24133
     components:
@@ -158789,8 +158350,6 @@ entities:
       pos: -23.5,41.5
       parent: 2
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       bodyType: Static
   - uid: 24134
     components:
@@ -158799,8 +158358,6 @@ entities:
       pos: -23.5,42.5
       parent: 2
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       bodyType: Static
 - proto: LockerEvidence
   entities:
@@ -158830,52 +158387,21 @@ entities:
         immutable: False
         temperature: 293.14673
         moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
   - uid: 24139
     components:
     - type: Transform
       pos: -77.5,17.5
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
     - type: EntityStorage
       air:
         volume: 200
         immutable: False
         temperature: 293.14673
         moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
   - uid: 24140
     components:
     - type: Transform
@@ -158887,22 +158413,8 @@ entities:
         immutable: False
         temperature: 293.14673
         moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
   - uid: 24141
     components:
     - type: Transform
@@ -158914,22 +158426,8 @@ entities:
         immutable: False
         temperature: 293.14673
         moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
   - uid: 24142
     components:
     - type: Transform
@@ -158941,22 +158439,8 @@ entities:
         immutable: False
         temperature: 293.14673
         moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
   - uid: 24143
     components:
     - type: Transform
@@ -158968,22 +158452,8 @@ entities:
         immutable: False
         temperature: 293.14673
         moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
   - uid: 24144
     components:
     - type: Transform
@@ -158995,60 +158465,26 @@ entities:
         immutable: False
         temperature: 293.14673
         moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
   - uid: 24145
     components:
     - type: Transform
       pos: -77.5,20.5
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24146
     components:
     - type: Transform
       pos: -77.5,14.5
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
     - type: EntityStorage
       air:
         volume: 200
         immutable: False
         temperature: 293.14673
         moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
   - uid: 24147
     components:
     - type: Transform
@@ -159060,22 +158496,8 @@ entities:
         immutable: False
         temperature: 293.14673
         moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
   - uid: 24148
     components:
     - type: Transform
@@ -159087,22 +158509,8 @@ entities:
         immutable: False
         temperature: 293.14673
         moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
   - uid: 24149
     components:
     - type: Transform
@@ -159114,22 +158522,8 @@ entities:
         immutable: False
         temperature: 293.14673
         moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
   - uid: 24150
     components:
     - type: Transform
@@ -159141,22 +158535,8 @@ entities:
         immutable: False
         temperature: 293.14673
         moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
 - proto: LockerFreezer
   entities:
   - uid: 19147
@@ -159170,22 +158550,8 @@ entities:
         immutable: False
         temperature: 234.99739
         moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
     - type: ContainerContainer
       containers:
         entity_storage: !type:Container
@@ -159226,8 +158592,6 @@ entities:
       pos: -24.5,13.5
       parent: 2
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       bodyType: Static
 - proto: LockerHeadOfSecurityFilled
   entities:
@@ -159238,8 +158602,6 @@ entities:
       pos: -61.5,27.5
       parent: 2
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       bodyType: Static
 - proto: LockerMedicalFilled
   entities:
@@ -159298,22 +158660,8 @@ entities:
         immutable: False
         temperature: 293.14673
         moles:
-        - 1.8856695
-        - 7.0937095
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
+          Oxygen: 1.8856695
+          Nitrogen: 7.0937095
     - type: ContainerContainer
       containers:
         entity_storage: !type:Container
@@ -159350,8 +158698,6 @@ entities:
       pos: 5.5,-46.5
       parent: 2
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       bodyType: Static
 - proto: LockerResearchDirectorFilled
   entities:
@@ -159362,8 +158708,6 @@ entities:
       pos: -58.5,-65.5
       parent: 2
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       bodyType: Static
 - proto: LockerSalvageSpecialistFilled
   entities:
@@ -159435,8 +158779,6 @@ entities:
       pos: -70.5,32.5
       parent: 2
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       bodyType: Static
   - uid: 24178
     components:
@@ -159445,8 +158787,6 @@ entities:
       pos: -71.5,28.5
       parent: 2
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       bodyType: Static
   - uid: 24179
     components:
@@ -159455,8 +158795,6 @@ entities:
       pos: -71.5,30.5
       parent: 2
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       bodyType: Static
   - uid: 24180
     components:
@@ -159465,8 +158803,6 @@ entities:
       pos: -71.5,34.5
       parent: 2
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       bodyType: Static
   - uid: 24181
     components:
@@ -159475,8 +158811,6 @@ entities:
       pos: -70.5,28.5
       parent: 2
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       bodyType: Static
   - uid: 24182
     components:
@@ -159485,8 +158819,6 @@ entities:
       pos: -70.5,30.5
       parent: 2
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       bodyType: Static
   - uid: 24183
     components:
@@ -159495,8 +158827,6 @@ entities:
       pos: -71.5,32.5
       parent: 2
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       bodyType: Static
   - uid: 24184
     components:
@@ -159505,8 +158835,6 @@ entities:
       pos: -70.5,34.5
       parent: 2
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       bodyType: Static
 - proto: LockerWallMedicalFilled
   entities:
@@ -159525,8 +158853,6 @@ entities:
       pos: -71.5,20.5
       parent: 2
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       bodyType: Static
 - proto: LockerWeldingSuppliesFilled
   entities:
@@ -159537,8 +158863,6 @@ entities:
       pos: -25.5,42.5
       parent: 2
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       bodyType: Static
   - uid: 24188
     components:
@@ -159654,8 +158978,6 @@ entities:
     - type: Transform
       parent: 5230
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 24200
@@ -159663,9 +158985,6 @@ entities:
     - type: Transform
       pos: -17.62911,13.7577505
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: MachineAnomalyGenerator
   entities:
   - uid: 24201
@@ -159810,9 +159129,6 @@ entities:
     - type: Transform
       pos: -78.218666,43.488773
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: MagazinePistolPractice
   entities:
   - uid: 24226
@@ -159820,9 +159136,6 @@ entities:
     - type: Transform
       pos: -73.42727,37.5614
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24227
     components:
     - type: Transform
@@ -159835,9 +159148,6 @@ entities:
     - type: Transform
       pos: 21.371876,61.96984
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24231
     components:
     - type: Transform
@@ -159851,17 +159161,11 @@ entities:
     - type: Transform
       pos: -26.490648,-44.269764
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24233
     components:
     - type: Transform
       pos: -26.521898,-44.80759
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: MailCapsulePrimed
   entities:
   - uid: 24234
@@ -159869,9 +159173,6 @@ entities:
     - type: Transform
       pos: -26.709398,-45.2037
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: MailingUnit
   entities:
   - uid: 24235
@@ -159908,23 +159209,6 @@ entities:
     components:
     - type: Transform
       pos: -31.5,-50.5
-      parent: 2
-- proto: MailMetricsCartridge
-  entities:
-  - uid: 24242
-    components:
-    - type: Transform
-      pos: -21.30126,-42.110176
-      parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-- proto: MailTeleporter
-  entities:
-  - uid: 24243
-    components:
-    - type: Transform
-      pos: -23.5,-45.5
       parent: 2
 - proto: MaintenanceFluffSpawner
   entities:
@@ -160556,9 +159840,6 @@ entities:
     - type: Transform
       pos: 6.2268815,85.315186
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24361
     components:
     - type: Transform
@@ -160591,9 +159872,6 @@ entities:
     - type: Transform
       pos: 7.4584947,-43.4027
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: MaterialDurathread
   entities:
   - uid: 24366
@@ -160748,9 +160026,6 @@ entities:
     - type: Transform
       pos: -59.643284,-13.31759
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: MedicalPatchPrefilledDermaline
   entities:
   - uid: 24391
@@ -160758,9 +160033,6 @@ entities:
     - type: Transform
       pos: -59.799534,-13.546757
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: MedicalScanner
   entities:
   - uid: 24392
@@ -160813,9 +160085,6 @@ entities:
     - type: Transform
       pos: -68.815315,-25.293142
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24400
     components:
     - type: Transform
@@ -160841,9 +160110,6 @@ entities:
     - type: Transform
       pos: -68.35699,-25.666508
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24404
     components:
     - type: Transform
@@ -160856,9 +160122,6 @@ entities:
     - type: Transform
       pos: -29.505661,-23.401249
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24406
     components:
     - type: Transform
@@ -160871,9 +160134,6 @@ entities:
     - type: Transform
       pos: -68.346565,-26.031343
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24408
     components:
     - type: Transform
@@ -160884,17 +160144,11 @@ entities:
     - type: Transform
       pos: 24.499063,-35.32163
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24410
     components:
     - type: Transform
       pos: 24.457397,-35.45714
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24411
     components:
     - type: Transform
@@ -160905,9 +160159,6 @@ entities:
     - type: Transform
       pos: -96.57731,3.63434
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: MedkitO2
   entities:
   - uid: 24413
@@ -160915,9 +160166,6 @@ entities:
     - type: Transform
       pos: -96.51481,3.457134
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: MedkitOxygenFilled
   entities:
   - uid: 24414
@@ -160925,9 +160173,6 @@ entities:
     - type: Transform
       pos: -50.62656,-22.29239
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24415
     components:
     - type: Transform
@@ -160943,9 +160188,6 @@ entities:
     - type: Transform
       pos: -77.42519,47.716457
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: MedkitRadiationFilled
   entities:
   - uid: 24418
@@ -161014,16 +160256,6 @@ entities:
     - type: Transform
       pos: -82.68806,-31.153528
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-- proto: MilitaryPowerCellLMG
-  entities:
-  - uid: 35903
-    components:
-    - type: Transform
-      pos: -82.37307,33.521587
-      parent: 2
 - proto: MiniGravityGeneratorCircuitboard
   entities:
   - uid: 24427
@@ -161031,9 +160263,6 @@ entities:
     - type: Transform
       pos: 19.467485,82.07451
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: MiningDrill
   entities:
   - uid: 24428
@@ -161106,9 +160335,6 @@ entities:
     - type: Transform
       pos: 19.473467,62.529545
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: MopBucket
   entities:
   - uid: 24437
@@ -161147,17 +160373,12 @@ entities:
     - type: Transform
       parent: 5252
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
   - uid: 24441
     components:
     - type: Transform
       pos: -59.979702,37.811188
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24442
     components:
     - type: Transform
@@ -161168,9 +160389,6 @@ entities:
     - type: Transform
       pos: -52.586475,-40.602276
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24444
     components:
     - type: Transform
@@ -161213,22 +160431,8 @@ entities:
         immutable: False
         temperature: 293.14673
         moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
     - type: ContainerContainer
       containers:
         entity_storage: !type:Container
@@ -161353,9 +160557,6 @@ entities:
     - type: Transform
       pos: -6.475136,44.5343
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24466
     components:
     - type: Transform
@@ -161377,35 +160578,21 @@ entities:
     - type: Transform
       pos: -18.297459,32.21604
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24470
     components:
     - type: Transform
       pos: 16.437511,73.58679
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 32637
     components:
     - type: Transform
       pos: -57.61302,-47.634308
       parent: 2
-    - type: NetworkConfigurator
-      linkModeActive: False
   - uid: 35913
-    mapInit: true
-    paused: true
     components:
     - type: Transform
       pos: -82.2931,-31.139275
       parent: 2
-    - type: NetworkConfigurator
-      lastUseAttempt: 43.6332897
-    - type: EmitSoundOnCollide
-      nextSound: -200.5331328
 - proto: MusicBoxInstrument
   entities:
   - uid: 24471
@@ -161413,9 +160600,6 @@ entities:
     - type: Transform
       pos: -46.485123,-60.728065
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24472
     components:
     - type: Transform
@@ -161435,8 +160619,6 @@ entities:
     - type: Transform
       parent: 16472
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 16478
@@ -161444,8 +160626,6 @@ entities:
     - type: Transform
       parent: 16472
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
 - proto: NewtonCradle
@@ -161655,9 +160835,6 @@ entities:
     - type: Transform
       pos: -54.77402,-21.435434
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24509
     components:
     - type: Transform
@@ -161705,13 +160882,6 @@ entities:
     - type: Transform
       pos: 8.5,-38.5
       parent: 2
-- proto: OrganFelinidEars
-  entities:
-  - uid: 24517
-    components:
-    - type: Transform
-      pos: -64.59338,72.61955
-      parent: 2
 - proto: OrganHumanLungs
   entities:
   - uid: 24518
@@ -161726,8 +160896,6 @@ entities:
     - type: Transform
       parent: 16825
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 16827
@@ -161735,8 +160903,6 @@ entities:
     - type: Transform
       parent: 16825
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 16828
@@ -161744,8 +160910,6 @@ entities:
     - type: Transform
       parent: 16825
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 16829
@@ -161753,8 +160917,6 @@ entities:
     - type: Transform
       parent: 16825
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 16830
@@ -161762,8 +160924,6 @@ entities:
     - type: Transform
       parent: 16825
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 16831
@@ -161771,8 +160931,6 @@ entities:
     - type: Transform
       parent: 16825
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 16832
@@ -161780,8 +160938,6 @@ entities:
     - type: Transform
       parent: 16825
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 16833
@@ -161789,8 +160945,6 @@ entities:
     - type: Transform
       parent: 16825
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 16834
@@ -161798,8 +160952,6 @@ entities:
     - type: Transform
       parent: 16825
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
 - proto: OxygenCanister
@@ -162027,9 +161179,6 @@ entities:
     - type: Transform
       pos: -83.670006,-22.662878
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: PaladinCircuitBoard
   entities:
   - uid: 9728
@@ -162063,8 +161212,6 @@ entities:
 
         HAND THESE OUT TO EVERY ONE OF THOSE MORONS AND MAYBE EVEN GIVE IT TO THE REST OF THE CREW SO THEY CAN FINALLY PROPERLY TELL ME WHAT EVEN WENT WRONG!
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
   - uid: 5166
     components:
@@ -162100,8 +161247,6 @@ entities:
 
         [bold]Reason: [/bold][color=red]Provide a Brief Explanation for Your Access Request [/color]
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
   - uid: 5167
     components:
@@ -162207,8 +161352,6 @@ entities:
         New Title:    [color=#002AAF]Sample Title[/color]
                        ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
   - uid: 5168
     components:
@@ -162246,8 +161389,6 @@ entities:
 
         [bold]Reason: [/bold][color=red]Reason for switching jobs.[/color]
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
   - uid: 5169
     components:
@@ -162326,8 +161467,6 @@ entities:
 
         Those who abuse granted permission can be fined up to 5000 spesos pursuant NT Handbook §16-8.7c[/color]
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
   - uid: 24558
     components:
@@ -162349,17 +161488,11 @@ entities:
     - type: Transform
       pos: -55.332737,9.015289
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24562
     components:
     - type: Transform
       pos: -55.624405,7.767735
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24563
     components:
     - type: Transform
@@ -162371,9 +161504,6 @@ entities:
     - type: Transform
       pos: -55.488987,9.056956
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24565
     components:
     - type: Transform
@@ -162558,17 +161688,11 @@ entities:
         Da ba dee da ba di
 
         Da ba dee da ba di
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24567
     components:
     - type: Transform
       pos: -68.02001,-7.467076
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24568
     components:
     - type: Transform
@@ -162740,9 +161864,6 @@ entities:
     - type: Transform
       pos: -28.495323,8.774485
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: PaperCNCSheet
   entities:
   - uid: 24597
@@ -162755,17 +161876,11 @@ entities:
     - type: Transform
       pos: 19.3385,61.67797
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24599
     components:
     - type: Transform
       pos: 19.30725,61.71967
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24600
     components:
     - type: Transform
@@ -162808,8 +161923,6 @@ entities:
 
         Signed [color=lightblue]NAME[/color].
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
   - uid: 5171
     components:
@@ -162840,44 +161953,30 @@ entities:
 
         Central Command
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
   - uid: 24602
     components:
     - type: Transform
       pos: -22.309095,13.505382
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24603
     components:
     - type: Transform
       rot: 6.283185307179586 rad
       pos: -85.763084,23.65817
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24604
     components:
     - type: Transform
       rot: 6.283185307179586 rad
       pos: -86.013084,23.616503
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24605
     components:
     - type: Transform
       rot: 6.283185307179586 rad
       pos: -85.61339,23.543587
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24606
     components:
     - type: Transform
@@ -162897,9 +161996,6 @@ entities:
       parent: 2
     - type: Paper
       content: "What the fuck did you just fucking say about me, you little bitch? I'll have you know I graduated top of my class in the Security Officer team, and I've been involved in numerous secret raids on Syndicate Agents, and I have over 300 confirmed kills. I am trained in gorilla warfare and I'm the top sniper in the entire NT armed forces. You are nothing to me but just another target. I will wipe you the fuck out with precision the likes of which has never been seen before on this Station, mark my fucking words. You think you can get away with saying that shit to me over the Internet? Think again, fucker. As we speak I am contacting my secret network of spies across the Sector and your empolyment ID is being traced right now so you better prepare for the storm, Mothroach. The storm that wipes out the pathetic little thing you call your life. You're fucking dead, kid. I can be anywhere, anytime, and I can kill you in over seven hundred ways, and that's just with my bare hands. Not only am I extensively trained in unarmed combat, but I have access to the entire arsenal of the NanoTrasen Marine Corps and I will use it to its full extent to wipe your miserable ass off the face of the continent, you little shit. If only you could have known what unholy retribution your little \"clever\" comment was about to bring down upon you, maybe you would have held your fucking tongue. But you couldn't, you didn't, and now you're paying the price, you goddamn idiot. I will shit fury all over you and you will drown in it. You're fucking dead, kiddo. "
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24609
     components:
     - type: Transform
@@ -162911,25 +162007,16 @@ entities:
     - type: Transform
       pos: -28.367962,18.10601
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24611
     components:
     - type: Transform
       pos: -28.513866,18.04351
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24612
     components:
     - type: Transform
       pos: -22.44458,13.744966
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24613
     components:
     - type: Transform
@@ -162960,17 +162047,11 @@ entities:
     - type: Transform
       pos: -79.626,-29.366861
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24619
     components:
     - type: Transform
       pos: -79.365585,-29.418945
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24620
     components:
     - type: Transform
@@ -162998,17 +162079,11 @@ entities:
     - type: Transform
       pos: -74.19889,-64.347595
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24625
     components:
     - type: Transform
       pos: -74.41764,-64.347595
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24626
     components:
     - type: Transform
@@ -163084,17 +162159,11 @@ entities:
     - type: Transform
       pos: -5.281551,32.72688
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24635
     components:
     - type: Transform
       pos: -6.7060103,32.799847
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24636
     components:
     - type: Transform
@@ -163202,25 +162271,16 @@ entities:
     - type: Transform
       pos: -56.581615,76.50343
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24652
     components:
     - type: Transform
       pos: -56.45537,76.33665
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24653
     components:
     - type: Transform
       pos: -56.757454,76.73276
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24654
     components:
     - type: Transform
@@ -163234,9 +162294,6 @@ entities:
     - type: Transform
       pos: -73.506744,-34.652504
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: Pen
   entities:
   - uid: 24656
@@ -163250,9 +162307,6 @@ entities:
     - type: Transform
       pos: -15.551703,-37.70465
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24658
     components:
     - type: Transform
@@ -163264,9 +162318,6 @@ entities:
     - type: Transform
       pos: -31.39633,15.661549
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24660
     components:
     - type: Transform
@@ -163278,9 +162329,6 @@ entities:
       rot: 6.283185307179586 rad
       pos: -85.30089,23.62692
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24662
     components:
     - type: Transform
@@ -163291,9 +162339,6 @@ entities:
     - type: Transform
       pos: 14.702975,33.801376
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24664
     components:
     - type: Transform
@@ -163310,9 +162355,6 @@ entities:
     - type: Transform
       pos: -72.960655,-64.43057
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24667
     components:
     - type: Transform
@@ -163332,9 +162374,6 @@ entities:
     - type: Transform
       pos: -28.00253,18.681744
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: PersonalAI
   entities:
   - uid: 24670
@@ -163342,17 +162381,11 @@ entities:
     - type: Transform
       pos: -69.34547,11.610961
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24671
     components:
     - type: Transform
       pos: -13.479013,14.776412
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24672
     components:
     - type: Transform
@@ -163363,17 +162396,11 @@ entities:
     - type: Transform
       pos: -4.5732703,-48.74827
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24674
     components:
     - type: Transform
       pos: -40.50114,-13.417582
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24675
     components:
     - type: Transform
@@ -163434,9 +162461,6 @@ entities:
     - type: Transform
       pos: 21.466423,-32.365753
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: PillCanisterRandom
   entities:
   - uid: 24684
@@ -163466,9 +162490,6 @@ entities:
     - type: Transform
       pos: -40.537083,8.695762
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24688
     components:
     - type: Transform
@@ -163510,9 +162531,6 @@ entities:
     - type: Transform
       pos: -35.44193,-4.519009
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: PlantBGoneSpray
   entities:
   - uid: 24693
@@ -163856,8 +162874,6 @@ entities:
     - type: Transform
       parent: 5252
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
 - proto: PlushieAtmosian
   entities:
@@ -163866,9 +162882,6 @@ entities:
     - type: Transform
       pos: -31.587652,27.697378
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: PlushieDurk
   entities:
   - uid: 24755
@@ -163977,17 +162990,11 @@ entities:
     - type: Transform
       pos: 8.366959,20.621464
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24772
     components:
     - type: Transform
       pos: -79.37678,29.678654
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24773
     components:
     - type: Transform
@@ -164007,9 +163014,6 @@ entities:
     - type: Transform
       pos: 27.45221,-52.080547
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: PlushieSharkBlue
   entities:
   - uid: 24440
@@ -164017,8 +163021,6 @@ entities:
     - type: Transform
       parent: 24439
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
   - uid: 24776
     components:
@@ -164051,6 +163053,13 @@ entities:
     - type: Transform
       pos: -39.52677,96.56322
       parent: 2
+- proto: PlushieSpawner50
+  entities:
+  - uid: 30843
+    components:
+    - type: Transform
+      pos: 12.5,26.5
+      parent: 2
 - proto: PlushieThrongler
   entities:
   - uid: 24781
@@ -164058,9 +163067,6 @@ entities:
     - type: Transform
       pos: -23.983637,4.967728
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: PlushieVox
   entities:
   - uid: 24782
@@ -164068,9 +163074,6 @@ entities:
     - type: Transform
       pos: -89.52199,-38.548233
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: PlushieXeno
   entities:
   - uid: 24783
@@ -164781,17 +163784,11 @@ entities:
     - type: Transform
       pos: -32.79072,-11.763052
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 24893
     components:
     - type: Transform
       pos: -32.79072,-11.325552
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: PottedPlant10
   entities:
   - uid: 24894
@@ -165296,57 +164293,6 @@ entities:
     - type: Transform
       pos: -74.35975,-50.946396
       parent: 2
-- proto: PowerCellIonSMG
-  entities:
-  - uid: 23500
-    components:
-    - type: Transform
-      parent: 19
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-- proto: PowerCellIRRevolver
-  entities:
-  - uid: 22347
-    components:
-    - type: Transform
-      pos: -82.33102,30.54499
-      parent: 2
-  - uid: 23277
-    components:
-    - type: Transform
-      pos: -82.695595,30.451176
-      parent: 2
-- proto: PowerCellIRSMG
-  entities:
-  - uid: 20
-    components:
-    - type: Transform
-      parent: 19
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 22
-    components:
-    - type: Transform
-      parent: 19
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 23498
-    components:
-    - type: Transform
-      parent: 19
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 23499
-    components:
-    - type: Transform
-      parent: 19
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
 - proto: PowerCellMedium
   entities:
   - uid: 24985
@@ -165361,9 +164307,6 @@ entities:
     - type: Transform
       pos: -31.455568,-56.3021
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: PowerCellRecharger
   entities:
   - uid: 1771
@@ -165535,9 +164478,6 @@ entities:
     - type: Transform
       pos: -61.572865,-60.54561
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: PoweredDimSmallLight
   entities:
   - uid: 25015
@@ -170007,32 +168947,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -57.5,49.5
       parent: 2
-- proto: PrefilledSyringe
-  entities:
-  - uid: 3
-    components:
-    - type: Transform
-      pos: -17.676973,21.605902
-      parent: 2
-    - type: SolutionContainerManager
-      solutions: null
-      containers:
-      - injector
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-    - type: ContainerContainer
-      containers:
-        solution@injector: !type:ContainerSlot
-          ent: 4
-  - uid: 25769
-    components:
-    - type: Transform
-      pos: -94.44326,11.169543
-      parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: Protolathe
   entities:
   - uid: 25770
@@ -170067,6 +168981,7 @@ entities:
     - type: Transform
       pos: -42.5,-41.5
       parent: 2
+    - type: StepTriggerActive
   - uid: 24237
     components:
     - type: Transform
@@ -170175,6 +169090,11 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-91.5
+      parent: 2
+  - uid: 5138
+    components:
+    - type: Transform
+      pos: -82.5,28.5
       parent: 2
   - uid: 9039
     components:
@@ -170956,8 +169876,6 @@ entities:
     - type: Transform
       parent: 23
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 33
@@ -170965,8 +169883,6 @@ entities:
     - type: Transform
       parent: 23
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 34
@@ -170974,8 +169890,6 @@ entities:
     - type: Transform
       parent: 23
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 35
@@ -170983,8 +169897,6 @@ entities:
     - type: Transform
       parent: 23
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
 - proto: RadiationCollectorFullTank
@@ -171086,9 +169998,6 @@ entities:
     - type: Transform
       pos: -10.967844,-39.290474
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 25947
     components:
     - type: Transform
@@ -171138,9 +170047,6 @@ entities:
     - type: Transform
       pos: -30.669836,-31.291609
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: Railing
   entities:
   - uid: 738
@@ -179009,9 +177915,6 @@ entities:
     - type: Transform
       pos: -12.485413,31.615393
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: RCDAmmo
   entities:
   - uid: 27361
@@ -179040,9 +177943,6 @@ entities:
       parent: 2
     - type: Openable
       opened: True
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 27365
     components:
     - type: Transform
@@ -179060,9 +177960,6 @@ entities:
       parent: 2
     - type: Openable
       opened: True
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 27368
     components:
     - type: Transform
@@ -179070,9 +177967,6 @@ entities:
       parent: 2
     - type: Openable
       opened: True
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 27369
     components:
     - type: Transform
@@ -179080,9 +177974,6 @@ entities:
       parent: 2
     - type: Openable
       opened: True
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ReagentContainerRice
   entities:
   - uid: 27370
@@ -179090,9 +177981,6 @@ entities:
     - type: Transform
       pos: -5.6186185,-4.5488963
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ReagentSlimeSpawner
   entities:
   - uid: 1417
@@ -184370,19 +183258,11 @@ entities:
     - type: Transform
       pos: -92.317085,-39.5385
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 28322
     components:
     - type: Transform
       pos: -18.309374,20.970549
       parent: 2
-    - type: RevolverAmmoProvider
-      currentSlot: 1
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 28323
     components:
     - type: Transform
@@ -184400,9 +183280,6 @@ entities:
     - type: Transform
       pos: -31.408543,-33.30049
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: RiceSeeds
   entities:
   - uid: 28326
@@ -184410,9 +183287,6 @@ entities:
     - type: Transform
       pos: -34.124058,-11.206805
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: RightArmBorg
   entities:
   - uid: 28327
@@ -184466,9 +183340,6 @@ entities:
     - type: Transform
       pos: -38.513123,38.58956
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 28336
     components:
     - type: Transform
@@ -184481,9 +183352,6 @@ entities:
     - type: Transform
       pos: -28.267319,17.584862
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 28338
     components:
     - type: Transform
@@ -184496,9 +183364,6 @@ entities:
     - type: Transform
       pos: -28.27774,17.886946
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 28340
     components:
     - type: Transform
@@ -184527,9 +183392,6 @@ entities:
     - type: Transform
       pos: 19.473467,62.529545
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: Scalpel
   entities:
   - uid: 28344
@@ -184538,9 +183400,6 @@ entities:
       rot: 6.283185307179586 rad
       pos: -20.514116,-20.42855
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ScalpelLaser
   entities:
   - uid: 28345
@@ -184548,9 +183407,6 @@ entities:
     - type: Transform
       pos: -41.508617,-38.314777
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ScalpelShiv
   entities:
   - uid: 16302
@@ -184558,8 +183414,6 @@ entities:
     - type: Transform
       parent: 16301
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
 - proto: ScienceTechFab
@@ -184609,17 +183463,11 @@ entities:
     - type: Transform
       pos: 20.536919,67.56388
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 28352
     components:
     - type: Transform
       pos: -80.36331,45.561035
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 28353
     components:
     - type: Transform
@@ -184633,9 +183481,6 @@ entities:
     - type: Transform
       pos: -6.5803747,32.528988
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ScrapCanister2
   entities:
   - uid: 28355
@@ -184643,9 +183488,6 @@ entities:
     - type: Transform
       pos: -6.739884,31.90339
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ScrapCloset
   entities:
   - uid: 28356
@@ -184659,9 +183501,6 @@ entities:
     - type: Transform
       pos: -80.51145,44.515717
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 28358
     components:
     - type: Transform
@@ -184688,9 +183527,6 @@ entities:
     - type: Transform
       pos: -77.465935,40.58911
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ScrapGlass
   entities:
   - uid: 28362
@@ -184705,17 +183541,11 @@ entities:
     - type: Transform
       pos: -6.247677,31.87212
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 28364
     components:
     - type: Transform
       pos: -75.61173,43.63187
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 28365
     components:
     - type: Transform
@@ -184729,9 +183559,6 @@ entities:
     - type: Transform
       pos: -80.50451,40.582386
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ScrapMedkit
   entities:
   - uid: 28367
@@ -184739,9 +183566,6 @@ entities:
     - type: Transform
       pos: -78.36438,47.426346
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 28368
     components:
     - type: Transform
@@ -184754,25 +183578,16 @@ entities:
     - type: Transform
       pos: -5.809541,32.257965
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 28370
     components:
     - type: Transform
       pos: -60.52691,44.53646
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 28371
     components:
     - type: Transform
       pos: -79.065285,40.44481
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ScrapSteel
   entities:
   - uid: 28372
@@ -184787,9 +183602,6 @@ entities:
     - type: Transform
       pos: -5.5080934,32.268227
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: Screen
   entities:
   - uid: 28374
@@ -184886,8 +183698,6 @@ entities:
     - type: Transform
       parent: 5142
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 28389
@@ -184895,9 +183705,6 @@ entities:
     - type: Transform
       pos: -67.50428,-50.505642
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 28390
     components:
     - type: Transform
@@ -185028,17 +183835,11 @@ entities:
     - type: Transform
       pos: -57.508373,-52.44489
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 28408
     components:
     - type: Transform
       pos: -2.5159895,-32.40014
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 28409
     components:
     - type: Transform
@@ -185059,17 +183860,11 @@ entities:
     - type: Transform
       pos: -34.569897,-24.314423
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 28413
     components:
     - type: Transform
       pos: -64.60747,-51.423088
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 28414
     components:
     - type: Transform
@@ -185118,25 +183913,16 @@ entities:
     - type: Transform
       pos: -57.57573,-51.31885
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 28423
     components:
     - type: Transform
       pos: -57.5844,-51.308426
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 28424
     components:
     - type: Transform
       pos: -2.9951563,-32.410564
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 28425
     components:
     - type: Transform
@@ -185161,9 +183947,6 @@ entities:
     - type: Transform
       pos: -60.49072,-23.356264
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 28429
     components:
     - type: Transform
@@ -185174,9 +183957,6 @@ entities:
     - type: Transform
       pos: -3.6826565,-32.32717
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 28431
     components:
     - type: Transform
@@ -185217,9 +183997,6 @@ entities:
     - type: Transform
       pos: -29.543098,27.622702
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 28439
     components:
     - type: Transform
@@ -185230,25 +184007,16 @@ entities:
     - type: Transform
       pos: -52.556396,36.62027
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 28441
     components:
     - type: Transform
       pos: -52.57723,35.766106
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 28442
     components:
     - type: Transform
       pos: -57.367393,-51.308426
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 28443
     components:
     - type: Transform
@@ -185263,9 +184031,6 @@ entities:
       parent: 2
     - type: Stack
       count: 4
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 28445
     components:
     - type: Transform
@@ -185283,25 +184048,16 @@ entities:
     - type: Transform
       pos: 4.745122,66.60148
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 28448
     components:
     - type: Transform
       pos: -95.30454,12.501907
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 28449
     components:
     - type: Transform
       pos: -73.537994,-34.37106
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: SheetUranium
   entities:
   - uid: 28450
@@ -185332,9 +184088,6 @@ entities:
     - type: Transform
       pos: 19.473467,62.529545
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ShotGunCabinetFilled
   entities:
   - uid: 28454
@@ -185355,8 +184108,6 @@ entities:
     - type: Transform
       parent: 5142
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 28456
@@ -187840,9 +186591,6 @@ entities:
     - type: Transform
       pos: -63.3452,86.61176
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: SingularityGenerator
   entities:
   - uid: 28776
@@ -188011,9 +186759,6 @@ entities:
     - type: Transform
       pos: -40.480427,7.729916
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 28803
     components:
     - type: Transform
@@ -188025,6 +186770,61 @@ entities:
     components:
     - type: Transform
       pos: -13.5,-58.5
+      parent: 2
+- proto: SmartFridgeMedical
+  entities:
+  - uid: 19177
+    components:
+    - type: Transform
+      pos: -64.5,-38.5
+      parent: 2
+    - type: Construction
+      containers:
+      - machine_parts
+      - machine_board
+      - smart_fridge_inventory
+      - entity_storage
+    - type: EntityStorage
+      air:
+        volume: 200
+        temperature: 293.14673
+        moles:
+          Oxygen: 1.8856695
+          Nitrogen: 7.0937095
+      closeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/closetclose.ogg
+      openSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/closetopen.ogg
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 19179
+          - 19178
+        machine_board: !type:Container
+          showEnts: False
+          occludes: True
+          ents: []
+        machine_parts: !type:Container
+          showEnts: False
+          occludes: True
+          ents: []
+  - uid: 28804
+    components:
+    - type: Transform
+      pos: -54.5,-26.5
+      parent: 2
+  - uid: 28805
+    components:
+    - type: Transform
+      pos: -13.5,-5.5
+      parent: 2
+  - uid: 28806
+    components:
+    - type: Transform
+      pos: -55.5,-12.5
       parent: 2
 - proto: SMESAdvanced
   entities:
@@ -188112,9 +186912,6 @@ entities:
     - type: Transform
       pos: -0.1349062,83.294945
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: SmokingPipeFilledCannabisRainbow
   entities:
   - uid: 28824
@@ -188134,9 +186931,6 @@ entities:
     - type: Transform
       pos: -50.414936,-31.496796
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 28827
     components:
     - type: Transform
@@ -188149,9 +186943,6 @@ entities:
     - type: Transform
       pos: 19.473467,62.529545
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: SoakedCigarette
   entities:
   - uid: 28829
@@ -188171,9 +186962,6 @@ entities:
     - type: Transform
       pos: -106.765236,26.818155
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: SoapHomemadeBanana
   entities:
   - uid: 28832
@@ -191978,26 +190766,17 @@ entities:
     - type: Transform
       pos: -40.68292,8.18499
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 29492
     components:
     - type: Transform
       pos: -40.4225,8.112022
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 29493
     components:
     - type: Transform
       pos: -40.474583,8.3205
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-- proto: SpacemenFigureSpawner
+- proto: SpacemenFigurineSpawner90
   entities:
   - uid: 29494
     components:
@@ -192018,9 +190797,6 @@ entities:
     - type: Transform
       pos: -16.465105,-26.719147
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: SpaceVillainArcadeFilled
   entities:
   - uid: 29497
@@ -192070,6 +190846,8 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 12.5,58.5
       parent: 2
+    - type: StepTriggerCleanup
+      stepTrigger: 30855
   - uid: 29505
     components:
     - type: Transform
@@ -193205,9 +191983,6 @@ entities:
     - type: Transform
       pos: -30.293959,-33.42549
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: SpoonPlastic
   entities:
   - uid: 29663
@@ -193236,9 +192011,6 @@ entities:
       rot: 6.283185307179586 rad
       pos: -107.28559,26.48016
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: SprayBottleWater
   entities:
   - uid: 5257
@@ -193246,8 +192018,6 @@ entities:
     - type: Transform
       parent: 5252
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
   - uid: 29667
     components:
@@ -193919,9 +192689,6 @@ entities:
     - type: Transform
       pos: -57.270035,75.62782
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: Stunbaton
   entities:
   - uid: 29761
@@ -194030,9 +192797,6 @@ entities:
     - type: Transform
       pos: -108.72062,-17.365732
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: SuitStorageBase
   entities:
   - uid: 16322
@@ -196044,17 +194808,11 @@ entities:
     - type: Transform
       pos: -91.53689,-42.544266
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 30061
     components:
     - type: Transform
       pos: 15.355933,-37.318428
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: SyndicateBusinessCard
   entities:
   - uid: 30062
@@ -196069,8 +194827,6 @@ entities:
     - type: Transform
       parent: 16381
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
   - uid: 30063
     components:
@@ -196096,11 +194852,30 @@ entities:
     - type: Transform
       pos: 3.7645264,67.2142
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: Syringe
   entities:
+  - uid: 3
+    components:
+    - type: Transform
+      pos: -17.676973,21.605902
+      parent: 2
+    - type: Tag
+      tags:
+      - Syringe
+      - SyringeGunAmmo
+    - type: SolutionContainerManager
+      solutions: null
+      containers:
+      - injector
+    - type: ContainerContainer
+      containers:
+        solution@injector: !type:ContainerSlot
+          ent: 4
+  - uid: 25769
+    components:
+    - type: Transform
+      pos: -94.44326,11.169543
+      parent: 2
   - uid: 30068
     components:
     - type: Transform
@@ -196111,9 +194886,6 @@ entities:
     - type: Transform
       pos: -94.77659,10.579221
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: SyringeCryostasis
   entities:
   - uid: 29024
@@ -196126,17 +194898,11 @@ entities:
     - type: Transform
       pos: -62.418392,-32.738274
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 30071
     components:
     - type: Transform
       pos: -62.611885,-32.424995
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 30072
     components:
     - type: Transform
@@ -196149,9 +194915,6 @@ entities:
     - type: Transform
       pos: -43.48007,-25.531715
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: Table
   entities:
   - uid: 1759
@@ -197913,6 +196676,8 @@ entities:
     - type: Transform
       pos: 14.5,65.5
       parent: 2
+    - type: StepTriggerCleanup
+      stepTrigger: 34994
 - proto: TableFancyGreen
   entities:
   - uid: 30397
@@ -198319,20 +197084,10 @@ entities:
     - type: Transform
       pos: -79.5,34.5
       parent: 2
-  - uid: 30466
-    components:
-    - type: Transform
-      pos: -79.5,28.5
-      parent: 2
   - uid: 30467
     components:
     - type: Transform
       pos: -77.5,34.5
-      parent: 2
-  - uid: 30468
-    components:
-    - type: Transform
-      pos: -81.5,28.5
       parent: 2
   - uid: 30469
     components:
@@ -198474,25 +197229,10 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -81.5,11.5
       parent: 2
-  - uid: 30495
-    components:
-    - type: Transform
-      pos: -80.5,28.5
-      parent: 2
-  - uid: 30496
-    components:
-    - type: Transform
-      pos: -82.5,31.5
-      parent: 2
   - uid: 30497
     components:
     - type: Transform
       pos: -78.5,34.5
-      parent: 2
-  - uid: 30498
-    components:
-    - type: Transform
-      pos: -82.5,30.5
       parent: 2
   - uid: 30499
     components:
@@ -198615,16 +197355,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,-37.5
-      parent: 2
-  - uid: 30524
-    components:
-    - type: Transform
-      pos: -82.5,28.5
-      parent: 2
-  - uid: 30525
-    components:
-    - type: Transform
-      pos: -82.5,29.5
       parent: 2
   - uid: 30526
     components:
@@ -199762,9 +198492,6 @@ entities:
     - type: Transform
       pos: -61.94472,-52.371765
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: TegCenter
   entities:
   - uid: 30736
@@ -199858,8 +198585,6 @@ entities:
     - type: Transform
       parent: 16787
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 16789
@@ -199867,8 +198592,6 @@ entities:
     - type: Transform
       parent: 16787
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 16790
@@ -199876,8 +198599,6 @@ entities:
     - type: Transform
       parent: 16787
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 16791
@@ -199885,8 +198606,6 @@ entities:
     - type: Transform
       parent: 16787
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 16792
@@ -199894,8 +198613,6 @@ entities:
     - type: Transform
       parent: 16787
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 16793
@@ -199903,8 +198620,6 @@ entities:
     - type: Transform
       parent: 16787
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 16794
@@ -199912,8 +198627,6 @@ entities:
     - type: Transform
       parent: 16787
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 16795
@@ -199921,8 +198634,6 @@ entities:
     - type: Transform
       parent: 16787
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
 - proto: TeslaGenerator
@@ -199965,8 +198676,6 @@ entities:
     - type: Transform
       parent: 16796
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 16798
@@ -199974,8 +198683,6 @@ entities:
     - type: Transform
       parent: 16796
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 16799
@@ -199983,8 +198690,6 @@ entities:
     - type: Transform
       parent: 16796
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 16800
@@ -199992,8 +198697,6 @@ entities:
     - type: Transform
       parent: 16796
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 16801
@@ -200001,8 +198704,6 @@ entities:
     - type: Transform
       parent: 16796
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 16802
@@ -200010,8 +198711,6 @@ entities:
     - type: Transform
       parent: 16796
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 16803
@@ -200019,8 +198718,6 @@ entities:
     - type: Transform
       parent: 16796
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 16804
@@ -200028,8 +198725,6 @@ entities:
     - type: Transform
       parent: 16796
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
 - proto: TeslaToy
@@ -200125,7 +198820,7 @@ entities:
     - type: Transform
       pos: -107.5,30.5
       parent: 2
-- proto: ToiletEmpty
+- proto: ToiletFilled
   entities:
   - uid: 30770
     components:
@@ -200185,17 +198880,11 @@ entities:
     - type: Transform
       pos: 18.378452,65.76307
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 30778
     components:
     - type: Transform
       pos: 14.522559,66.103035
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ToolboxElectrical
   entities:
   - uid: 30779
@@ -200203,9 +198892,6 @@ entities:
     - type: Transform
       pos: 20.459536,87.47361
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ToolboxElectricalFilled
   entities:
   - uid: 15110
@@ -200313,9 +198999,6 @@ entities:
     - type: Transform
       pos: -96.54678,2.7425065
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ToolboxGoldFilled
   entities:
   - uid: 30800
@@ -200323,9 +199006,6 @@ entities:
     - type: Transform
       pos: -42.572926,11.674113
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ToolboxMechanical
   entities:
   - uid: 30801
@@ -200333,9 +199013,6 @@ entities:
     - type: Transform
       pos: 20.462236,86.629654
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ToolboxMechanicalFilled
   entities:
   - uid: 30802
@@ -200398,9 +199075,6 @@ entities:
     - type: Transform
       pos: -96.54678,2.6278436
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 30814
     components:
     - type: Transform
@@ -200413,8 +199087,6 @@ entities:
     - type: Transform
       parent: 16291
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 30815
@@ -200436,9 +199108,6 @@ entities:
     - type: Transform
       pos: -107.5121,26.546003
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: TowelColorSyndicate
   entities:
   - uid: 30818
@@ -200446,9 +199115,6 @@ entities:
     - type: Transform
       pos: 4.4900165,65.26693
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: TowelColorTeal
   entities:
   - uid: 30819
@@ -200463,9 +199129,6 @@ entities:
     - type: Transform
       pos: 20.417915,-38.411743
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ToyFigurineBartender
   entities:
   - uid: 30821
@@ -200515,9 +199178,6 @@ entities:
     - type: Transform
       pos: 19.755165,61.6467
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ToyFigurineNukieCommander
   entities:
   - uid: 30828
@@ -200530,9 +199190,6 @@ entities:
     - type: Transform
       pos: -73.47281,8.397427
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ToyFigurineNukieElite
   entities:
   - uid: 30830
@@ -200554,9 +199211,6 @@ entities:
     - type: Transform
       pos: 20.598915,61.61543
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ToyFigurineSpaceDragon
   entities:
   - uid: 30833
@@ -200595,9 +199249,6 @@ entities:
     - type: Transform
       pos: -92.67125,-39.444687
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ToyHammer
   entities:
   - uid: 30840
@@ -200605,9 +199256,6 @@ entities:
     - type: Transform
       pos: -76.59972,56.49962
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ToyHonk
   entities:
   - uid: 30841
@@ -200622,13 +199270,6 @@ entities:
     - type: Transform
       pos: -16.530664,-9.513399
       parent: 2
-- proto: ToySpawner
-  entities:
-  - uid: 30843
-    components:
-    - type: Transform
-      pos: 12.5,26.5
-      parent: 2
 - proto: ToySword
   entities:
   - uid: 30844
@@ -200636,9 +199277,6 @@ entities:
     - type: Transform
       pos: -32.280212,-21.065405
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: TrainingBomb
   entities:
   - uid: 30845
@@ -200653,33 +199291,22 @@ entities:
     - type: Transform
       parent: 5252
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
   - uid: 30846
     components:
     - type: Transform
       pos: -50.715096,-41.42972
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 30847
     components:
     - type: Transform
       pos: -50.496346,-41.45057
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 30848
     components:
     - type: Transform
       pos: -50.298958,-41.388027
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 30849
     components:
     - type: Transform
@@ -200719,17 +199346,20 @@ entities:
     - type: Transform
       pos: 12.958439,58.26873
       parent: 2
+    - type: StepTriggerActive
   - uid: 30856
     components:
     - type: Transform
       pos: -54.386715,68.5138
       parent: 2
+    - type: StepTriggerActive
   - uid: 30857
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -80.86474,15.280195
       parent: 2
+    - type: StepTriggerActive
 - proto: TrashBananiumPeel
   entities:
   - uid: 30858
@@ -201285,13 +199915,6 @@ entities:
       - Arsenal
       - Experimental
       - CivilianServices
-- proto: UniqueLockerBlueshieldOfficerFilled
-  entities:
-  - uid: 30875
-    components:
-    - type: Transform
-      pos: -27.5,-22.5
-      parent: 2
 - proto: UniqueLockerNanorepFilled
   entities:
   - uid: 30876
@@ -201328,9 +199951,6 @@ entities:
     - type: Transform
       pos: -75.2064,-32.580383
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: VariantCubeBox
   entities:
   - uid: 30881
@@ -201338,9 +199958,6 @@ entities:
     - type: Transform
       pos: -69.39189,-37.381336
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: VehicleKeyJanicart
   entities:
   - uid: 30882
@@ -201355,25 +199972,16 @@ entities:
     - type: Transform
       pos: -65.50227,33.15645
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 30884
     components:
     - type: Transform
       pos: -65.590416,33.056213
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 30885
     components:
     - type: Transform
       pos: -65.58,33.15003
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: VendingBarDrobe
   entities:
   - uid: 30886
@@ -201722,8 +200330,6 @@ entities:
     - type: Transform
       parent: 16842
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
 - proto: VendingMachineRestockDonut
@@ -201733,8 +200339,6 @@ entities:
     - type: Transform
       parent: 16842
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
 - proto: VendingMachineRestockRobustSoftdrinks
@@ -201744,8 +200348,6 @@ entities:
     - type: Transform
       parent: 16842
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
 - proto: VendingMachineRestockSmokes
@@ -201755,8 +200357,6 @@ entities:
     - type: Transform
       parent: 16842
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
 - proto: VendingMachineRoboDrobe
@@ -202003,9 +200603,6 @@ entities:
     - type: Transform
       pos: -88.59648,7.3648953
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: WallmountSubstationElectronics
   entities:
   - uid: 30977
@@ -202013,17 +200610,11 @@ entities:
     - type: Transform
       pos: 19.55082,84.22183
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 30978
     components:
     - type: Transform
       pos: 19.51957,84.47201
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: WallmountTelescreen
   entities:
   - uid: 9002
@@ -223731,8 +222322,6 @@ entities:
       pos: -63.5,0.5
       parent: 2
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       bodyType: Static
   - uid: 34892
     components:
@@ -223756,8 +222345,6 @@ entities:
       pos: -73.5,-6.5
       parent: 2
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       bodyType: Static
   - uid: 34896
     components:
@@ -223766,8 +222353,6 @@ entities:
       pos: -14.5,-47.5
       parent: 2
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       bodyType: Static
   - uid: 34897
     components:
@@ -223818,11 +222403,6 @@ entities:
     - type: Transform
       pos: -26.389925,-2.414999
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-    - type: Pullable
-      prevFixedRotation: True
   - uid: 34905
     components:
     - type: Transform
@@ -223885,11 +222465,6 @@ entities:
     - type: Transform
       pos: -25.396624,-2.4150176
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-    - type: Pullable
-      prevFixedRotation: True
 - proto: WaterVaporCanister
   entities:
   - uid: 34917
@@ -224144,53 +222719,17 @@ entities:
     - type: Transform
       pos: -71.24104,38.501465
       parent: 2
-- proto: WeaponLaserCellRevolver
+- proto: WeaponLaserSidearm
   entities:
-  - uid: 16747
+  - uid: 22
     components:
     - type: Transform
-      pos: -82.351845,30.586685
+      pos: -82.591034,28.773918
       parent: 2
-  - uid: 16748
-    components:
-    - type: Transform
-      pos: -82.51852,30.763893
-      parent: 2
-    - type: Gun
-      burstCooldownModified: 0.25
-- proto: WeaponLaserCellSMG
-  entities:
   - uid: 25
     components:
     - type: Transform
-      parent: 19
-    - type: Gun
-      burstCooldownModified: 0.25
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 27
-    components:
-    - type: Transform
-      parent: 19
-    - type: Gun
-      burstCooldownModified: 0.25
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-- proto: WeaponLauncherNonLethal
-  entities:
-  - uid: 16751
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -82.63926,29.49778
-      parent: 2
-  - uid: 16762
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -82.36842,29.487356
+      pos: -82.40127,28.334127
       parent: 2
 - proto: WeaponMailLake
   entities:
@@ -224199,17 +222738,11 @@ entities:
     - type: Transform
       pos: -23.558775,-44.371017
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 34940
     components:
     - type: Transform
       pos: -23.517107,-44.631615
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: WeaponPistolFlintlock
   entities:
   - uid: 34941
@@ -224217,50 +222750,11 @@ entities:
     - type: Transform
       pos: 20.46067,-56.226517
       parent: 2
-    - type: Gun
-      lastFire: 9727.9736066
-    - type: UseDelay
-      delays:
-        default:
-          endTime: 9734.7236066
-          startTime: 9726.7236066
-          length: 8
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-    - type: Forensics
-      residues: []
-      dNAs: []
-      fibers:
-      - regal blue durathread fibers
-      fingerprints: []
   - uid: 34942
     components:
     - type: Transform
       pos: 15.503528,-56.43681
       parent: 2
-- proto: WeaponPistolMk58
-  entities:
-  - uid: 34944
-    components:
-    - type: Transform
-      pos: -82.570595,31.50399
-      parent: 2
-    - type: Gun
-      burstCooldownModified: 0.25
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-  - uid: 34945
-    components:
-    - type: Transform
-      pos: -82.351845,31.493567
-      parent: 2
-    - type: Gun
-      burstCooldownModified: 0.25
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: WeaponRifleFoam
   entities:
   - uid: 34948
@@ -224273,21 +222767,6 @@ entities:
     - type: Transform
       pos: -46.405766,8.548396
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-- proto: WeaponShotgunEnforcer
-  entities:
-  - uid: 16749
-    components:
-    - type: Transform
-      pos: -81.29288,28.704517
-      parent: 2
-  - uid: 16750
-    components:
-    - type: Transform
-      pos: -81.282455,28.412647
-      parent: 2
 - proto: WeaponShotgunHandmade
   entities:
   - uid: 34952
@@ -224295,25 +222774,6 @@ entities:
     - type: Transform
       pos: -97.5816,32.270622
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-- proto: WeaponShotgunKammerer
-  entities:
-  - uid: 23503
-    components:
-    - type: Transform
-      pos: -80.44636,28.457695
-      parent: 2
-    - type: Gun
-      burstCooldownModified: 0.25
-  - uid: 23505
-    components:
-    - type: Transform
-      pos: -80.43073,28.770412
-      parent: 2
-    - type: Gun
-      burstCooldownModified: 0.25
 - proto: WeaponSniperMosin
   entities:
   - uid: 34953
@@ -224347,8 +222807,6 @@ entities:
     - type: Transform
       parent: 16429
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
 - proto: WeedSpray
   entities:
@@ -224395,17 +222853,11 @@ entities:
     - type: Transform
       pos: -51.65863,30.69801
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 34969
     components:
     - type: Transform
       pos: -8.569945,19.50632
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: WelderMini
   entities:
   - uid: 34970
@@ -224413,17 +222865,11 @@ entities:
     - type: Transform
       pos: 14.861215,89.76386
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 34971
     components:
     - type: Transform
       pos: 15.070267,89.565094
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: WeldingFuelTankFull
   entities:
   - uid: 34972
@@ -224495,8 +222941,6 @@ entities:
       pos: -23.5,44.5
       parent: 2
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       bodyType: Static
 - proto: WetFloorSign
   entities:
@@ -224505,32 +222949,24 @@ entities:
     - type: Transform
       parent: 5252
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
   - uid: 5260
     components:
     - type: Transform
       parent: 5252
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
   - uid: 5261
     components:
     - type: Transform
       parent: 5252
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
   - uid: 5262
     components:
     - type: Transform
       parent: 5252
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
   - uid: 34985
     components:
@@ -224590,6 +223026,7 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 14.211157,65.38821
       parent: 2
+    - type: StepTriggerActive
 - proto: Windoor
   entities:
   - uid: 34995
@@ -224759,31 +223196,10 @@ entities:
       autoClose: False
 - proto: WindoorSecureArmoryLocked
   entities:
-  - uid: 35021
-    components:
-    - type: Transform
-      pos: -79.5,29.5
-      parent: 2
   - uid: 35022
     components:
     - type: Transform
       pos: -79.5,34.5
-      parent: 2
-  - uid: 35023
-    components:
-    - type: Transform
-      pos: -81.5,29.5
-      parent: 2
-  - uid: 35024
-    components:
-    - type: Transform
-      pos: -80.5,29.5
-      parent: 2
-  - uid: 35025
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -81.5,31.5
       parent: 2
   - uid: 35026
     components:
@@ -224806,12 +223222,6 @@ entities:
     components:
     - type: Transform
       pos: -78.5,34.5
-      parent: 2
-  - uid: 35030
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -81.5,30.5
       parent: 2
 - proto: WindoorSecureAtmosphericsLocked
   entities:
@@ -225054,12 +223464,6 @@ entities:
       parent: 2
     - type: Airlock
       autoClose: False
-  - uid: 35068
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -81.5,29.5
-      parent: 2
   - uid: 35069
     components:
     - type: Transform
@@ -225517,11 +223921,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -77.5,34.5
       parent: 2
-  - uid: 35148
-    components:
-    - type: Transform
-      pos: -82.5,30.5
-      parent: 2
   - uid: 35149
     components:
     - type: Transform
@@ -225539,12 +223938,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -72.5,9.5
-      parent: 2
-  - uid: 35153
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -82.5,31.5
       parent: 2
   - uid: 35154
     components:
@@ -225593,29 +223986,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -72.5,8.5
-      parent: 2
-  - uid: 35162
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -81.5,28.5
-      parent: 2
-  - uid: 35163
-    components:
-    - type: Transform
-      pos: -82.5,31.5
-      parent: 2
-  - uid: 35164
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -80.5,28.5
-      parent: 2
-  - uid: 35165
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -79.5,28.5
       parent: 2
   - uid: 35166
     components:
@@ -226385,8 +224755,6 @@ entities:
     - type: Transform
       parent: 5142
     - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
   - uid: 9047
@@ -226399,17 +224767,11 @@ entities:
     - type: Transform
       pos: -74.50835,-26.14727
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 35297
     components:
     - type: Transform
       pos: 11.0009575,88.79943
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 35298
     components:
     - type: Transform
@@ -226458,6 +224820,8 @@ entities:
     - type: Transform
       pos: -54.5,68.5
       parent: 2
+    - type: StepTriggerCleanup
+      stepTrigger: 30856
   - uid: 35306
     components:
     - type: Transform
@@ -226603,9 +224967,6 @@ entities:
     - type: Transform
       pos: 14.703672,82.08658
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 35328
     components:
     - type: Transform
@@ -226627,9 +224988,6 @@ entities:
     - type: Transform
       pos: -48.321835,62.51481
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 35333
     components:
     - type: Transform
@@ -226652,9 +225010,6 @@ entities:
     - type: Transform
       pos: 10.26778,91.38153
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 35337
     components:
     - type: Transform
@@ -226667,9 +225022,6 @@ entities:
     - type: Transform
       pos: -87.55574,20.568762
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: Wronch
   entities:
   - uid: 35339
@@ -226751,9 +225103,6 @@ entities:
     - type: Transform
       pos: -75.0052,-26.556873
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: ZiptiesBroken
   entities:
   - uid: 35342

--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -21,7 +21,7 @@
   #- Barratry
   #- Kettle
   #- Submarine
-  #- Leonid
+  - Leonid
   #- Delta
   #- Chloris
   #- Cog

--- a/Resources/Prototypes/_Goobstation/Maps/leonid.yml
+++ b/Resources/Prototypes/_Goobstation/Maps/leonid.yml
@@ -41,7 +41,7 @@
 - type: gameMap
   id: Leonid
   mapName: 'Leonid Station'
-  mapPath: /Maps/_Goobstation/leonid.yml
+  mapPath: /Maps/_Trauma/leonid.yml # Trauma
   minPlayers: 50
   stations:
     Leonid:


### PR DESCRIPTION
## About the PR
- added areas around kitchen
- added usual gun safes plus enforcer because it had it

god i love random shit with damping removed FOR NO REASON

## Media
<img width="1132" height="654" alt="15:58:59" src="https://github.com/user-attachments/assets/4c6ac9ca-cf3e-46e2-a853-76f7dfe2ece4" />

<img width="570" height="593" alt="15:59:17" src="https://github.com/user-attachments/assets/a0608f48-769e-4585-a0bd-24825ca42589" />


**Changelog**
:cl:
- tweak: Re-enabled Leonid station, redid its armory.