### PR TITLE
fix shitmed body part appearance

### DIFF
--- a/Content.Client/Humanoid/HumanoidAppearanceSystem.cs
+++ b/Content.Client/Humanoid/HumanoidAppearanceSystem.cs
@@ -79,8 +79,7 @@ public sealed partial class HumanoidAppearanceSystem : SharedHumanoidAppearanceS
         foreach (var (key, info) in component.CustomBaseLayers)
         {
             oldLayers.Remove(key);
-            SetLayerData(entity, key, info.Id, sexMorph: false, color: info.Color,
-                overrideSkin: true); // Shitmed
+            SetLayerData(entity, key, info.Id, sexMorph: false, color: info.Color);
         }
 
         // hide old layers
@@ -97,8 +96,7 @@ public sealed partial class HumanoidAppearanceSystem : SharedHumanoidAppearanceS
         HumanoidVisualLayers key,
         string? protoId,
         bool sexMorph = false,
-        Color? color = null,
-        bool overrideSkin = false) // Shitmed
+        Color? color = null)
     {
         var component = entity.Comp1;
         var sprite = entity.Comp2;
@@ -119,8 +117,8 @@ public sealed partial class HumanoidAppearanceSystem : SharedHumanoidAppearanceS
         var proto = _prototypeManager.Index<HumanoidSpeciesSpriteLayer>(protoId);
         component.BaseLayers[key] = proto;
 
-        if (proto.MatchSkin && !overrideSkin) // Shitmed - check overrideSkin
-            layer.Color = component.SkinColor.WithAlpha(proto.LayerAlpha);
+        if (proto.MatchSkin)
+            layer.Color = (color ?? component.SkinColor).WithAlpha(proto.LayerAlpha); // Trauma - use layer color first if it's defined, for part transplants to keep original skin
 
         if (proto.BaseSprite != null)
             _sprite.LayerSetSprite((entity.Owner, sprite), layerIndex, proto.BaseSprite);

--- a/Content.Server/Humanoid/Systems/RandomHumanoidAppearanceSystem.cs
+++ b/Content.Server/Humanoid/Systems/RandomHumanoidAppearanceSystem.cs
@@ -1,13 +1,3 @@
-// SPDX-FileCopyrightText: 2022 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2022 Flipp Syder <76629141+vulppine@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2022 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2023 Leon Friedrich <60421075+ElectroJr@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2023 Visne <39844191+Visne@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 Verm <32827189+Vermidia@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
-//
-// SPDX-License-Identifier: AGPL-3.0-or-later
-
 using Content.Server.CharacterAppearance.Components;
 using Content.Shared.Humanoid;
 using Content.Shared.Preferences;


### PR DESCRIPTION
## About the PR
while debugging some genetics stuff i fixed this mochocode that broke `SetSkinColor`

bodyparts no longer override every layers color, they only do it if the part has a different color than the body's skin. the fallback logic is now in client humanoid system which is fixed

## Media
still works
<img width="121" height="111" alt="13:20:41" src="https://github.com/user-attachments/assets/b5e6b729-aa69-415f-abae-fb06d4f05ad2" />
