### PR TITLE
Nanotask printer delay

### DIFF
--- a/Content.Shared/CartridgeLoader/Cartridges/NanoTaskCartridgeComponent.cs
+++ b/Content.Shared/CartridgeLoader/Cartridges/NanoTaskCartridgeComponent.cs
@@ -30,7 +30,7 @@ public sealed partial class NanoTaskCartridgeComponent : Component
     /// How long in between each time the user can print out a task
     /// </summary>
     [DataField]
-    public TimeSpan PrintDelay = TimeSpan.FromSeconds(20); /// Trauma - Increase PrintDelay from 5 to 20
+    public TimeSpan PrintDelay = TimeSpan.FromSeconds(5);
 }
 
 /// <summary>

--- a/Resources/Prototypes/Entities/Objects/Devices/cartridges.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/cartridges.yml
@@ -126,6 +126,7 @@
   - type: UIFragment
     ui: !type:NanoTaskUi
   - type: NanoTaskCartridge
+    printDelay: 20 # Trauma - change base print delay for nanotask to 20
 
 - type: entity
   parent: BasePDACartridge


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->
PrintDelay of nanotask cartridge
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Infinite ghetto jetpack / Infinite ghetto jetpack is le bad. 
I was tempted to just replace the Paper parent of nanotask with BasePaper so it couldn't be used for moneyprinting but tiders would shoot me. 
## Technical details
<!-- Summary of code changes for easier review. -->
no
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
no
## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: NanoTask printing delay increased from 5 to 20 seconds.