### PR TITLE
rework crawling held item speed

### DIFF
--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.EventListeners.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.EventListeners.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.Hands.Components;
+using Content.Shared.Hands.Components;
 using Content.Shared.Stunnable;
 
 namespace Content.Shared.Hands.EntitySystems;
@@ -11,7 +11,7 @@ public abstract partial class SharedHandsSystem
     private void InitializeEventListeners()
     {
         SubscribeLocalEvent<HandsComponent, GetStandUpTimeEvent>(OnStandupArgs);
-        SubscribeLocalEvent<HandsComponent, KnockedDownRefreshEvent>(OnKnockedDownRefresh);
+        //SubscribeLocalEvent<HandsComponent, KnockedDownRefreshEvent>(OnKnockedDownRefresh); // Trauma - using custom crawl speed logic
     }
 
     /// <summary>

--- a/Content.Shared/Item/ItemSizePrototype.Trauma.cs
+++ b/Content.Shared/Item/ItemSizePrototype.Trauma.cs
@@ -1,0 +1,14 @@
+namespace Content.Shared.Item;
+
+/// <summary>
+/// Trauma - add CrawlSpeedModifier for crawling logic
+/// </summary>
+public sealed partial class ItemSizePrototype
+{
+    /// <summary>
+    /// Modifier applied to crawling speed for entities holding an item with this size.
+    /// Multiplicative, so holding 2 items with 50% speed makes you crawl at 25% speed.
+    /// </summary>
+    [DataField]
+    public float CrawlSpeedModifier = 1f;
+}

--- a/Content.Trauma.Shared/Standing/CrawlSpeedSystem.cs
+++ b/Content.Trauma.Shared/Standing/CrawlSpeedSystem.cs
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+using Content.Shared.Hands.Components;
+using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Item;
+using Content.Shared.Stunnable;
+using Robust.Shared.Prototypes;
+
+namespace Content.Trauma.Shared.Standing;
+
+/// <summary>
+/// Makes crawling speed depend on held items sizes.
+/// </summary>
+public sealed class CrawlSpeedSystem : EntitySystem
+{
+    [Dependency] private readonly IPrototypeManager _proto = default!;
+    [Dependency] private readonly SharedHandsSystem _hands = default!;
+
+    /// <summary>
+    /// How many hands you need for 100% base crawling speed.
+    /// More hands (harmpack) will speed you up, losing hands will slow you down.
+    /// </summary>
+    public const int ExpectedHandCount = 2;
+
+    /// <summary>
+    /// Minimum crawling speed if you lost both of your hands.
+    /// </summary>
+    public const float MinCrawlSpeed = 0.1f;
+
+    /// <summary>
+    /// Cached crawl speed modifiers for each item size.
+    /// </summary>
+    public readonly Dictionary<ProtoId<ItemSizePrototype>, float> SpeedModifiers = new();
+
+    private EntityQuery<ItemComponent> _itemQuery;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        _itemQuery = GetEntityQuery<ItemComponent>();
+
+        SubscribeLocalEvent<HandsComponent, KnockedDownRefreshEvent>(OnKnockedDownRefresh);
+
+        SubscribeLocalEvent<PrototypesReloadedEventArgs>(OnPrototypesReloaded);
+        LoadPrototypes();
+    }
+
+    private void OnKnockedDownRefresh(Entity<HandsComponent> ent, ref KnockedDownRefreshEvent args)
+    {
+        var totalHands = _hands.GetHandCount(ent.AsNullable());
+        if (totalHands == 0)
+        {
+            args.SpeedModifier *= MinCrawlSpeed; // torsolo can still wiggle around, very slowly
+            return; // can't hold anything so don't bother checking
+        }
+
+        // first scale by number of hands.
+        args.SpeedModifier *= (float) totalHands / ExpectedHandCount;
+
+        // then scale by held item sizes
+        foreach (var held in _hands.EnumerateHeld(ent.AsNullable()))
+        {
+            args.SpeedModifier *= GetSpeedModifier(held);
+        }
+    }
+
+    private void OnPrototypesReloaded(PrototypesReloadedEventArgs args)
+    {
+        if (args.WasModified<ItemSizePrototype>())
+            LoadPrototypes();
+    }
+
+    public float GetSpeedModifier(EntityUid uid)
+    {
+        if (!_itemQuery.TryComp(uid, out var item))
+            return 0f; // you are carrying someone while crawling??? can't move chuddy
+
+        return SpeedModifiers[item.Size];
+    }
+
+    private void LoadPrototypes()
+    {
+        SpeedModifiers.Clear();
+        foreach (var proto in _proto.EnumeratePrototypes<ItemSizePrototype>())
+        {
+            SpeedModifiers[proto.ID] = proto.CrawlSpeedModifier;
+        }
+    }
+}

--- a/Resources/Prototypes/item_size.yml
+++ b/Resources/Prototypes/item_size.yml
@@ -15,6 +15,7 @@
   id: Small
   weight: 2
   name: item-component-size-Small
+  crawlSpeedModifier: 0.85 # Trauma
   defaultShape:
   - 0,0,0,1
 
@@ -23,6 +24,7 @@
   id: Normal
   weight: 4
   name: item-component-size-Normal
+  crawlSpeedModifier: 0.7 # Trauma
   defaultShape:
   - 0,0,1,1
 
@@ -31,6 +33,7 @@
   id: Large
   weight: 8
   name: item-component-size-Large
+  crawlSpeedModifier: 0.6 # Trauma
   defaultShape:
   - 0,0,3,1
 
@@ -39,6 +42,7 @@
   id: Huge
   weight: 16
   name: item-component-size-Huge
+  crawlSpeedModifier: 0.4 # Trauma
   defaultShape:
   - 0,0,3,3
 
@@ -47,5 +51,6 @@
   id: Ginormous
   weight: 32
   name: item-component-size-Ginormous
+  crawlSpeedModifier: 0.2 # Trauma
   defaultShape:
   - 0,0,5,5


### PR DESCRIPTION
## About the PR
- losing or gaining hands has a flat modifier on your speed, 1 hand is 50% speed and 4 is 200%
- losing both hands makes you crawl at 10% speed instead of making you fully immobile, kenshi parity
- holding tiny items doesnt matter at all
- holding small-huge items multiplies your crawl speed, so 2 60% speed items gives you 36% modifier for held items

## Why / Balance
trying to crawl holding a powersink should be a struggle (like 1% speed)
trying to crawl holding 2 cigarettes should not

## Technical details
real life parity you can crawl holding a pen easily

## Media

https://github.com/user-attachments/assets/7992fa2d-34ef-4c49-8aa5-d7c422e8acf0



**Changelog**
:cl:
- tweak: Harmpack will double crawl speed, losing all your hands still lets you crawl at 10% speed.
- tweak: Crawling with items in your hands now scales based off item size instead of preventing you from moving entirely.