### PR TITLE
tweak gun prediction projectile hiding

### DIFF
--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -686,7 +686,6 @@ public abstract partial class SharedGunSystem : EntitySystem
         if (shooter != null)
             Projectiles.SetShooter(uid, projectile, shooter.Value);
 
-        Log.Debug($"client={_netManager.IsClient} Shot projectile {ToPrettyString(uid)}");
         Physics.UpdateIsPredicted(uid, physics); // Trauma - predict this shit
 
         TransformSystem.SetWorldRotation(uid, direction.ToWorldAngle() + projectile.Angle);

--- a/Content.Trauma.Client/Projectiles/HiddenProjectileComponent.cs
+++ b/Content.Trauma.Client/Projectiles/HiddenProjectileComponent.cs
@@ -1,8 +1,0 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-namespace Content.Trauma.Client.Projectiles;
-
-/// <summary>
-/// Added to make sure a projectile never has its light enabled.
-/// </summary>
-[RegisterComponent]
-public sealed partial class HiddenProjectileComponent : Component;

--- a/Content.Trauma.Shared/Projectiles/DeletingProjectileEvent.cs
+++ b/Content.Trauma.Shared/Projectiles/DeletingProjectileEvent.cs
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+namespace Content.Trauma.Shared.Projectiles;
+
+/// <summary>
+/// Event broadcast before deleting a projectile that has hit something.
+/// </summary>
+[ByRefEvent]
+public record struct DeletingProjectileEvent(EntityUid Entity);

--- a/Content.Trauma.Shared/Projectiles/PredictedProjectileSystem.cs
+++ b/Content.Trauma.Shared/Projectiles/PredictedProjectileSystem.cs
@@ -170,7 +170,11 @@ public sealed class PredictedProjectileSystem : EntitySystem
         }
 
         if ((comp.DeleteOnCollide && comp.ProjectileSpent) || (comp.NoPenetrateMask & otherFixture.CollisionLayer) != 0) // Goobstation - Make x-ray arrows not penetrate blob
+        {
+            var deleteEv = new DeletingProjectileEvent(uid);
+            RaiseLocalEvent(ref deleteEv);
             PredictedQueueDel(uid);
+        }
 
         if (comp.ImpactEffect != null && TryComp(uid, out TransformComponent? xform) && _timing.IsFirstTimePredicted)
         {


### PR DESCRIPTION
## About the PR
removed the projectile hiding thing because it's effectively the same entity teleporting back to the shooter, not a separate entity. this made it disappear where the ping was actually visible (e.g. dragon fireball)
fixes #495

need a better solution in the future