### PR TITLE
kill mouse groin

### DIFF
--- a/Resources/Prototypes/Body/Prototypes/Animal/animal.yml
+++ b/Resources/Prototypes/Body/Prototypes/Animal/animal.yml
@@ -40,17 +40,12 @@
   root: chest
   slots:
     chest:
-      part: ChestAnimal
-      connections:
-      - groin
-      organs:
-        lungs: OrganAnimalLungs
-        heart: OrganAnimalHeart
-    groin:
-      part: GroinAnimal
+      part: TorsoMouse
       connections:
       - legs
       organs:
+        lungs: OrganAnimalLungs
+        heart: OrganAnimalHeart
         stomach: OrganMouseStomach
         liver: OrganAnimalLiver
         kidneys: OrganAnimalKidneys

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -2095,6 +2095,7 @@
       tags:
       - Mouse
   - type: MobCallable
+  - type: XenoCompatible # to let egg sack surgeries work nicely...
   # </Goobstation>
 
 - type: entity

--- a/Resources/Prototypes/_Shitmed/Entities/Surgery/surgeries.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Surgery/surgeries.yml
@@ -425,7 +425,7 @@
     - SurgeryStepInsertFeature
     - SurgeryStepSealWounds
   - type: SurgeryPartCondition
-    parts: [ Groin ]
+    parts: [ Groin, Chest ]
   - type: SurgeryPartRemovedCondition
     connection: legs
     part: Leg
@@ -667,7 +667,7 @@
   name: Remove Liver
   components:
   - type: SurgeryPartCondition
-    parts: [ Groin ]
+    parts: [ Groin, Chest ]
   - type: SurgeryOrganCondition
     organ:
     - type: Liver
@@ -682,7 +682,7 @@
     - SurgeryStepInsertLiver
     - SurgeryStepSealOrganWound
   - type: SurgeryPartCondition
-    parts: [ Groin ]
+    parts: [ Groin, Chest ]
   - type: SurgeryOrganSlotCondition
     organSlot: liver
   - type: SurgeryOrganCondition
@@ -727,7 +727,7 @@
   name: Remove Stomach
   components:
   - type: SurgeryPartCondition
-    parts: [ Groin ]
+    parts: [ Groin, Chest ]
   - type: SurgeryOrganCondition
     organ:
     - type: Stomach
@@ -742,7 +742,7 @@
     - SurgeryStepInsertOrgan
     - SurgeryStepSealOrganWound
   - type: SurgeryPartCondition
-    parts: [ Groin ]
+    parts: [ Groin, Chest ]
   - type: SurgeryOrganSlotCondition
     organSlot: stomach
   - type: SurgeryOrganCondition

--- a/Resources/Prototypes/_Shitmed/Entities/Surgery/xeno_human.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Surgery/xeno_human.yml
@@ -174,7 +174,7 @@
     - SurgeryStepInsertEggSack
     - SurgeryStepSealOrganWound
   - type: SurgeryPartCondition
-    parts: [ Groin ]
+    parts: [ Chest, Groin ]
   - type: SurgeryOrganSlotCondition
     organSlot: egg_sack
   - type: SurgeryOrganCondition
@@ -238,7 +238,7 @@
   name: Remove Transplanted Egg Sack
   components:
   - type: SurgeryPartCondition
-    parts: [ Groin ]
+    parts: [ Chest, Groin ]
   - type: SurgeryOrganCondition
     organ:
     - type: EggSack

--- a/Resources/Prototypes/_Trauma/Body/Parts/mouse.yml
+++ b/Resources/Prototypes/_Trauma/Body/Parts/mouse.yml
@@ -1,0 +1,16 @@
+# combined chest and groin so you can't cut off a mouse groin and use it yourself
+# fuck you mocho
+- type: entity
+  parent: [ PartAnimalBase, BaseChest ]
+  id: TorsoMouse
+  name: mouse torso
+  components:
+  - type: Sprite
+    layers:
+    - state: chest_m
+    - state: groin_m
+  - type: BodyPart
+    children:
+      legs:
+        id: legs
+        type: Leg


### PR DESCRIPTION
## About the PR
mice now have a torso instead of chest+groin
you can no longer attach mouse groin to yourself to have free egg sack, get the xeno compat implant chuddy

mice are now xeno compatible by default so you can coincidentally give them plasma vessel, thats it

fixes #591

## Media
<img width="335" height="270" alt="16:52:49" src="https://github.com/user-attachments/assets/93d34e14-127c-40f4-82cf-dada0aad1faf" />
<img width="388" height="274" alt="16:53:26" src="https://github.com/user-attachments/assets/ad77aa0b-4af2-42d2-b1a7-f649254d5032" />
<img width="398" height="100" alt="16:36:20" src="https://github.com/user-attachments/assets/7124d685-ec0f-4be0-86fc-02528c03af7d" />

**Changelog**
:cl:
- tweak: Mice no longer have a groin part so you can't cheese the egg sack.
