### PR TITLE
fix smart equip for guns removing mag

### DIFF
--- a/Content.Shared/Containers/ItemSlot/ItemSlotsComponent.Trauma.cs
+++ b/Content.Shared/Containers/ItemSlot/ItemSlotsComponent.Trauma.cs
@@ -1,7 +1,20 @@
 namespace Content.Shared.Containers.ItemSlots;
 
 /// <summary>
-/// Trauma - add lavaland related fields
+/// Trauma - add SmartEquip bool
+/// </summary>
+public sealed partial class ItemSlotsComponent
+{
+    /// <summary>
+    /// Allows smart equip keybinds (e.g. F for suit storage) to take and insert items.
+    /// The default of false will just put the item itself into your hands.
+    /// </summary>
+    [DataField]
+    public bool SmartEquip;
+}
+
+/// <summary>
+/// Trauma - add lavaland related fields for a slot
 /// </summary>
 public sealed partial class ItemSlot
 {

--- a/Content.Shared/Interaction/SmartEquipSystem.cs
+++ b/Content.Shared/Interaction/SmartEquipSystem.cs
@@ -1,12 +1,3 @@
-// SPDX-FileCopyrightText: 2023 Kara <lunarautomaton6@gmail.com>
-// SPDX-FileCopyrightText: 2024 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 Plykiya <58439124+Plykiya@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 plykiya <plykiya@protonmail.com>
-// SPDX-FileCopyrightText: 2024 themias <89101928+themias@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
-//
-// SPDX-License-Identifier: AGPL-3.0-or-later
-
 using Content.Shared.ActionBlocker;
 using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Hands.Components;
@@ -191,7 +182,7 @@ public sealed class SmartEquipSystem : EntitySystem
         }
 
         // case 3 (itemslot item):
-        if (TryComp<ItemSlotsComponent>(slotItem, out var slots))
+        if (TryComp<ItemSlotsComponent>(slotItem, out var slots) && slots.SmartEquip) // Trauma - check SmartEquip bool
         {
             if (handItem == null)
             {

--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -14,6 +14,7 @@
   - type: Item
     size: Ginormous
   - type: ItemSlots
+    smartEquip: true # Trauma
     slots:
       item:
         name: Sabre


### PR DESCRIPTION
## About the PR
items now opt in to smart equip for item slots, currently just sheaths but it can by ymlmaxxed in 1 line for whatever else might need it
fixes #610

hos cap and cc sheath all still work, guns now actually equip instead of trying to take the mag out :face_holding_back_tears: 

**Changelog**
:cl:
- fix: Fixed smart equip trying to take mags out of guns instead of equipping them.
