### PR TITLE
limit slime steroids to 8 extracts 6 offspring

### DIFF
--- a/Content.Goobstation.Shared/EntityEffects/Effects/ModifySlimeComponent.cs
+++ b/Content.Goobstation.Shared/EntityEffects/Effects/ModifySlimeComponent.cs
@@ -25,6 +25,18 @@ public sealed partial class ModifySlimeComponent : EntityEffectBase<ModifySlimeC
     public int OffspringBonus;
 
     /// <summary>
+    /// Limit on extracts produced which cannot be exceeded.
+    /// </summary>
+    [DataField]
+    public int ExtractLimit = 8;
+
+    /// <summary>
+    /// Limit on offspring which cannot be exceeded.
+    /// </summary>
+    [DataField]
+    public int OffspringLimit = 6;
+
+    /// <summary>
     /// How much will we increase/decrease the mutation chance?
     /// </summary>
     [DataField]
@@ -41,8 +53,9 @@ public sealed class ModifySlimeComponentEffectSystem : EntityEffectSystem<SlimeC
         var slime = ent.Comp;
         var effect = args.Effect;
         slime.ExtractsProduced += effect.ExtractBonus;
+        slime.ExtractsProduced = Math.Min(slime.ExtractsProduced, effect.ExtractLimit);
         slime.MaxOffspring += effect.OffspringBonus;
-
+        slime.MaxOffspring = Math.Min(slime.MaxOffspring, effect.OffspringLimit);
         slime.MutationChance = Math.Clamp(slime.MutationChance + effect.ChanceModifier, 0f, 1f);
         Dirty(ent);
     }


### PR DESCRIPTION
## About the PR
fixes #538

chud that took over xenobio never added a cap for it

**Changelog**
:cl:
- fix: Fixed slime steroids letting you make infinite slimes, it's capped to 6 max now.
- tweak: Capped slime extracts to 8 max.