### PR TITLE
blacklist borgs from language traits

### DIFF
--- a/Resources/Prototypes/_EinsteinEngines/Traits/languages.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Traits/languages.yml
@@ -7,6 +7,9 @@
   description: trait-language-foreigner-light-desc
   category: LanguageTraits
   cost: -1
+  blacklist:
+    components:
+      - BorgChassis
   components:
   - type: ForeignerTrait
     cantUnderstand: false
@@ -18,6 +21,9 @@
   description: trait-language-foreigner-desc
   category: LanguageTraits
   cost: -2
+  blacklist:
+    components:
+      - BorgChassis
   components:
   - type: ForeignerTrait
     baseTranslator: TranslatorForeigner
@@ -29,6 +35,9 @@
   description: trait-language-solcommon-desc
   category: LanguageTraits
   cost: 1
+  blacklist:
+    components:
+      - BorgChassis
   components:
   - type: LanguageSpeaker
   languagesSpoken:
@@ -42,6 +51,9 @@
   description: trait-language-tradeband-desc
   category: LanguageTraits
   cost: 1
+  blacklist:
+    components:
+      - BorgChassis
   components:
   - type: LanguageSpeaker
   languagesSpoken:
@@ -55,6 +67,9 @@
   description: trait-language-freespeak-desc
   category: LanguageTraits
   cost: 1
+  blacklist:
+    components:
+      - BorgChassis
   components:
   - type: LanguageSpeaker
   languagesSpoken:
@@ -68,6 +83,9 @@
   description: trait-language-elyran-desc
   category: LanguageTraits
   cost: 1
+  blacklist:
+    components:
+      - BorgChassis
   components:
   - type: LanguageSpeaker
   languagesSpoken:
@@ -95,6 +113,9 @@
   description: trait-language-novunederic-desc
   category: LanguageTraits
   cost: 1
+  blacklist:
+    components:
+      - BorgChassis
   components:
   - type: LanguageSpeaker
   languagesSpoken:


### PR DESCRIPTION
goida yaml, fixes #422

:cl:
- fix: Fixed borgs being affected by language-related traits.