### PR TITLE
miasma now gives diseases

### DIFF
--- a/Content.Goobstation.Shared/EntityEffects/Effects/InfectDisease.cs
+++ b/Content.Goobstation.Shared/EntityEffects/Effects/InfectDisease.cs
@@ -13,6 +13,12 @@ public sealed partial class InfectDisease : EntityEffectBase<InfectDisease>
     [DataField(required: true)]
     public EntProtoId Disease;
 
+    [DataField]
+    public bool Mutate;
+
+    [DataField]
+    public float? MutationRate;
+
     public override string? EntityEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
         => Loc.GetString("entity-effect-guidebook-infect-disease", ("chance", Probability), ("disease", prototype.Index(Disease).Name));
 }
@@ -23,6 +29,8 @@ public sealed class InfectDiseaseEffectSystem : EntityEffectSystem<DiseaseCarrie
 
     protected override void Effect(Entity<DiseaseCarrierComponent> ent, ref EntityEffectEvent<InfectDisease> args)
     {
-        _disease.TryInfect(ent.AsNullable(), args.Effect.Disease, out _);
+        var effect = args.Effect;
+        if (_disease.TryInfect(ent.AsNullable(), effect.Disease, out var disease) && effect.Mutate)
+            _disease.MutateDisease(disease.Value, effect.MutationRate);
     }
 }

--- a/Content.Shared/EntityEffects/EntityEffect.Trauma.cs
+++ b/Content.Shared/EntityEffects/EntityEffect.Trauma.cs
@@ -1,0 +1,13 @@
+namespace Content.Shared.EntityEffects;
+
+/// <summary>
+/// Trauma - add ScaleProbability
+/// </summary>
+public abstract partial class EntityEffect
+{
+    /// <summary>
+    /// If true, probability will be increased/decreased by effect scale.
+    /// </summary>
+    [DataField]
+    public bool ScaleProbability;
+}

--- a/Content.Shared/EntityEffects/SharedEntityEffectsSystem.cs
+++ b/Content.Shared/EntityEffects/SharedEntityEffectsSystem.cs
@@ -100,7 +100,7 @@ public sealed partial class SharedEntityEffectsSystem : EntitySystem, IEntityEff
         {
             var seed = SharedRandomExtensions.HashCodeCombine((int)_timing.CurTick.Value, GetNetEntity(target).Id, 0);
             var rand = new System.Random(seed);
-            if (!rand.Prob(effect.Probability))
+            if (!rand.Prob(effect.Probability * (effect.ScaleProbability ? scale : 1f))) // Trauma - multiply by scale if ScaleProbability is true
                 return false;
         }
 

--- a/Resources/Prototypes/Reagents/botany.yml
+++ b/Resources/Prototypes/Reagents/botany.yml
@@ -1,36 +1,3 @@
-# SPDX-FileCopyrightText: 2021 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
-# SPDX-FileCopyrightText: 2021 Vera Aguilera Puerto <6766154+Zumorica@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2021 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
-# SPDX-FileCopyrightText: 2022 Alex Evgrashin <aevgrashin@yandex.ru>
-# SPDX-FileCopyrightText: 2022 Flipp Syder <76629141+vulppine@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2022 Moony <moonheart08@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2022 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2022 Sam Weaver <weaversam8@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2022 ShadowCommander <10494922+ShadowCommander@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2022 moonheart08 <moonheart08@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 Doru991 <75124791+Doru991@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 Kara <lunarautomaton6@gmail.com>
-# SPDX-FileCopyrightText: 2023 Maxtone <124747282+MagnusCrowe@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 Sailor <109166122+Equivocateur@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 deltanedas <39013340+deltanedas@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 deltanedas <@deltanedas:kde.org>
-# SPDX-FileCopyrightText: 2024 Aidenkrz <aiden@djkraz.com>
-# SPDX-FileCopyrightText: 2024 Alpha-Two <92269094+Alpha-Two@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Alpha-Two <alpha2.5232@gmail.com>
-# SPDX-FileCopyrightText: 2024 Ashley Woodiss-Field <ash@DESKTOP-H64M4AI.localdomain>
-# SPDX-FileCopyrightText: 2024 ColesMagnum <98577947+AW-FulCode@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Eris <eris@erisws.com>
-# SPDX-FileCopyrightText: 2024 Errant <35878406+Errant-4@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Flesh <62557990+PolterTzi@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 IlyaElDunaev <154531074+IlyaElDunaev@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Tayrtahn <tayrtahn@gmail.com>
-# SPDX-FileCopyrightText: 2024 metalgearsloth <comedian_vs_clown@hotmail.com>
-# SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
-#
-# SPDX-License-Identifier: AGPL-3.0-or-later
-
 - type: reagent
   id: EZNutrient
   name: reagent-name-e-z-nutrient
@@ -279,7 +246,7 @@
         type: Local
         visualType: Medium
         messages: [ "ammonia-smell" ]
-        probability: 0.1
+        probability: 1
         conditions:
         - !type:ReagentCondition
           reagent: Ammonia
@@ -311,7 +278,19 @@
         - !type:MetabolizerTypeCondition
           type: [ Vox ]
         factor: -4
-
+      - !type:InfectDisease # Trauma - miasma gives you diseases
+        probability: 0.2
+        scaleProbability: true # more moles more disease
+        conditions:
+        - !type:MetabolizerTypeCondition
+          type: [ Rat, Vox, Yowie ]
+          inverted: true
+        - !type:ReagentCondition
+          reagent: Ammonia
+          min: 0.5
+        disease: DiseaseBaseMouse # mostly guaranteed cough transmission
+        mutate: true
+        mutationRate: 3 # very random
 
 - type: reagent
   id: Diethylamine


### PR DESCRIPTION
## About the PR
evil virologists room of rotting cows now makes random diseases
inhaling miasma (not eating/injecting ammonia liquid) has a random chance to infect you with something, higher chance with more moles in your lungs

rats vox and yowie are immune

## Why / Balance
viro being 1% less bare bones :face_holding_back_tears: 

atmos can now be bioterrorists if they make a miasma farm

## Technical details
ScaleProbability added to effects to make probability scale with reagent count etc
mutation stuff added to InfectDisease

**Changelog**
:cl:
- add: Breathing miasma can now give you diseases, as predicted by 19th century doctors.
