### PR TITLE
emag refactoring and fix aghost announcing orders

### DIFF
--- a/Content.Goobstation.Server/Shuttle/EmergencyShuttleSystem.Emag.cs
+++ b/Content.Goobstation.Server/Shuttle/EmergencyShuttleSystem.Emag.cs
@@ -70,9 +70,9 @@ public sealed class GoobEmergencyShuttleSystem : EntitySystem
             args.UserUid,
             component.EmagTime,
             new EmergencyShuttleConsoleEmagDoAfterEvent(),
-            uid,
-            uid,
-            args.EmagUid)
+            eventTarget: uid,
+            target: uid,
+            used: args.EmagUid)
         {
             DistanceThreshold = 1.5f,
             NeedHand = true,

--- a/Content.Shared/Emag/Components/EmagComponent.cs
+++ b/Content.Shared/Emag/Components/EmagComponent.cs
@@ -1,17 +1,3 @@
-// SPDX-FileCopyrightText: 2022 Leon Friedrich <60421075+ElectroJr@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2022 Rane <60792108+Elijahrane@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2023 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2023 deltanedas <39013340+deltanedas@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2023 deltanedas <@deltanedas:kde.org>
-// SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
-// SPDX-FileCopyrightText: 2025 Piras314 <p1r4s@proton.me>
-// SPDX-FileCopyrightText: 2025 ScarKy0 <106310278+ScarKy0@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2025 SolsticeOfTheWinter <solsticeofthewinter@gmail.com>
-// SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
-//
-// SPDX-License-Identifier: AGPL-3.0-or-later
-
 using Content.Shared.Emag.Systems;
 using Content.Shared.Tag;
 using Robust.Shared.Audio;
@@ -19,7 +5,6 @@ using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 using Robust.Shared.Serialization;
-using Content.Shared.Whitelist; // Shitmed - Starlight Abductors
 
 namespace Content.Shared.Emag.Components;
 
@@ -48,12 +33,6 @@ public sealed partial class EmagComponent : Component
     [DataField]
     [AutoNetworkedField]
     public SoundSpecifier EmagSound = new SoundCollectionSpecifier("sparks");
-
-    /// <summary>
-    ///     Shitmed - Starlight Abductors: Entities that this EMAG works on.
-    /// </summary>
-    [DataField, AutoNetworkedField]
-    public EntityWhitelist? ValidTargets;
 
     /// <summary>
     /// Goobstation - The text displayed when successful.

--- a/Content.Shared/Emag/Components/EmaggedComponent.cs
+++ b/Content.Shared/Emag/Components/EmaggedComponent.cs
@@ -1,13 +1,3 @@
-// SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2023 deltanedas <39013340+deltanedas@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2023 deltanedas <deltanedas@laptop>
-// SPDX-FileCopyrightText: 2023 deltanedas <user@zenith>
-// SPDX-FileCopyrightText: 2023 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2025 ScarKy0 <106310278+ScarKy0@users.noreply.github.com>
-//
-// SPDX-License-Identifier: AGPL-3.0-or-later
-
 using Content.Shared.Emag.Systems;
 using Robust.Shared.GameStates;
 

--- a/Content.Shared/Emag/Systems/EmagSystem.cs
+++ b/Content.Shared/Emag/Systems/EmagSystem.cs
@@ -1,21 +1,7 @@
-// SPDX-FileCopyrightText: 2023 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2023 deltanedas <39013340+deltanedas@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2023 deltanedas <@deltanedas:kde.org>
-// SPDX-FileCopyrightText: 2023 deltanedas <deltanedas@laptop>
-// SPDX-FileCopyrightText: 2023 deltanedas <user@zenith>
-// SPDX-FileCopyrightText: 2023 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 Arendian <137322659+Arendian@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 Aviu00 <93730715+Aviu00@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 Saphire <lattice@saphi.re>
-// SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
-// SPDX-FileCopyrightText: 2025 Piras314 <p1r4s@proton.me>
-// SPDX-FileCopyrightText: 2025 ScarKy0 <106310278+ScarKy0@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2025 SolsticeOfTheWinter <solsticeofthewinter@gmail.com>
-// SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
-//
-// SPDX-License-Identifier: AGPL-3.0-or-later
-
+// <Trauma>
+using Content.Goobstation.Common.Effects;
+using Content.Trauma.Common.Emag;
+// </Trauma>
 using Content.Shared.Administration.Logs;
 using Content.Shared.Charges.Components;
 using Content.Shared.Charges.Systems;
@@ -27,8 +13,6 @@ using Content.Shared.Popups;
 using Content.Shared.Tag;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Serialization;
-using Content.Shared.Whitelist;
-using Content.Goobstation.Common.Effects; // Shitmed - Starlight Abductors
 
 namespace Content.Shared.Emag.Systems;
 
@@ -40,13 +24,14 @@ namespace Content.Shared.Emag.Systems;
 /// 5. Optionally, set Repeatable on the event to true if you don't want the emagged component to be added
 public sealed class EmagSystem : EntitySystem
 {
+    // <Trauma>
+    [Dependency] private readonly SparksSystem _sparks = default!;
+    // </Trauma>
     [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
     [Dependency] private readonly SharedChargesSystem _sharedCharges = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly TagSystem _tag = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
-    [Dependency] private readonly EntityWhitelistSystem _whitelist = default!; // DeltaV - Add a whitelist/blacklist to the Emag
-    [Dependency] private readonly SparksSystem _sparks = default!; // goob edit - sparks everywhere
 
     public override void Initialize()
     {
@@ -90,17 +75,16 @@ public sealed class EmagSystem : EntitySystem
             return false;
         }
 
-        // Shitmed - Starlight Abductors: Check if the target has a whitelist, and check if it passes
-        if (_whitelist.IsWhitelistFail(ent.Comp.ValidTargets, target))
-        {
-            _popup.PopupClient(Loc.GetString("emag-attempt-failed", ("tool", ent)), user, user);
+        // <Trauma>
+        var attemptEv = new EmagAttemptEvent(target, user);
+        RaiseLocalEvent(ent, ref attemptEv);
+        if (attemptEv.Cancelled)
             return false;
-        }
-        // Shitmed end
+        // </Trauma>
 
         var typeToUse = customEmagType ?? ent.Comp.EmagType;
 
-        var emaggedEvent = new GotEmaggedEvent(user, ent.Comp.EmagType, EmagUid: ent);
+        var emaggedEvent = new GotEmaggedEvent(user, ent.Comp.EmagType, EmagUid: ent); // Goob - add ent
         RaiseLocalEvent(target, ref emaggedEvent);
         if (!emaggedEvent.Handled)
             return false;
@@ -178,4 +162,5 @@ public enum EmagType
 /// <param name="EmagUid">Uid of emag entity, Goobstation</param>
 /// <remarks>Needs to be handled in shared/client, not just the server, to actually show the emagging popup</remarks>
 [ByRefEvent]
-public record struct GotEmaggedEvent(EntityUid UserUid, EmagType Type, bool Handled = false, bool Repeatable = false, EntityUid? EmagUid = null); // Goob edit
+public record struct GotEmaggedEvent(EntityUid UserUid, EmagType Type, bool Handled = false, bool Repeatable = false,
+    EntityUid? EmagUid = null); // Goob edit

--- a/Content.Trauma.Common/Emag/EmagAttemptEvent.cs
+++ b/Content.Trauma.Common/Emag/EmagAttemptEvent.cs
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+namespace Content.Trauma.Common.Emag;
+
+/// <summary>
+/// Event raised on the emag to allow preventing it from working.
+/// </summary>
+[ByRefEvent]
+public record struct EmagAttemptEvent(EntityUid Target, EntityUid User, bool Cancelled = false);

--- a/Content.Trauma.Shared/Emag/EmagWhitelistComponent.cs
+++ b/Content.Trauma.Shared/Emag/EmagWhitelistComponent.cs
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+using Content.Shared.Whitelist;
+using Robust.Shared.GameStates;
+
+namespace Content.Trauma.Shared.Emag;
+
+/// <summary>
+/// Only allows this emag to work on entities matching a whitelist.
+/// </summary>
+[RegisterComponent, NetworkedComponent, Access(typeof(EmagWhitelistSystem))]
+[AutoGenerateComponentState]
+public sealed partial class EmagWhitelistComponent : Component
+{
+    [DataField(required: true), AutoNetworkedField]
+    public EntityWhitelist Whitelist = default!;
+}

--- a/Content.Trauma.Shared/Emag/EmagWhitelistSystem.cs
+++ b/Content.Trauma.Shared/Emag/EmagWhitelistSystem.cs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+using Content.Trauma.Common.Emag;
+using Content.Shared.Popups;
+using Content.Shared.Whitelist;
+
+namespace Content.Trauma.Shared.Emag;
+
+public sealed class EmagWhitelistSystem : EntitySystem
+{
+    [Dependency] private readonly EntityWhitelistSystem _whitelist = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<EmagWhitelistComponent, EmagAttemptEvent>(OnEmagAttempt);
+    }
+
+    private void OnEmagAttempt(Entity<EmagWhitelistComponent> ent, ref EmagAttemptEvent args)
+    {
+        if (args.Cancelled || _whitelist.IsWhitelistPass(ent.Comp.Whitelist, args.Target))
+            return;
+
+        var user = args.User;
+        _popup.PopupClient(Loc.GetString("emag-attempt-failed", ("tool", ent)), user, user);
+        args.Cancelled = true;
+    }
+}

--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -4,6 +4,22 @@
   name: admin observer
   categories: [ HideSpawnMenu ]
   components:
+  # <Trauma>
+  - type: Body
+    prototype: Aghost
+    thermalVisibility: false # so you can't see aghost with thermals...
+  - type: SupermatterImmune
+  - type: Speech
+    speechVerb: HolierThanThou
+  - type: Eye
+    visMask:
+      - Ghost
+      - Normal
+      - CosmicCultMonument
+      - Abductor
+  - type: Emagged # so cargo orders aren't announced and can bypass alert levels
+    emagType: All
+  # </Trauma>
   - type: ContentEye
     maxZoom: 8.916104, 8.916104
   - type: Tag
@@ -38,9 +54,6 @@
   - type: Physics
     bodyType: Kinematic # Admin ghosts should ignore the laws of physics.
     ignorePaused: true
-  - type: Body
-    prototype: Aghost
-    thermalVisibility: false # WD EDIT
   - type: Access
     groups:
     - AllAccess
@@ -111,15 +124,6 @@
   - type: Loadout
     prototypes: [ MobAghostGear ]
   - type: BypassInteractionChecks
-  - type: SupermatterImmune # Goobstation
-  - type: Speech # Goobstation
-    speechVerb: HolierThanThou
-  - type: Eye
-    visMask:
-      - Ghost
-      - Normal
-      - CosmicCultMonument # DeltaV - Cosmic Cult
-      - Abductor
   - type: ExplosionResistance
     damageCoefficient: 0
 

--- a/Resources/Prototypes/_Shitmed/Entities/Specific/Abductor/tools.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Specific/Abductor/tools.yml
@@ -282,7 +282,8 @@
         components:
         - type: Emag
           emagType: Access
-          validTargets:
+        - type: EmagWhitelist
+          whitelist:
             components:
             - Airlock
         soundStateActivate:


### PR DESCRIPTION
## About the PR
- made abductor multitool shitcode use its own component and an event instead of shitting up emag system
- aghost is now emagged so they dont announce orders, fixes #521

**Changelog**
:cl:
ADMIN:
- fix: Fixed aghost cargo orders action announcing your orders.