### PR TITLE
Allow selecting species-specific languages in character editor

### DIFF
--- a/Resources/Prototypes/_Trauma/Traits/languages.yml
+++ b/Resources/Prototypes/_Trauma/Traits/languages.yml
@@ -111,19 +111,3 @@
     - NewKinPidgin
   languagesUnderstood:
     - NewKinPidgin
-
-- type: trait
-  id: RobotTalk
-  name: language-RobotTalk-name
-  description: language-RobotTalk-description
-  category: LanguageTraits
-  cost: 2
-  blacklist:
-    components:
-      - BorgChassis
-  components:
-  - type: LanguageSpeaker
-  languagesSpoken:
-    - RobotTalk
-  languagesUnderstood:
-    - RobotTalk


### PR DESCRIPTION
## About the PR
Characters can now choose to speak languages of other species. The traits cost 2 points though, so you'd have to take foreigner (or foreigner-light) to pick them.
I also wanted to add a trait that would prevent you from using your own species' language, but couldn't figure out how to do so cleanly, so I chose to leave a TODO instead.

## Why / Balance
More character customization = more gooder.
Speaking other species' language is kinda strong-ish? (and would be difficult to do in-universe for some cases), hence the increased cost.

## Technical details
YAMLmaxxing

## Media
All the new traits are conveniently highlited in red.
<img width="258" height="403" alt="изображение" src="https://github.com/user-attachments/assets/8b73509d-c2a1-4217-ae4a-49745613bb21" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

**Changelog**
:cl:
- tweak: You can now chose other species' language in character editor
