### PR TITLE
Does a lot of new additions to Meta, AI restoration + Bug Fixes

### DIFF
--- a/Resources/Maps/_Trauma/meta.yml
+++ b/Resources/Maps/_Trauma/meta.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 271.1.0
   forkId: ""
   forkVersion: ""
-  time: 01/22/2026 21:22:42
-  entityCount: 27956
+  time: 01/22/2026 23:15:58
+  entityCount: 27957
 maps:
 - 1
 grids:
@@ -11227,7 +11227,7 @@ entities:
       pos: -42.5,29.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -23765.297
+      secondsUntilStateChange: -23812.62
       state: Opening
     - type: DeviceLinkSink
       invokeCounter: 2
@@ -36433,6 +36433,11 @@ entities:
     components:
     - type: Transform
       pos: 2.5,-65.5
+      parent: 2
+  - uid: 25171
+    components:
+    - type: Transform
+      pos: -0.5,-63.5
       parent: 2
   - uid: 27728
     components:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->
Removes floating grille and lattice from Engi
Maps AI restoration console and board to R&D Office, and Tech Vault.
Removes Extra SecTechFab outside of armory
Armory now has a security turret and control panel
Spare Robotics console in R&D Office removed
Radio Host now has power

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Helps solve https://github.com/Trauma-Station/Trauma-Station/issues/431 and remove the Sectechfab that I forgot to remove.
Hopefully the armory turret doesn't throw invalid this time with https://github.com/Trauma-Station/Trauma-Station/pull/345 merged
One of the few maps that forgot to remove the robotics console from R&D Office, since its now in AI Upload or AI SAT

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
Floating grill and the lattice removed
<img width="457" height="434" alt="image" src="https://github.com/user-attachments/assets/73b4ac9b-f848-4f4e-b777-bfe84ab746a2" />
Spare Sectecfab removed used to be next to the SecTech above armory, armory turret and panel added
<img width="807" height="528" alt="image" src="https://github.com/user-attachments/assets/8b8ea373-8742-424d-8f4f-4cf5661c90f9" />
Spare AI Restoration board added to techvault
<img width="678" height="422" alt="image" src="https://github.com/user-attachments/assets/0732969b-019c-482b-b6a9-19364670ec3c" />
Spare robotics console replaced with AI Restoration Console
<img width="671" height="500" alt="image" src="https://github.com/user-attachments/assets/9d0d2978-1869-4b6a-843c-1f358fe16379" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
Maps:
- add: Meta, AI restoration console to R&D Office, and the board is added to Tech Vault!
- add: Meta, Armory now has a security turret
- remove: Meta, Extra SecTechFab and Spare robotics console
- fix: Meta, The floating grill and the lattice in Engi has been removed
- fix: Meta, APC in Radio Host now has power

