### PR TITLE
make dept economy actually real

### DIFF
--- a/Content.Server/Cargo/Systems/CargoSystem.Trauma.cs
+++ b/Content.Server/Cargo/Systems/CargoSystem.Trauma.cs
@@ -1,0 +1,43 @@
+using Content.Server.AlertLevel;
+using Content.Shared.Cargo;
+using Content.Shared.Cargo.Components;
+using Content.Shared.Cargo.Prototypes;
+using Content.Shared.Emag.Systems;
+
+namespace Content.Server.Cargo.Systems;
+
+/// <summary>
+/// Trauma - methods for cargo order restrictions
+/// </summary>
+public sealed partial class CargoSystem
+{
+    /// <summary>
+    /// Check that the user has the account's approve access.
+    /// Does nothing when emagged with an access breaker.
+    /// </summary>
+    public bool CheckAccessPopup(Entity<CargoOrderConsoleComponent> ent, EntityUid user, CargoAccountPrototype account)
+    {
+        if (!_emag.CheckFlag(ent, EmagType.Access) && !_accessReaderSystem.UserHasAccess(user, account.ApproveAccess))
+        {
+            ConsolePopup(user, Loc.GetString("cargo-console-order-not-allowed"));
+            PlayDenySound(ent, ent.Comp);
+            return false;
+        }
+
+        return true;
+    }
+
+    public bool CheckAlertPopup(Entity<CargoOrderConsoleComponent> ent, EntityUid user, CargoOrderData order, EntityUid station)
+    {
+        if (!_emag.CheckFlag(ent, EmagType.Interaction)
+            && order.RequiredAlerts is {} alerts
+            && (CompOrNull<AlertLevelComponent>(station)?.CurrentLevel is not {} current || !alerts.Contains(current)))
+        {
+            ConsolePopup(user, Loc.GetString("cargo-console-alert-level", ("product", order.ProductName)));
+            PlayDenySound(ent, ent.Comp);
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/Content.Shared/Access/Systems/AccessReaderSystem.Trauma.cs
+++ b/Content.Shared/Access/Systems/AccessReaderSystem.Trauma.cs
@@ -1,0 +1,15 @@
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.Access.Systems;
+
+/// <summary>
+/// Trauma - API additions for access checking
+/// </summary>
+public sealed partial class AccessReaderSystem
+{
+    /// <summary>
+    /// Returns true if the user has a given access level.
+    /// </summary>
+    public bool UserHasAccess(EntityUid user, ProtoId<AccessLevelPrototype> level)
+        => FindAccessTags(user).Contains(level);
+}

--- a/Content.Shared/Access/Systems/AccessReaderSystem.cs
+++ b/Content.Shared/Access/Systems/AccessReaderSystem.cs
@@ -1,95 +1,3 @@
-// SPDX-FileCopyrightText: 2021 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2021 Flipp Syder <76629141+vulppine@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2021 Paul Ritter <ritter.paul1@gmail.com>
-// SPDX-FileCopyrightText: 2021 Paul Ritter <ritter.paul1@googlemail.com>
-// SPDX-FileCopyrightText: 2021 Vera Aguilera Puerto <gradientvera@outlook.com>
-// SPDX-FileCopyrightText: 2021 Wrexbe <wrexbe@protonmail.com>
-// SPDX-FileCopyrightText: 2022 20kdc <asdd2808@gmail.com>
-// SPDX-FileCopyrightText: 2022 Moony <moonheart08@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2022 Rane <60792108+Elijahrane@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2022 keronshb <54602815+keronshb@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2022 mirrorcult <lunarautomaton6@gmail.com>
-// SPDX-FileCopyrightText: 2022 wrexbe <81056464+wrexbe@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2023 0x6273 <0x40@keemail.me>
-// SPDX-FileCopyrightText: 2023 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2023 ElectroJr <leonsfriedrich@gmail.com>
-// SPDX-FileCopyrightText: 2023 Julian Giebel <juliangiebel@live.de>
-// SPDX-FileCopyrightText: 2023 PrPleGoo <PrPleGoo@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2023 TemporalOroboros <TemporalOroboros@gmail.com>
-// SPDX-FileCopyrightText: 2023 Visne <39844191+Visne@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2023 deltanedas <deltanedas@laptop>
-// SPDX-FileCopyrightText: 2023 deltanedas <user@zenith>
-// SPDX-FileCopyrightText: 2024 AJCM <AJCM@tutanota.com>
-// SPDX-FileCopyrightText: 2024 Aiden <aiden@djkraz.com>
-// SPDX-FileCopyrightText: 2024 Alex Evgrashin <aevgrashin@yandex.ru>
-// SPDX-FileCopyrightText: 2024 Alex Pavlenko <diraven@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 Alice "Arimah" Heurlin <30327355+arimah@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 ArkiveDev <95712736+ArkiveDev@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 Boaz1111 <149967078+Boaz1111@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 Brandon Hu <103440971+Brandon-Huu@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 Chief-Engineer <119664036+Chief-Engineer@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 Cojoke <83733158+Cojoke-dot@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 Doomsdrayk <robotdoughnut@comcast.net>
-// SPDX-FileCopyrightText: 2024 DrEnzyme <DrEnzyme@gmail.com>
-// SPDX-FileCopyrightText: 2024 DrSmugleaf <10968691+DrSmugleaf@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 Ed <96445749+TheShuEd@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 Elysium206 <151651971+Elysium206@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 Emisse <99158783+Emisse@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 Eoin Mcloughlin <helloworld@eoinrul.es>
-// SPDX-FileCopyrightText: 2024 Errant <35878406+Errant-4@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 Fildrance <fildrance@gmail.com>
-// SPDX-FileCopyrightText: 2024 Flareguy <78941145+Flareguy@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 Floofi <126319569+Shadowtheprotogen546@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 Ghagliiarghii <68826635+Ghagliiarghii@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 HS <81934438+HolySSSS@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 IProduceWidgets <107586145+IProduceWidgets@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 K-Dynamic <20566341+K-Dynamic@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 Kevin Zheng <kevinz5000@gmail.com>
-// SPDX-FileCopyrightText: 2024 Ko4ergaPunk <62609550+Ko4ergaPunk@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 Leon Friedrich <60421075+ElectroJr@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 MetalSage <74924875+MetalSage@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 MetalSage <metalsage.official@gmail.com>
-// SPDX-FileCopyrightText: 2024 MilenVolf <63782763+MilenVolf@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 Mr. 27 <45323883+Dutch-VanDerLinde@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 MureixloI <132683811+MureixloI@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 PJBot <pieterjan.briers+bot@gmail.com>
-// SPDX-FileCopyrightText: 2024 Partmedia <kevinz5000@gmail.com>
-// SPDX-FileCopyrightText: 2024 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
-// SPDX-FileCopyrightText: 2024 Plykiya <58439124+Plykiya@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 Redfire1331 <125223432+Redfire1331@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 Rouge2t7 <81053047+Sarahon@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 Tayrtahn <tayrtahn@gmail.com>
-// SPDX-FileCopyrightText: 2024 Truoizys <153248924+Truoizys@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 TsjipTsjip <19798667+TsjipTsjip@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 Ubaser <134914314+UbaserB@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
-// SPDX-FileCopyrightText: 2024 WarMechanic <69510347+WarMechanic@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 beck-thompson <107373427+beck-thompson@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 c4llv07e <38111072+c4llv07e@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 deathride58 <deathride58@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 deltanedas <39013340+deltanedas@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 deltanedas <@deltanedas:kde.org>
-// SPDX-FileCopyrightText: 2024 eoineoineoin <github@eoinrul.es>
-// SPDX-FileCopyrightText: 2024 github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 marbow <152051971+marboww@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 metalgearsloth <comedian_vs_clown@hotmail.com>
-// SPDX-FileCopyrightText: 2024 mhamster <81412348+mhamsterr@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 neutrino <67447925+neutrino-laser@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 nikthechampiongr <32041239+nikthechampiongr@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 osjarw <62134478+osjarw@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 pa.pecherskij <pa.pecherskij@interfax.ru>
-// SPDX-FileCopyrightText: 2024 plykiya <plykiya@protonmail.com>
-// SPDX-FileCopyrightText: 2024 redfire1331 <Redfire1331@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 slarticodefast <161409025+slarticodefast@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 Арт <123451459+JustArt1m@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2025 ScarKy0 <106310278+ScarKy0@users.noreply.github.com>
-//
-// SPDX-License-Identifier: AGPL-3.0-or-later
-
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
@@ -115,7 +23,7 @@ using Robust.Shared.Timing;
 
 namespace Content.Shared.Access.Systems;
 
-public sealed class AccessReaderSystem : EntitySystem
+public sealed partial class AccessReaderSystem : EntitySystem // Trauma - made partial
 {
     [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private readonly InventorySystem _inventorySystem = default!;

--- a/Content.Shared/Cargo/Prototypes/CargoAccountPrototype.Trauma.cs
+++ b/Content.Shared/Cargo/Prototypes/CargoAccountPrototype.Trauma.cs
@@ -1,0 +1,17 @@
+using Content.Shared.Access;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.Cargo.Prototypes;
+
+/// <summary>
+/// Trauma - ungimping dept economy
+/// </summary>
+public sealed partial class CargoAccountPrototype
+{
+    /// <summary>
+    /// The access level required to approve orders.
+    /// Ignored if the used console has been emagged by an access breaker.
+    /// </summary>
+    [DataField(required: true)]
+    public ProtoId<AccessLevelPrototype> ApproveAccess;
+}

--- a/Resources/Prototypes/Catalog/cargo_accounts.yml
+++ b/Resources/Prototypes/Catalog/cargo_accounts.yml
@@ -5,6 +5,7 @@
   color: "#b48b57"
   radioChannel: Supply
   acquisitionSlip: PaperAcquisitionSlipCargo
+  approveAccess: Quartermaster # Trauma
 
 - type: cargoAccount
   id: Engineering
@@ -13,6 +14,7 @@
   color: "#ff733c"
   radioChannel: Engineering
   acquisitionSlip: PaperAcquisitionSlipEngineering
+  approveAccess: ChiefEngineer # Trauma
 
 - type: cargoAccount
   id: Medical
@@ -21,6 +23,7 @@
   color: "#57b8f0"
   radioChannel: Medical
   acquisitionSlip: PaperAcquisitionSlipMedical
+  approveAccess: ChiefMedicalOfficer # Trauma
 
 - type: cargoAccount
   id: Science
@@ -29,6 +32,7 @@
   color: "#cd7ccd"
   radioChannel: Science
   acquisitionSlip: PaperAcquisitionSlipScience
+  approveAccess: ResearchDirector # Trauma
 
 - type: cargoAccount
   id: Security
@@ -37,6 +41,7 @@
   color: "#ff4242"
   radioChannel: Security
   acquisitionSlip: PaperAcquisitionSlipSecurity
+  approveAccess: HeadOfSecurity # Trauma
 
 - type: cargoAccount
   id: Service
@@ -45,3 +50,4 @@
   color: "#539c00"
   radioChannel: Service
   acquisitionSlip: PaperAcquisitionSlipService
+  approveAccess: HeadOfPersonnel # Trauma

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -919,7 +919,7 @@
     account: Engineering
     announcementChannel: Engineering
     removeLimitAccess: [ "ChiefEngineer" ]
-    mode: SendToPrimary
+    #mode: SendToPrimary # Trauma - ungimp dept economy
   - type: ActiveRadio
     channels:
     - Engineering
@@ -928,7 +928,7 @@
   - type: PointLight
     color: "#c9c042"
   - type: AccessReader
-    access: [["Engineering"]]
+    access: [["ChiefEngineer"]] # Trauma - use head access
 
 - type: entity
   id: ComputerCargoOrdersMedical
@@ -952,7 +952,7 @@
     account: Medical
     announcementChannel: Medical
     removeLimitAccess: [ "ChiefMedicalOfficer" ]
-    mode: SendToPrimary
+    #mode: SendToPrimary # Trauma - ungimp dept economy
   - type: ActiveRadio
     channels:
     - Medical
@@ -961,7 +961,7 @@
   - type: PointLight
     color: "#41e0fc"
   - type: AccessReader
-    access: [["Medical"]]
+    access: [["ChiefMedicalOfficer"]] # Trauma - use head access
 
 - type: entity
   id: ComputerCargoOrdersScience
@@ -985,7 +985,7 @@
     account: Science
     announcementChannel: Science
     removeLimitAccess: [ "ResearchDirector" ]
-    mode: SendToPrimary
+    #mode: SendToPrimary # Trauma - ungimp dept economy
   - type: ActiveRadio
     channels:
     - Science
@@ -994,7 +994,7 @@
   - type: PointLight
     color: "#b53ca1"
   - type: AccessReader
-    access: [["Research"]]
+    access: [["ResearchDirector"]] # Trauma - use head access
 
 - type: entity
   id: ComputerCargoOrdersSecurity
@@ -1018,7 +1018,7 @@
     account: Security
     announcementChannel: Security
     removeLimitAccess: [ "HeadOfSecurity" ]
-    mode: SendToPrimary
+    #mode: SendToPrimary # Trauma - ungimp dept economy
   - type: ActiveRadio
     channels:
     - Security
@@ -1027,7 +1027,7 @@
   - type: PointLight
     color: "#d11d00"
   - type: AccessReader
-    access: [["Security"]]
+    access: [["HeadOfSecurity"]] # Trauma - use head access
 
 - type: entity
   id: ComputerCargoOrdersService
@@ -1051,7 +1051,7 @@
     account: Service
     announcementChannel: Service
     removeLimitAccess: [ "HeadOfPersonnel" ]
-    mode: SendToPrimary
+    #mode: SendToPrimary # Trauma - ungimp dept economy
   - type: ActiveRadio
     channels:
     - Service
@@ -1060,7 +1060,7 @@
   - type: PointLight
     color: "#afe837"
   - type: AccessReader
-    access: [["Service"], ["Theatre"]]
+    access: [["HeadOfPersonnel"]] # Trauma - use head access
 
 - type: entity
   id: ComputerCargoBounty


### PR DESCRIPTION
## About the PR
- department ordering consoles are now local instead of sending them to the cargo console
- approving an order (unless emagged) requires the head access for the account used. CE for engi etc

it already only shows orders specific to the console so dont need any anti troll shit for removing other departments orders on your console etc

you can now yell at your head to approve orders instead of yelling at qm on common

## Why / Balance
its your money trust, except you need my permission to use it...
give dept heads actual control over "their" money, crazy concept

## Media
<img width="992" height="276" alt="19:13:51" src="https://github.com/user-attachments/assets/45d9ee36-dfa5-4d14-ab9a-7dfb44252ace" />
<img width="990" height="253" alt="19:14:11" src="https://github.com/user-attachments/assets/7f7dd415-acd9-47b4-a8b8-c29da194feb9" />
<img width="521" height="92" alt="19:14:23" src="https://github.com/user-attachments/assets/86cea110-2b55-4533-ae33-26fea4e1597e" />

CE access is needed for engi console

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

**Changelog**
:cl:
- tweak: Changed department economy so that heads approve their departments orders, not cargo approving everyone's orders.
