### PR TITLE
Unperishable select food

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/donkpocket.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/donkpocket.yml
@@ -84,7 +84,7 @@
 # Base
 
 - type: entity
-  parent: FoodInjectableBase
+  parent: FoodUnperishableBase # Trauma - Donkpockets are unperishable.
   id: FoodDonkpocketBase
   abstract: true
   components:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/donut.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/donut.yml
@@ -25,7 +25,7 @@
 # Base
 
 - type: entity
-  parent: FoodInjectableBase
+  parent: FoodUnperishableBase # Trauma - Highly processed slop for the secoffs.
   id: FoodDonutBase
   abstract: true
   description: Goes great with robust coffee.

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -2451,7 +2451,7 @@
 
 - type: entity
   name: bungo pit
-  parent: FoodInjectableBase
+  parent: FoodUnperishableBase # Trauma - Huge seed doesn't rot, also poison hoarding.
   id: FoodBungoPit
   components:
   - type: Sprite
@@ -2756,7 +2756,7 @@
 
 - type: entity
   name: cherry pit
-  parent: FoodInjectableBase
+  parent: FoodUnperishableBase # Trauma - Basically a seed.
   id: TrashCherryPit
   components:
   - type: Sprite


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->
maint loot mapped donkpockets
secoff lunchbreak donuts
bungo/cherry pits (evil poison before rot vs evil poison after, same difference)
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Highly processed superfood donkpockets/donuts shouldn't rot, basically twinkies. Donuts made to not rot so secoffs can stuff their face (no the cardboard box isn't what preserves them, they are just made of trash. but not actually making them trash so future pr can add donut healing secoffs SURELY)

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Donuts no longer rot into slop. Secoffs get a reliable mini meal at brig.
- tweak: Donkpockets no longer rot into slop. Tiders get a reliable mini meal in maint.
- tweak:  Bungo and cherry pits no longer rot into slop, remaining a viable poison for annoying chefs/botanists.
