### PR TITLE
fix AP ignoring damage increases

### DIFF
--- a/Content.Shared/Damage/Components/DamageOtherOnHitComponent.Trauma.cs
+++ b/Content.Shared/Damage/Components/DamageOtherOnHitComponent.Trauma.cs
@@ -1,0 +1,10 @@
+namespace Content.Shared.Damage.Components;
+
+/// <summary>
+/// Trauma - add IncreaseOnly field, works the same as in ProjectileComponent.
+/// </summary>
+public sealed partial class DamageOtherOnHitComponent
+{
+    [DataField]
+    public bool IncreaseOnly;
+}

--- a/Content.Shared/Damage/Systems/SharedDamageOtherOnHitSystem.Trauma.cs
+++ b/Content.Shared/Damage/Systems/SharedDamageOtherOnHitSystem.Trauma.cs
@@ -48,7 +48,7 @@ public abstract partial class SharedDamageOtherOnHitSystem
 
         var targetPart = _gun.GetTargetPart(args.Component.Thrower, args.Target);
         var dmg = _damageable.ChangeDamage(args.Target, component.Damage * _damageable.UniversalThrownDamageModifier, component.IgnoreResistances,
-            targetPart: targetPart, origin: args.Component.Thrower);
+            targetPart: targetPart, origin: args.Component.Thrower, increaseOnly: component.IncreaseOnly);
 
         // <Goob>
         // For stuff that cares about it being attacked.

--- a/Content.Shared/EntityEffects/Effects/Damage/HealthChangeEntityEffectSystem.cs
+++ b/Content.Shared/EntityEffects/Effects/Damage/HealthChangeEntityEffectSystem.cs
@@ -56,7 +56,8 @@ public sealed partial class HealthChangeEntityEffectSystem : EntityEffectSystem<
                 interruptsDoAfters: false,
                 targetPart: args.Effect.UseTargeting ? args.Effect.TargetPart : null,
                 ignoreBlockers: args.Effect.IgnoreBlockers,
-                splitDamage: args.Effect.SplitDamage);
+                splitDamage: args.Effect.SplitDamage,
+                increaseOnly: args.Effect.IncreaseOnly); // Trauma
     }
 }
 
@@ -90,7 +91,10 @@ public sealed partial class HealthChange : EntityEffectBase<HealthChange>
 
     [DataField]
     public bool IgnoreBlockers = true;
