### PR TITLE
Grab cooldown multiplier fix

### DIFF
--- a/Content.Shared/Movement/Pulling/Systems/PullingSystem.Trauma.cs
+++ b/Content.Shared/Movement/Pulling/Systems/PullingSystem.Trauma.cs
@@ -203,7 +203,7 @@ public sealed partial class PullingSystem
         var now = _timing.CurTime;
         var attackRateEv = new GetMeleeAttackRateEvent(puller, meleeWeapon.AttackRate, 1, puller);
         RaiseLocalEvent(puller, ref attackRateEv);
-        meleeWeapon.NextAttack = now + puller.Comp.StageChangeCooldown / attackRateEv.Multipliers; // Trauma - grab cooldown multipliers fix
+        meleeWeapon.NextAttack = now + puller.Comp.StageChangeCooldown / attackRateEv.Multipliers;
         DirtyField(puller, meleeWeapon, nameof(MeleeWeaponComponent.NextAttack));
 
         var beforeEvent = new BeforeHarmfulActionEvent(puller, HarmfulActionType.Grab);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->
Capoerias insane attackspeed was actually crippling your ability to upgrade grabs
today I will commit the sin of blindly trusting https://github.com/Goob-Station/Goob-Station/pull/5929 c# commit and pretend the issue persists since our upstream merges.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Capoeria sweepkick now properly applies its grabspeed increase, instead of reducing it.