### PR TITLE
make base lavaland mob weather immune

### DIFF
--- a/Resources/Prototypes/_Lavaland/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Mobs/base.yml
@@ -44,3 +44,4 @@
   - type: Tag
     tags:
     - DoorBumpOpener
+  - type: WeatherImmune


### PR DESCRIPTION
fuck you roden

:cl:
- fix: Fixed new lavaland mobs dying from ash storms.