-    // </Shitmed>
+
+    [DataField]
+    public bool IncreaseOnly;
+    // </Trauma>
 
     public override string EntityEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
         {

--- a/Content.Shared/Execution/SharedExecutionSystem.Trauma.cs
+++ b/Content.Shared/Execution/SharedExecutionSystem.Trauma.cs
@@ -1,0 +1,24 @@
+using Content.Shared.Body.Components;
+using Content.Shared.Body.Part;
+using Content.Shared.Body.Systems;
+using Content.Shared._Shitmed.Medical.Surgery.Wounds.Systems;
+
+namespace Content.Shared.Execution;
+
+public sealed partial class SharedExecutionSystem
+{
+    [Dependency] private readonly SharedBodySystem _body = default!;
+    [Dependency] private readonly WoundSystem _wound = default!;
+
+    private void Decapitation(EntityUid victim)
+    {
+        if (!TryComp<BodyComponent>(victim, out var body))
+            return;
+
+        var ent = (victim, body);
+        if (_body.FindPart(ent, BodyPartType.Head) is not {} head || _body.FindPart(ent, BodyPartType.Chest) is not {} chest)
+            return;
+
+        _wound.AmputateWoundable(chest, head);
+    }
+}

--- a/Content.Shared/Execution/SharedExecutionSystem.cs
+++ b/Content.Shared/Execution/SharedExecutionSystem.cs
@@ -1,15 +1,3 @@
-// SPDX-FileCopyrightText: 2024 Celene <4323352+CuteMoonGod@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 Celene <maurice_riepert94@web.de>
-// SPDX-FileCopyrightText: 2024 Mervill <mervills.email@gmail.com>
-// SPDX-FileCopyrightText: 2024 Plykiya <58439124+Plykiya@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 Scribbles0 <91828755+Scribbles0@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2025 Piras314 <p1r4s@proton.me>
-// SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
-//
-// SPDX-License-Identifier: AGPL-3.0-or-later
-
 using Content.Shared.ActionBlocker;
 using Content.Shared.Chat;
 using Content.Shared.CombatMode;
@@ -26,15 +14,13 @@ using Content.Shared.Weapons.Melee.Events;
 using Content.Shared.Interaction.Events;
 using Robust.Shared.Player;
 using Robust.Shared.Audio.Systems;
-using Content.Shared.Body.Part; // Goobstation decapitation
-using Content.Shared.Body.Systems; // Goobstation decapitation
-using Content.Shared._Shitmed.Medical.Surgery.Wounds.Systems; // Goobstation decapitation
+
 namespace Content.Shared.Execution;
 
 /// <summary>
 ///     Verb for violently murdering cuffed creatures.
 /// </summary>
-public sealed class SharedExecutionSystem : EntitySystem
+public sealed partial class SharedExecutionSystem : EntitySystem // Trauma - made partial
 {
     [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
@@ -45,8 +31,6 @@ public sealed class SharedExecutionSystem : EntitySystem
     [Dependency] private readonly SharedCombatModeSystem _combat = default!;
     [Dependency] private readonly SharedExecutionSystem _execution = default!;
     [Dependency] private readonly SharedMeleeWeaponSystem _melee = default!;
-    [Dependency] private readonly WoundSystem _wounds = default!; // Goobstation decapitation
-    [Dependency] private readonly SharedBodySystem _body = default!; // Goobstation decapitation
 
     /// <inheritdoc/>
     public override void Initialize()
@@ -166,7 +150,7 @@ public sealed class SharedExecutionSystem : EntitySystem
         args.Handled = true;
     }
 
-    public void ShowExecutionInternalPopup(string locString, EntityUid attacker, EntityUid victim, EntityUid weapon, bool predict = true) // Made public by goobstation
+    public void ShowExecutionInternalPopup(string locString, EntityUid attacker, EntityUid victim, EntityUid weapon, bool predict = true) // Goob - Made public
     {
         if (predict)
         {
@@ -188,7 +172,7 @@ public sealed class SharedExecutionSystem : EntitySystem
         }
     }
 
-    public void ShowExecutionExternalPopup(string locString, EntityUid attacker, EntityUid victim, EntityUid weapon) // Made public by goobstation
+    public void ShowExecutionExternalPopup(string locString, EntityUid attacker, EntityUid victim, EntityUid weapon) // Goob - Made public
     {
         _popup.PopupEntity(
             Loc.GetString(locString, ("attacker", Identity.Entity(attacker, EntityManager)), ("victim", Identity.Entity(victim, EntityManager)), ("weapon", weapon)),
@@ -233,8 +217,10 @@ public sealed class SharedExecutionSystem : EntitySystem
         else
         {
             _melee.AttemptLightAttack(attacker, weapon, meleeWeaponComp, victim);
-            if (entity.Comp.Decapitation)// Goobstation Decapitation
+            // <Goob>
+            if (entity.Comp.Decapitation)
                 Decapitation(victim);
+            // </Goob>
         }
 
         _combat.SetInCombatMode(attacker, prev);
@@ -247,27 +233,4 @@ public sealed class SharedExecutionSystem : EntitySystem
             _execution.ShowExecutionExternalPopup(externalMsg, attacker, victim, entity);
         }
     }
-
-    // Goobatation  start Decapitation
-    private void Decapitation(EntityUid victim)
-    {
-        var bodyparts = _body.GetBodyChildren(victim);
-
-        var head = new EntityUid?();
-        var body = new EntityUid?();
-
-        foreach (var bodypart in bodyparts)
-        {
-            if (bodypart.Component.PartType == BodyPartType.Chest)
-                body = bodypart.Id;
-            if (bodypart.Component.PartType == BodyPartType.Head)
-                head = bodypart.Id;
-        }
-
-        if(!head.HasValue || !body.HasValue)
-            return;
-
-        _wounds.AmputateWoundable(body.Value,head.Value);
-    }
-    // Goobstation end
 }

--- a/Content.Shared/Projectiles/ProjectileComponent.Trauma.cs
+++ b/Content.Shared/Projectiles/ProjectileComponent.Trauma.cs
@@ -1,0 +1,33 @@
+using System.Numerics;
+using Robust.Shared.Map;
+using Robust.Shared.Physics.Dynamics;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+
+namespace Content.Shared.Projectiles;
+
+/// <summary>
+/// Trauma - extensions to projectile for damage and targeting changes.
+/// </summary>
+public sealed partial class ProjectileComponent
+{
+    /// <summary>
+    /// When <see cref="IgnoreResistances"/> is false, only allow modifier events to increase damage.
+    /// </summary>
+    [DataField]
+    public bool IncreaseOnly;
+
+    [DataField]
+    public bool Penetrate;
+
+    /// <summary>
+    ///     Collision mask of what not to penetrate if <see cref="Penetrate"/> is true.
+    /// </summary>
+    [DataField(customTypeSerializer: typeof(FlagSerializer<CollisionMask>))]
+    public int NoPenetrateMask = 0;
+
+    [NonSerialized]
+    public List<EntityUid> IgnoredEntities = new();
+
+    [DataField]
+    public Vector2 TargetCoordinates;
+}

--- a/Content.Shared/Projectiles/ProjectileComponent.cs
+++ b/Content.Shared/Projectiles/ProjectileComponent.cs
@@ -1,9 +1,3 @@
-// <Trauma>
-using System.Numerics;
-using Robust.Shared.Map;
-using Robust.Shared.Physics.Dynamics;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
-// </Trauma>
 using Content.Shared.Damage;
 using Content.Shared.FixedPoint;
 using Robust.Shared.Audio;
@@ -106,19 +100,5 @@ public sealed partial class ProjectileComponent : Component
     public FixedPoint2 PenetrationAmount = FixedPoint2.Zero;
 
     // Goobstation start
-    [DataField]
-    public bool Penetrate;
-
-    /// <summary>
-    ///     Collision mask of what not to penetrate if <see cref="Penetrate"/> is true.
-    /// </summary>
-    [DataField(customTypeSerializer: typeof(FlagSerializer<CollisionMask>))]
-    public int NoPenetrateMask = 0;
-
-    [NonSerialized]
-    public List<EntityUid> IgnoredEntities = new();
-
-    [DataField]
-    public Vector2 TargetCoordinates;
     // Goobstation end
 }

