### PR TITLE
add use in hand mode to interactor + verbs

### DIFF
--- a/Content.Goobstation.Server/Factory/InteractorSystem.cs
+++ b/Content.Goobstation.Server/Factory/InteractorSystem.cs
@@ -42,16 +42,12 @@ public sealed class InteractorSystem : SharedInteractorSystem
             return;
         }
 
-        // nothing there
-        if (FindTarget(ent) is not {} target)
-        {
-            Machine.Failed(ent.Owner);
-            return;
-        }
+        // skip finding a target for use in hand, it's unused.
+        var target = ent.Comp.UseInHand ? null : FindTarget(ent);
 
         _constructionQuery.TryComp(target, out var construction);
         var originalCount = construction?.InteractionQueue.Count ?? 0;
-        if (!InteractWith(ent, target))
+        if (!TryInteractWith(ent, target))
         {
             // have to remove it since user's filter was bad due to unhandled interaction
             Machine.Failed(ent.Owner);

--- a/Content.Goobstation.Shared/Factory/InteractorComponent.cs
+++ b/Content.Goobstation.Shared/Factory/InteractorComponent.cs
@@ -24,10 +24,22 @@ public sealed partial class InteractorComponent : Component
     public ProtoId<SinkPortPrototype> AltInteractPort = "AltInteract";
 
     /// <summary>
+    /// Signal port to toggle or enable/disable <see cref="UseInHand"/>.
+    /// </summary>
+    [DataField]
+    public ProtoId<SinkPortPrototype> UseInHandPort = "UseInHand";
+
+    /// <summary>
     /// Whether to use alt interaction, i.e. use the highest priority verb on the target entity.
     /// </summary>
     [DataField, AutoNetworkedField]
     public bool AltInteract;
+
+    /// <summary>
+    /// Whether to use the item inhand, ignores target entities.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool UseInHand;
 }
 
 [Serializable, NetSerializable]

--- a/Resources/Locale/en-US/_Goobstation/factory/interactor.ftl
+++ b/Resources/Locale/en-US/_Goobstation/factory/interactor.ftl
@@ -1,0 +1,12 @@
+interactor-verb-toggle-alt-interact = Toggle Alt Interact Mode
+interactor-verb-toggled-alt-interact = {$enabled ->
+    [true]Enabled
+    *[false]Disabled
+} alt interact mode.
+interactor-verb-toggle-use-in-hand = Toggle Use In Hand Mode
+interactor-verb-toggled-use-in-hand = {$enabled ->
+    [true]Enabled
+    *[false]Disabled
+} use in hand mode.
+
+interactor-verb-no-screwdriver = You need a screwdriver

--- a/Resources/Locale/en-US/_Goobstation/machines/automation.ftl
+++ b/Resources/Locale/en-US/_Goobstation/machines/automation.ftl
@@ -92,13 +92,16 @@ signal-port-description-machine-failed = Signal port that gets pulsed after a ma
 signal-port-name-automation-slot-tool = Item: Tool
 signal-port-description-automation-slot-tool = An automation slot for an interactor's held tool.
 
+signal-port-name-alt-interact = Alt Interact Mode
+signal-port-description-alt-interact = Signal port to toggle alt interact mode, or set it to a HIGH/LOW value.
+
+signal-port-name-use-in-hand = Use In Hand Mode
+signal-port-description-use-in-hand = Signal port to toggle use in hand mode, or set it to a HIGH/LOW value. This will ignore targets and use Z or Alt+Z on the held tool.
+
 # Autodoc
 
 signal-port-name-automation-slot-autodoc-hand = Item: Autodoc Hand
 signal-port-description-automation-slot-autodoc-hand = An automation slot for an autodoc's held organ/part/etc from STORE ITEM / GRAB ITEM instructions.
-
-signal-port-name-alt-interact = Alt Interact Mode
-signal-port-description-alt-interact = Signal port to toggle alt interact mode, or set it to a HIGH/LOW value.
 
 # Gas Canister
 

--- a/Resources/Prototypes/_Goobstation/DeviceLink/sink_ports.yml
+++ b/Resources/Prototypes/_Goobstation/DeviceLink/sink_ports.yml
@@ -115,6 +115,11 @@
   name: signal-port-name-alt-interact
   description: signal-port-description-alt-interact
 
+- type: sinkPort
+  id: UseInHand
+  name: signal-port-name-use-in-hand
+  description: signal-port-description-use-in-hand
+
 # Autodoc
 
 - type: sinkPort

--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/interactor.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/interactor.yml
@@ -115,6 +115,7 @@
     - Start
     - AutoStart
     - AltInteract
+    - UseInHand
   - type: DeviceLinkSource
     ports:
     - Started


### PR DESCRIPTION
## About the PR
- added use in hand setting to simulate Z / Alt+Z
- added verbs to toggle alt interact and use in hand modes while holding a screwdriver

## Media
the verbs
<img width="237" height="111" alt="12:04:16" src="https://github.com/user-attachments/assets/c7172991-1e1e-4a5c-90eb-b9a1762939aa" />

welder turns on with use in hand enabled, wow
<img width="89" height="77" alt="12:05:20" src="https://github.com/user-attachments/assets/8b4ea5b2-c46c-4d7c-91dc-d88267003e09" />
<img width="78" height="82" alt="12:05:24" src="https://github.com/user-attachments/assets/4819e317-72fb-45ea-8e4b-0b73045d4d40" />


**Changelog**
:cl:
- add: Added a Use In Hand mode to the interactor.
- add: Added verbs for the interactor to toggle settings without needing to link anything.
