### PR TITLE
fix agent id inheritance

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -621,10 +621,15 @@
     tags: [] # ignore "WhitelistChameleon" tag
 
 - type: entity
-  parent: [PassengerIDCard, BaseChameleon]
+  parent: [IDCardStandard, BaseChameleon] # Trauma - don't parent passenger id
   id: AgentIDCard
+  name: assistant ID card # Trauma - i hate this
   suffix: Agent
   components:
+  - type: Sprite # Trauma - i hate this
+    layers:
+    - state: default
+    - state: idpassenger
   - type: Access
     tags:
     - Maintenance


### PR DESCRIPTION
## About the PR
agent id no longer has tider preset job which was overriding syndie/rev access

fixes #617

## Media

<img width="967" height="333" alt="11:23:11" src="https://github.com/user-attachments/assets/2bf938d5-d538-457d-a5da-5d770b2f23aa" />

**Changelog**
:cl:
- fix: Fixed agent and revolutionary IDs only having maints access.