--- a/Content.Shared/_Shitmed/Damage/Systems/DamageableSystem.Parts.cs
+++ b/Content.Shared/_Shitmed/Damage/Systems/DamageableSystem.Parts.cs
@@ -63,7 +63,8 @@ public sealed partial class DamageableSystem
         float partMultiplier,
         bool ignoreBlockers = false,
         SplitDamageBehavior splitDamageBehavior = SplitDamageBehavior.Split,
-        bool canMiss = true)
+        bool canMiss = true,
+        bool increaseOnly = false)
     {
         var adjustedDamage = damage * partMultiplier;
         // This cursed shitcode lets us know if the target part is a power of 2
@@ -195,7 +196,7 @@ public sealed partial class DamageableSystem
         var rand = new System.Random(seed);
         var chosenTarget = rand.PickAndTake(possibleTargets);
         return ChangeDamage(chosenTarget.Id, adjustedDamage, ignoreResistances,
-            interruptsDoAfters, origin, ignoreBlockers: ignoreBlockers);
+            interruptsDoAfters, origin, ignoreBlockers: ignoreBlockers, increaseOnly: increaseOnly);
     }
 
     public List<float> GetDamageVariationMultipliers(EntityUid uid, float variation, int count)

--- a/Content.Trauma.Shared/Projectiles/PredictedProjectileSystem.cs
+++ b/Content.Trauma.Shared/Projectiles/PredictedProjectileSystem.cs
@@ -135,7 +135,7 @@ public sealed class PredictedProjectileSystem : EntitySystem
         var deleted = Deleted(target);
 
         var canMiss = executed == null; // if you are executing someone its PB, no missing
-        if (_damageable.TryChangeDamage((target, damageable), ev.Damage, out var damage, comp.IgnoreResistances, origin: shooter, targetPart: targetPart, canMiss: canMiss) && Exists(shooter))
+        if (_damageable.TryChangeDamage((target, damageable), ev.Damage, out var damage, comp.IgnoreResistances, origin: shooter, targetPart: targetPart, canMiss: canMiss, increaseOnly: comp.IncreaseOnly) && Exists(shooter))
         {
             if (!deleted && _net.IsServer) // intentionally not predicting so you know if color flashes its 100% a hit
             {

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -170,7 +170,7 @@
     damage:
       types:
         Piercing: 11 # 20% decrease
-    ignoreResistances: true
+    increaseOnly: true # Trauma - apply modifiers, but ignore decreases
 
 - type: entity
   id: BaseBulletUranium

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -430,7 +430,7 @@
     removalTime: 1.5
   - type: LandAtCursor
   - type: DamageOtherOnHit
-    ignoreResistances: true
+    increaseOnly: true # Trauma - apply modifiers, but ignore decreases
     damage:
       types:
         Slash: 10

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/croissant.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/croissant.yml
@@ -26,7 +26,7 @@
     sound: /Audio/Weapons/star_hit.ogg
   - type: LandAtCursor
   - type: DamageOtherOnHit
-    ignoreResistances: true
+    increaseOnly: true # Trauma - apply modifiers, but ignore decreases
     damage:
       types:
         Slash: 5


### PR DESCRIPTION
changed AP ammo to a new increaseOnly bool for changing damage which applies modifiers but ignores any that decrease damage (most armor)

## Media
magdumping regular python into deathsquad, damage is still reduced
<img width="296" height="193" alt="12:45:48" src="https://github.com/user-attachments/assets/93f7c04c-9148-4cc9-bf43-179c0a11d471" />

shot ap python once, full damage
<img width="285" height="192" alt="12:45:57" src="https://github.com/user-attachments/assets/eb3d570d-8171-4d1b-8d55-013027def103" />

executing works on deathsquad
<img width="301" height="215" alt="12:46:23" src="https://github.com/user-attachments/assets/5880a450-def0-4897-ba68-274b39b591c4" />

**Changelog**
:cl:
- fix: Fixed AP weapons ignoring damage increases like species downsides or executions.