### PR TITLE
Face huggers can infect without a person now ig

### DIFF
--- a/Content.Server/_White/Xenomorphs/FaceHugger/FaceHuggerSystem.cs
+++ b/Content.Server/_White/Xenomorphs/FaceHugger/FaceHuggerSystem.cs
@@ -161,9 +161,6 @@ public sealed class FaceHuggerSystem : EntitySystem
         var query = EntityQueryEnumerator<FaceHuggerComponent>();
         while (query.MoveNext(out var uid, out var faceHugger))
         {
-            if (!faceHugger.PlayerControlled)
-                return;
-
             if (!faceHugger.Active && time > faceHugger.RestIn)
                 faceHugger.Active = true;
 
@@ -196,6 +193,9 @@ public sealed class FaceHuggerSystem : EntitySystem
                 }
             }
             // Goobstaion end
+
+            if (!faceHugger.PlayerControlled) // Trauma, no auto jumping facehuggers without player
+                return;
 
             if (faceHugger.Active && clothing?.InSlot == null)
             {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
Facehuggers can now infect if manually put onto someone now ig

resolves [520](https://github.com/Trauma-Station/Trauma-Station/issues/520#issuecomment-3797432478) (Even tho the issue doesn't explain it right)

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
:cl:
- tweak: Facehuggers can now infect if manually put onto someone.
