### PR TITLE
change hypoport trait to be an opt out

### DIFF
--- a/Content.Trauma.Shared/Medical/Components/NoHypoportComponent.cs
+++ b/Content.Trauma.Shared/Medical/Components/NoHypoportComponent.cs
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+namespace Content.Trauma.Shared.Medical.Components;
+
+/// <summary>
+/// Marker component used by hypoport trait + player effects
+/// </summary>
+[RegisterComponent]
+public sealed partial class NoHypoportComponent : Component;

--- a/Content.Trauma.Shared/Station/PlayerEffectsPrototype.cs
+++ b/Content.Trauma.Shared/Station/PlayerEffectsPrototype.cs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+using Content.Shared.EntityConditions;
+using Content.Shared.EntityEffects;
+using Robust.Shared.Prototypes;
+
+namespace Content.Trauma.Shared.Station;
+
+/// <summary>
+/// Runs a list of entity effects on any player that spawns which passes some conditions.
+/// This probably includes borgs AI etc.
+/// </summary>
+[Prototype]
+public sealed partial class PlayerEffectsPrototype: IPrototype
+{
+    [IdDataField]
+    public string ID { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// All of these conditions must pass for the spawned player.
+    /// </summary>
+    [DataField]
+    public EntityCondition[]? Conditions;
+
+    /// <summary>
+    /// If all conditions pass these effects get applied to the spawned player.
+    /// </summary>
+    [DataField(required: true)]
+    public EntityEffect[] Effects = default!;
+}

--- a/Content.Trauma.Shared/Station/PlayerEffectsSystem.cs
+++ b/Content.Trauma.Shared/Station/PlayerEffectsSystem.cs
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+using Content.Shared.EntityConditions;
+using Content.Shared.EntityEffects;
+using Content.Shared.GameTicking;
+using Robust.Shared.Prototypes;
+
+namespace Content.Trauma.Shared.Station;
+
+/// <summary>
+/// Runs entity effects for station players after they spawn.
+/// </summary>
+public sealed class PlayerEffectsSystem : EntitySystem
+{
+    [Dependency] private readonly SharedEntityConditionsSystem _conditions = default!;
+    [Dependency] private readonly SharedEntityEffectsSystem _effects = default!;
+    [Dependency] private readonly IPrototypeManager _proto = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<PlayerSpawnCompleteEvent>(OnSpawnCompleted);
+    }
+
+    private void OnSpawnCompleted(PlayerSpawnCompleteEvent args)
+    {
+        var uid = args.Mob;
+        foreach (var proto in _proto.EnumeratePrototypes<PlayerEffectsPrototype>())
+        {
+            if (_conditions.TryConditions(uid, proto.Conditions))
+                _effects.ApplyEffects(uid, proto.Effects);
+        }
+    }
+}

--- a/Resources/Locale/en-US/_Trauma/guidebook/entityeffects/conditions.ftl
+++ b/Resources/Locale/en-US/_Trauma/guidebook/entityeffects/conditions.ftl
@@ -9,3 +9,4 @@ entity-effect-condition-guidebook-cosmic-cultist = the target is a cosmic cultis
 entity-effect-condition-shadowling-or-thrall = target is a shadowling or thrall
 entity-effect-condition-not-shadowling-or-thrall = target is not a shadowling or thrall
 entity-condition-guidebook-is-humanoid = target is humanoid
+entity-condition-guidebook-hypoport-target = target can receive a hypoport

--- a/Resources/Locale/en-US/_Trauma/traits/traits.ftl
+++ b/Resources/Locale/en-US/_Trauma/traits/traits.ftl
@@ -1,2 +1,2 @@
-trait-hypoport-name = Hypoport
-trait-hypoport-desc = You have a hypoport installed in your neck to allow instant, sterile hypospray usage.
+trait-no-hypoport-name = No Hypoport
+trait-no-hypoport-desc = Unlike most personnel, having a hypoport creeps you out too much. You won't have a hypoport installed.

