### PR TITLE
Unfuck coscult monument

### DIFF
--- a/Resources/Prototypes/_DV/CosmicCult/Tileset/monument.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/Tileset/monument.yml
@@ -30,7 +30,7 @@
         density: 1000
         hard: false
   - type: Visibility
-    layer: 32 # Trauma: unfuck vislayers
+    layer: 32
 #  - type: SpriteFade # - Supercode breaks clickability with this.
   - type: Sprite
     sprite: _DV/CosmicCult/Tileset/monument.rsi
@@ -128,7 +128,7 @@
   suffix: Spawn, DO NOT MAP
   components:
   - type: Visibility
-    layer: 32 # Trauma: unfuck vislayers
+    layer: 32
   - type: Sprite
     sprite: _DV/CosmicCult/Tileset/monument.rsi
     layers:
@@ -186,7 +186,7 @@
   suffix: Spawn, DO NOT MAP
   components:
   - type: Visibility
-    layer: 32 # Trauma: unfuck vislayers
+    layer: 32
   - type: Sprite
     sprite: _DV/CosmicCult/Tileset/monument.rsi
     layers:
@@ -241,7 +241,7 @@
   suffix: Spawn, DO NOT MAP
   components:
   - type: Visibility
-    layer: 32 # Trauma: unfuck vislayers
+    layer: 32
   - type: Sprite
     sprite: _DV/CosmicCult/Tileset/monument.rsi
     layers:

--- a/Resources/Prototypes/_Goobstation/Heretic/Entities/Structures/Specific/Heretic/eldritch_influence.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Entities/Structures/Specific/Heretic/eldritch_influence.yml
@@ -71,7 +71,7 @@
     state: icon
   - type: Clickable
   - type: Visibility
-    layer: 64 # keep in sync with VisibilityFlags.EldritchInfluence for upstream merges # Trauma: 32 -> 64
+    layer: 64 # keep in sync with VisibilityFlags.EldritchInfluence for upstream merges
 
 - type: entity
   id: EldritchInfluenceIntermediate
@@ -94,6 +94,6 @@
     sprite: _Goobstation/Heretic/reality_fracture.rsi
     state: icon_harvested
   - type: Visibility
-    layer: 64 # Trauma: 32 -> 64
+    layer: 64
   - type: EldritchInfluence
     spent: true


### PR DESCRIPTION
## About the PR
It was invisible because someone screwed up visibility layers. Heretics probably suffer from the same issue, I'll check shortly and fix if needed.

## Why / Balance
Cultists kinda need to see their own monument.
Fixes #627 

## Technical details
16 -> 32

## Media
Nein

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.


**Changelog**
:cl:
- fix: Cosmic cultists can see their own monument again.
- fix: Heretics can see reality shifts again.
