### PR TITLE
fix heretics not being able to take holy damage ever

### DIFF
--- a/Content.Goobstation.Server/Religion/WeakToHolySystem.cs
+++ b/Content.Goobstation.Server/Religion/WeakToHolySystem.cs
@@ -96,6 +96,7 @@ public sealed class WeakToHolySystem : EntitySystem
         if (!_body.TryGetRootPart(ent, out var rootPart, body: body))
             return;
 
+        // TODO: hello why the fuck are you doing this!?
         foreach (var woundable in _wound.GetAllWoundableChildren(rootPart.Value))
         {
             if (HasComp<DamageableComponent>(woundable))

--- a/Content.Trauma.Shared/EntityEffects/SetDamageContainer.cs
+++ b/Content.Trauma.Shared/EntityEffects/SetDamageContainer.cs
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+using Content.Shared.Damage.Components;
+using Content.Shared.Damage.Systems;
+using Content.Shared.Damage.Prototypes;
+using Content.Shared.EntityEffects;
+using Robust.Shared.Prototypes;
+
+namespace Content.Trauma.Shared.EntityEffects;
+
+/// <summary>
+/// Changes the target entity's damage container to a different one.
+/// </summary>
+public sealed partial class SetDamageContainer : EntityEffectBase<SetDamageContainer>
+{
+    [DataField(required: true)]
+    public ProtoId<DamageContainerPrototype> Container;
+
+    public override string? EntityEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
+        => null; // not used by any reagents
+}
+
+public sealed class SetDamageContainerEffectSystem : EntityEffectSystem<DamageableComponent, SetDamageContainer>
+{
+    [Dependency] private readonly DamageableSystem _damage = default!;
+
+    protected override void Effect(Entity<DamageableComponent> ent, ref EntityEffectEvent<SetDamageContainer> args)
+    {
+        _damage.SetDamageContainerID(ent.AsNullable(), args.Effect.Container);
+    }
+}

--- a/Resources/Prototypes/_Goobstation/Heretic/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/GameRules/roundstart.yml
@@ -63,6 +63,10 @@
     - HereticKnowledgeObjective
     - HereticSacrificeObjective
     - HereticSacrificeHeadObjective
+  - type: AntagPlayerEffects
+    effects:
+    - !type:SetDamageContainer
+      container: BiologicalMetaphysical # allow heretics to take holy damage, crazy
   - type: AntagSelection
     selectionTime: IntraPlayerSpawn
     agentName: heretic-roundend-name


### PR DESCRIPTION
## About the PR
nothing ever changed their damage container to allow holy :face_holding_back_tears:
so made it that every heretic gets it changed to BiologicalMetaphysical

i can only assume this was lost at some point, surely it existed??

fixes #619

**Changelog**
:cl:
- fix: Fixed Heretics never being able to take holy damage.