### PR TITLE
TACTICAL  ESPIONAGE  ACTION

### DIFF
--- a/Content.Server/CardboardBox/CardboardBoxSystem.cs
+++ b/Content.Server/CardboardBox/CardboardBoxSystem.cs
@@ -1,3 +1,6 @@
+// <Trauma>
+using Content.Trauma.Common.CardboardBox;
+// </Trauma>
 using Content.Server.Storage.EntitySystems;
 using Content.Shared.Access.Components;
 using Content.Shared.CardboardBox;
@@ -77,6 +80,15 @@ public sealed class CardboardBoxSystem : SharedCardboardBoxSystem
         //Play effect & sound
         if (component.Mover != null)
         {
+            // <Trauma>
+            var attemptEv = new BoxAlertAttemptEvent();
+            RaiseLocalEvent(uid, ref attemptEv);
+            if (attemptEv.Cancelled)
+                return;
+
+            var ev = new BoxAlertedEvent();
+            RaiseLocalEvent(uid, ref ev);
+            // </Trauma>
             if (_timing.CurTime > component.EffectCooldown)
             {
                 RaiseNetworkEvent(new PlayBoxEffectMessage(GetNetEntity(uid), GetNetEntity(component.Mover.Value)));
@@ -94,6 +106,12 @@ public sealed class CardboardBoxSystem : SharedCardboardBoxSystem
 
     private void AfterStorageClosed(EntityUid uid, CardboardBoxComponent component, ref StorageAfterCloseEvent args)
     {
+        // <Trauma>
+        var attemptEv = new BoxStealthAttemptEvent();
+        RaiseLocalEvent(uid, ref attemptEv);
+        if (attemptEv.Cancelled)
+            return;
+        // </Trauma>
         // If this box has a stealth/chameleon effect, enable the stealth effect.
         if (TryComp(uid, out StealthComponent? stealth))
         {

--- a/Content.Shared/CardboardBox/Components/CardboardBoxComponent.cs
+++ b/Content.Shared/CardboardBox/Components/CardboardBoxComponent.cs
@@ -1,12 +1,3 @@
-// SPDX-FileCopyrightText: 2022 keronshb <54602815+keronshb@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2023 Ilya246 <57039557+Ilya246@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2023 Leon Friedrich <60421075+ElectroJr@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2023 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
-//
-// SPDX-License-Identifier: MIT
-
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Serialization;

--- a/Content.Shared/CardboardBox/SharedCardboardBoxSystem.cs
+++ b/Content.Shared/CardboardBox/SharedCardboardBoxSystem.cs
@@ -1,8 +1,3 @@
-// SPDX-FileCopyrightText: 2022 keronshb <54602815+keronshb@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
-//
-// SPDX-License-Identifier: MIT
-
 namespace Content.Shared.CardboardBox;
 
 public abstract class SharedCardboardBoxSystem : EntitySystem

--- a/Content.Trauma.Common/CardboardBox/BoxAlertAttemptEvent.cs
+++ b/Content.Trauma.Common/CardboardBox/BoxAlertAttemptEvent.cs
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+namespace Content.Trauma.Common.CardboardBox;
+
+/// <summary>
+/// Event raised on a cardboard box to prevent the alert sound+effect.
+/// </summary>
+[ByRefEvent]
+public record struct BoxAlertAttemptEvent(bool Cancelled = false);

--- a/Content.Trauma.Common/CardboardBox/BoxAlertedEvent.cs
+++ b/Content.Trauma.Common/CardboardBox/BoxAlertedEvent.cs
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+namespace Content.Trauma.Common.CardboardBox;
+
+/// <summary>
+/// Event raised on a cardboard box when an alert effect has been played.
+/// </summary>
+[ByRefEvent]
+public record struct BoxAlertedEvent();

--- a/Content.Trauma.Common/CardboardBox/BoxStealthAttemptEvent.cs
+++ b/Content.Trauma.Common/CardboardBox/BoxStealthAttemptEvent.cs
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+namespace Content.Trauma.Common.CardboardBox;
+
+/// <summary>
+/// Event raised on a cardboard box to prevent enabling stealth for it.
+/// </summary>
+[ByRefEvent]
+public record struct BoxStealthAttemptEvent(bool Cancelled = false);

--- a/Content.Trauma.Shared/CardboardBox/DisabledBoxComponent.cs
+++ b/Content.Trauma.Shared/CardboardBox/DisabledBoxComponent.cs
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+
+namespace Content.Trauma.Shared.CardboardBox;
+
+/// <summary>
+/// Component added to boxes that are disabled from its opening being witnessed.
+/// When removed it will try to re-enable stealth.
+/// </summary>
+[RegisterComponent, NetworkedComponent, Access(typeof(JustABoxSystem))]
+[AutoGenerateComponentState, AutoGenerateComponentPause]
+public sealed partial class DisabledBoxComponent : Component
+{
+    /// <summary>
+    /// When stealth can next be enabled.
+    /// </summary>
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
+    [AutoNetworkedField, AutoPausedField]
+    public TimeSpan NextStealth;
+}

--- a/Content.Trauma.Shared/CardboardBox/JustABoxComponent.cs
+++ b/Content.Trauma.Shared/CardboardBox/JustABoxComponent.cs
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+using Robust.Shared.GameStates;
+
+namespace Content.Trauma.Shared.CardboardBox;
+
+/// <summary>
+/// Disables a box's stealth when opened near witnesses (people outside of it)
+/// It will re-enable after <see cref="StealthCooldown"/>.
+/// Huh?
+/// </summary>
+/// <remarks>
+/// Just a box...
+/// </remarks>
+[RegisterComponent, NetworkedComponent, Access(typeof(JustABoxSystem))]
+public sealed partial class JustABoxComponent : Component
+{
+    /// <summary>
+    /// How long it gets put on cooldown after being opened near witnesses.
+    /// </summary>
+    [DataField]
+    public TimeSpan StealthCooldown = TimeSpan.FromSeconds(40);
+
+    /// <summary>
+    /// Range to look for witnesses in.
+    /// </summary>
+    [DataField]
+    public float WitnessRange = 6f;
+}

--- a/Content.Trauma.Shared/CardboardBox/JustABoxSystem.cs
+++ b/Content.Trauma.Shared/CardboardBox/JustABoxSystem.cs
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+using Content.Shared.Examine;
+using Content.Shared.Stealth;
+using Content.Shared.Stealth.Components;
+using Content.Shared.Storage.EntitySystems;
+using Content.Trauma.Common.CardboardBox;
+using Content.Trauma.Shared.Mobs;
+using Robust.Shared.Timing;
+
+namespace Content.Trauma.Shared.CardboardBox;
+
+public sealed class JustABoxSystem : EntitySystem
+{
+    [Dependency] private readonly EntityLookupSystem _lookup = default!;
+    [Dependency] private readonly ExamineSystemShared _examine = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly SharedEntityStorageSystem _entityStorage = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly SharedStealthSystem _stealth = default!;
+
+    /// <summary>
+    /// Flags to look for witnesses.
+    /// Does not have contained, so being in the box won't trigger an alert.
+    /// </summary>
+    public const LookupFlags Flags = LookupFlags.Dynamic | LookupFlags.Static;
+
+    private HashSet<Entity<AwakeMobComponent>> _witnesses = new();
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<JustABoxComponent, BoxAlertAttemptEvent>(OnAlertAttempt);
+        SubscribeLocalEvent<JustABoxComponent, BoxAlertedEvent>(OnAlerted);
+
+        SubscribeLocalEvent<DisabledBoxComponent, BoxAlertAttemptEvent>(OnDisabledAlertAttempt);
+        SubscribeLocalEvent<DisabledBoxComponent, BoxStealthAttemptEvent>(OnDisabledStealthAttempt);
+        SubscribeLocalEvent<DisabledBoxComponent, ComponentRemove>(OnDisabledRemove);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var query = EntityQueryEnumerator<DisabledBoxComponent>();
+        var now = _timing.CurTime;
+        while (query.MoveNext(out var uid, out var comp))
+        {
+            if (comp.NextStealth > now)
+                continue;
+
+            RemCompDeferred(uid, comp);
+        }
+    }
+
+    private void OnAlertAttempt(Entity<JustABoxComponent> ent, ref BoxAlertAttemptEvent args)
+    {
+        // no alert if you open it unseen
+        args.Cancelled |= WasUnseen(ent);
+    }
+
+    private void OnAlerted(Entity<JustABoxComponent> ent, ref BoxAlertedEvent args)
+    {
+        var disabled = EnsureComp<DisabledBoxComponent>(ent);
+        disabled.NextStealth = _timing.CurTime + ent.Comp.StealthCooldown;
+        Dirty(ent, disabled);
+    }
+
+    private void OnDisabledAlertAttempt(Entity<DisabledBoxComponent> ent, ref BoxAlertAttemptEvent args)
+    {
+        args.Cancelled = true;
+    }
+
+    private void OnDisabledStealthAttempt(Entity<DisabledBoxComponent> ent, ref BoxStealthAttemptEvent args)
+    {
+        args.Cancelled = true;
+    }
+
+    private void OnDisabledRemove(Entity<DisabledBoxComponent> ent, ref ComponentRemove args)
+    {
+        if (TerminatingOrDeleted(ent) || // don't care
+            _entityStorage.IsOpen(ent.Owner) || // it will re-stealth when closed later
+            !TryComp<StealthComponent>(ent, out var stealth))
+            return;
+
+        _stealth.SetVisibility(ent.Owner, stealth.MaxVisibility, stealth);
+        _stealth.SetEnabled(ent.Owner, true, stealth);
+    }
+
+    public bool WasUnseen(Entity<JustABoxComponent> ent)
+    {
+        var coords = Transform(ent).Coordinates;
+        var mapCoords = _transform.ToMapCoordinates(coords);
+        var range = ent.Comp.WitnessRange;
+        _witnesses.Clear();
+        _lookup.GetEntitiesInRange(coords, range, _witnesses, Flags);
+        foreach (var witness in _witnesses)
+        {
+            var pos = _transform.GetMapCoordinates(witness.Owner);
+            if (_examine.InRangeUnOccluded(mapCoords, pos, range, predicate: null))
+                return false; // !
+        }
+
+        return true;
+    }
+}

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/big_boxes.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/big_boxes.yml
@@ -24,6 +24,7 @@
   description: Huh? Just a box...
   abstract: true
   components:
+    - type: JustABox # Trauma - just a box...
     - type: Transform
       noRot: true
     - type: Clickable
@@ -86,7 +87,8 @@
     - type: Damageable
       damageModifierSet: FlimsyMetallic #Syndicate boxes should have a bit of protection
     - type: CardboardBox
-      quiet: true
+      effectSound: /Audio/_Goobstation/Voice/surprised.ogg # Trauma - more impactful sound
+      quiet: false # Trauma - false so custom logic can be used to control it
     - type: Stealth
       hadOutline: true
     - type: StealthOnMove


### PR DESCRIPTION
## About the PR
resolves #658

stealth box loses its stealth power for 40 seconds after you open it near a mob that can see it
it also has the ! sound

## Why / Balance
mgs4 pc port soon, august 27th 2022 pyro tf2 incident

**Changelog**
:cl:
- tweak: Stealth box now loses stealth for 40 seconds if you open it near other mobs. Occupants are ignored.
