### PR TITLE
fix dart gun not having inhands

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/dart_gun.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/dart_gun.yml
@@ -16,6 +16,7 @@
     sprite: _Goobstation/Objects/Weapons/Guns/Cannons/dart_gun.rsi
     state: icon
   - type: Item
+    sprite: _Goobstation/Objects/Weapons/Guns/Cannons/syringe_gun.rsi # use syringe gun inhands, it looks close enough
     size: Small
     storedRotation: -90
   - type: Gun


### PR DESCRIPTION
## About the PR
use regular syringe gun's inhands they look close enough

## Why / Balance
mfw invisible traitor item :heart_eyes: 

## Media
<img width="161" height="108" alt="15:42:18" src="https://github.com/user-attachments/assets/68fef2ec-e24e-4704-aebc-b7264854052e" />

**Changelog**
:cl:
- fix: Fixed traitor dart guns not having inhand sprites.