--- a/Resources/Prototypes/_Trauma/EntityEffects/hypoport.yml
+++ b/Resources/Prototypes/_Trauma/EntityEffects/hypoport.yml
@@ -23,3 +23,24 @@
       slot: hypoport
     - !type:InsertNewOrgan
       organ: HypoportSecureNukie
+
+# Give all crew a hypoport unless they opt out.
+- type: playerEffects
+  id: InstallHypoports
+  conditions:
+  - !type:WhitelistCondition
+    whitelist:
+      components:
+      - HumanoidAppearance # no corgis or whatever the fuck
+    blacklist:
+      components:
+      - NoHypoport # to let people opt out for schizo characters via trait
+      - Silicon
+      - BorgChassis
+    guidebookText: entity-condition-guidebook-hypoport-target
+  effects:
+  - !type:NestedEffect
+    proto: InstallHypoport
+  - !type:RemoveComponents
+    components:
+    - type: NoHypoport # leave no trace

--- a/Resources/Prototypes/_Trauma/Traits/quirks.yml
+++ b/Resources/Prototypes/_Trauma/Traits/quirks.yml
@@ -1,11 +1,10 @@
 - type: trait
-  id: Hypoport
-  name: trait-hypoport-name
-  description: trait-hypoport-desc
+  id: NoHypoport
+  name: trait-no-hypoport-name
+  description: trait-no-hypoport-desc
   category: Quirks
   blacklist:
     components:
     - BorgChassis
-  effects:
-  - !type:NestedEffect
-    proto: InstallHypoport
+  components:
+  - type: NoHypoport

--- a/Resources/ServerInfo/_Trauma/Guidebook/Medical/Hypoports.xml
+++ b/Resources/ServerInfo/_Trauma/Guidebook/Medical/Hypoports.xml
@@ -24,7 +24,7 @@ Very useful to have for patients that have hypoports!
 You can use the detailed health examine button to see if someone has a hypoport installed.
 
 The standard hypoport can be made at a medfab or exofab roundstart and allows anyone with a hypospray to easily inject you with medicines.
-This hypoport is what you get for free if you enable the [bold]Hypoport[/bold] trait.
+This hypoport is what you get for free as a station role, unless you enable the [bold]No Hypoport[/bold] trait or remove it in-round.
 
 [color=#c96dbf]Science[/color] is able to research [bold]secure hypoports[/bold] which check the user's ID.
 The access needed starts out as Medical, but can be changed using a multitool.
@@ -47,7 +47,7 @@ The first surgery to do is opening a hypoport cavity. Once you've done that you 
 
 # Hypoports as a traitor
 
-Because not everyone will have a hypoport, you can no longer rely on hypopen with nocturine being a guaranteed KO. As a result it's much cheaper (and you can just get a regular hypo anyway)
+Because some players may choose to not have a hypoport, you can no longer rely on hypopen with nocturine being a guaranteed KO. As a result it's much cheaper (and you can just get a regular hypo anyway)
 
 If you are a traitor with a hypoport you can use it to easily heal yourself on the go. If you change a secure hypoport's access to Syndicate, an Agent ID will allow you alone to use it.
 Very handy if the doctors are carrying poisons on them, "just in case".


### PR DESCRIPTION
## About the PR
now by default all crew will get a hypoport
the trait is now **No Hypoport** to opt out, for turbo and others with schizo characters

## Why / Balance
fixes #489

## Technical details
added PlayerEffectsPrototype for running entity effects on spawned crew.
you can be very evil with this

## Media
no trait, hypoport exists by default

<img width="412" height="417" alt="10:48:01" src="https://github.com/user-attachments/assets/ae14118f-6ca9-47b3-84d4-e47286473017" />

the trait
<img width="908" height="82" alt="10:48:15" src="https://github.com/user-attachments/assets/9818639a-8488-4019-a9db-2ca0c29fe1ce" />

no more hypoport
<img width="300" height="356" alt="10:48:36" src="https://github.com/user-attachments/assets/4b590c07-c972-4d5a-8824-7f0f91324965" />

**Changelog**
:cl:
- tweak: All crew get hypoports by default. The No Hypoport trait is now an opt-out.
