### PR TITLE
Departmental econ real

### DIFF
--- a/Resources/Prototypes/_Trauma/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/_Trauma/Catalog/Fills/Lockers/heads.yml
@@ -10,6 +10,7 @@
     children:
     - id: ClothingHeadsetAltCommand
     - id: CommandMegaphone
+    - id: CargoRequestServiceComputerCircuitboard
 
 - type: entityTable
   id: LockerFillChiefEngineerTrauma
@@ -22,6 +23,7 @@
     - id: CartridgeRocketSingularityBuster
     - id: WeaponLauncherSingularityBuster
     - id: MachinePowerTransmissionLaserFlatpack
+    - id: CargoRequestEngineeringComputerCircuitboard
 
 - type: entityTable
   id: LockerFillChiefMedicalOfficerTrauma
@@ -34,6 +36,7 @@
     - id: ClothingBeltMilitaryWebbingCMOFilled
     - id: DiseaseDiagnoserFlatPack
     - id: VaccinatorFlatPack
+    - id: CargoRequestMedicalComputerCircuitboard
 
 - type: entityTable
   id: LockerFillResearchDirectorTrauma
@@ -45,6 +48,7 @@
     - id: ClothingBeltGeminiHoloProjector # Who better to do science with than yourself?
     - id: MMI
     - id: FreeformLawboard
+    - id: CargoRequestScienceComputerCircuitboard
 
 - type: entityTable
   id: LockerFillHeadOfSecurityTrauma
@@ -53,3 +57,4 @@
     - id: ClothingBeltSheathHeadOfSecurityFilled
     - id: ReinforcementCallerHos
     - id: TelescopicShield
+    - id: CargoRequestSecurityComputerCircuitboard


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
Added Departmental request computers to each heads locker

## Why / Balance
pls sir may i buy some steel for sci 

NO YOU WILL BREAK INTO CAPTAINS ROOM AND STEAL THEIR ID TO APPROVE CARGO REQUESTS FROM CARGO COMPUTER, DEATH TO DEPARTMENTAL ECONOMY

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- add: Each head now gets their departments cargo request computers.
