### PR TITLE
only package linux and win amd64 server

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
       run: dotnet build Content.Packaging --configuration Release --no-restore /m
 
     - name: Package server
-      run: dotnet run --project Content.Packaging server --platform win-x64 --platform win-arm64 --platform linux-x64 --platform linux-arm64 --platform osx-x64 --platform osx-arm64
+      run: dotnet run --project Content.Packaging server --platform win-x64 --platform linux-x64
 
     - name: Package client
       run: dotnet run --project Content.Packaging client --no-wipe-release


### PR DESCRIPTION
no longer publishing mac or arm server builds, fuck waiting 25 minutes for publish

itoddlers can cope but theres too many winbabbies that dont know how to use git