### PR TITLE
Entropic colossus fixes

### DIFF
--- a/Content.Server/_DV/CosmicCult/EntitySystems/CosmicColossusSystem.cs
+++ b/Content.Server/_DV/CosmicCult/EntitySystems/CosmicColossusSystem.cs
@@ -25,14 +25,14 @@ public sealed class CosmicColossusSystem : SharedCosmicColossusSystem
 
     private void OnSpawn(Entity<CosmicColossusComponent> ent, ref ComponentInit args) // I WANT THIS BIG GUY HURLED TOWARDS THE STATION
     {
+        if (!ent.Comp.Timed) return;
         ent.Comp.DeathTimer = _timing.CurTime + ent.Comp.DeathWait;
         if (_station.GetStationInMap(Transform(ent).MapID) is { } station && TryComp<StationDataComponent>(station, out var stationData))
         {
             var stationGrid = _station.GetLargestGrid((station, stationData));
             _throw.TryThrow(ent, Transform(stationGrid!.Value).Coordinates, baseThrowSpeed: 30, null, 0, 0, false, false, false, false, false);
         }
-        if (ent.Comp.Timed)
-            _actions.AddAction(ent, ref ent.Comp.EffigyPlaceActionEntity, ent.Comp.EffigyPlaceAction, ent);
+        _actions.AddAction(ent, ref ent.Comp.EffigyPlaceActionEntity, ent.Comp.EffigyPlaceAction, ent);
     }
 
     protected override void OnColossusEffigy(Entity<CosmicColossusComponent> ent, ref EventCosmicColossusEffigy args)

--- a/Content.Shared/_DV/CosmicCult/Components/CosmicColossusComponent.cs
+++ b/Content.Shared/_DV/CosmicCult/Components/CosmicColossusComponent.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Whitelist;
 using Robust.Shared.Audio;
 using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
@@ -62,7 +63,7 @@ public sealed partial class CosmicColossusComponent : Component
 
     [DataField] public float SunderThrowDistance = 3f;
 
-    [DataField] public TimeSpan SunderStun = TimeSpan.FromSeconds(2);
+    [DataField] public TimeSpan SunderStun = TimeSpan.FromSeconds(1);
 
     [DataField] public TimeSpan IngressDoAfter = TimeSpan.FromSeconds(4);
 
@@ -97,6 +98,12 @@ public sealed partial class CosmicColossusComponent : Component
 
     [ViewVariables]
     public EntityUid? ImprisonedEntity => Container?.ContainedEntity;
+
+    /// <summary>
+    ///     Entities not affected by entropic sunder
+    /// </summary>
+    [DataField(required: true)]
+    public EntityWhitelist SunderBlacklist = new();
 }
 
 [Serializable, NetSerializable]

--- a/Resources/Locale/en-US/_DV/cosmiccult/ghostroles.ftl
+++ b/Resources/Locale/en-US/_DV/cosmiccult/ghostroles.ftl
@@ -33,7 +33,7 @@ ghost-role-colossus-effigy-confirm = If placement is  valid, press again to Beck
 
 ghost-role-colossus-effigy-error-grid = Invalid location! An Effigy must be beckoned upon a stable surface.
 ghost-role-colossus-effigy-error-location = Invalid location! The Effigy must be beckoned near {$LOCATION}.
-ghost-role-colossus-effigy-error-intersection = Too crowded! An Effigy requires an empty 3x1 area to be beckoned.
+ghost-role-colossus-effigy-error-intersection = Too crowded! An Effigy requires an empty tile to be beckoned.
 ghost-role-colossus-effigy-error-space = Too close to space! An Effigy must be be at least {$DISTANCE}m away.
 
 objective-condition-effigy-no-target = Beckon an Effigy wherever you desire.

--- a/Resources/Prototypes/_DV/CosmicCult/Mobs/colossus.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/Mobs/colossus.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ BaseSimpleMob, FlyingMobBase ]
+  parent: [ BaseMob, FlyingMobBase ]
   abstract: true
   id: MobCosmicColossusBase
   name: entropic colossus
@@ -10,10 +10,6 @@
     cultistText: cosmic-examine-text-cultentity
     othersText: cosmic-examine-text-entities
   - type: AntagImmune
-  - type: StaminaResistance
-    damageCoefficient: 0 # No more stunning colossi
-  - type: ModifyDelayedKnockdown
-    cancel: true # No batoning the colossi either
   - type: Sprite
     drawdepth: Mobs
     sprite: _DV/CosmicCult/Mobs/colossus.rsi
@@ -120,6 +116,7 @@
     - CannotSuicide
     - DoorBumpOpener
     - Unimplantable
+    - StunImmune
   - type: Damageable
     damageContainer: InorganicMetaphysical
     damageModifierSet: CosmicColossus
@@ -148,9 +145,11 @@
   - type: IntrinsicRadioReceiver
   - type: IntrinsicRadioTransmitter
     channels:
+    - Common
     - CosmicRadio
   - type: ActiveRadio
     channels:
+    - Common
     - CosmicRadio
   - type: ZombieImmune
   - type: UserInterface
@@ -211,6 +210,16 @@
     color: "#42a4ae"
     activateSound: null
     deactivateSound: null
+  - type: Polymorphable
+  - type: Pullable
+  - type: WeakToHoly
+    alwaysTakeHoly: true
+  - type: CosmicColossus
+    sunderBlacklist:
+      components:
+      - Ghost
+      - CosmicCult
+      - CosmicColossus
 
 - type: entity
   parent: [ MobCosmicColossusBase ]
@@ -224,6 +233,8 @@
     - ColossusNames
     - ColossusTitlesLone
     nameFormat: name-format-colossus
+  - type: CosmicColossus
+    timed: true
 
 - type: entity
   parent: [ MobCosmicColossusBase ]
@@ -234,7 +245,6 @@
     - ColossusNames
     - ColossusTitlesBase
     nameFormat: name-format-colossus
-  - type: CosmicColossus
 
 - type: speechSounds
   id: ColossusSpeech

--- a/Resources/Prototypes/_DV/CosmicCult/events.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/events.yml
@@ -6,10 +6,8 @@
     weight: 3
     earliestStart: 30
     reoccurrenceDelay: 20
-    minimumPlayers: 25
+    minimumPlayers: 40
     duration: null
-  #- type: PrecognitionResult # Trauma: psionics aren't real
-  #  message: psionic-power-precognition-colossus-spawn-result-message
   - type: SpaceSpawnRule
   - type: GameRule
     chaosScore: 600 # Same as dragon
@@ -32,6 +30,3 @@
         text: ghost-role-colossus-briefing
         color: CadetBlue
         sound: /Audio/_DV/CosmicCult/antag_cosmic_AI_briefing.ogg
-      components:
-      - type: CosmicColossus
-        timed: true


### PR DESCRIPTION
## About the PR
Colossus can no longer be stunned, properly takes holy damage, and doesn't push ghosts with it's groundslam.
Removed misinformation (it said that effigy needs 1x3 free space, but it actually only needs a single tile).
Nerfed entropic sunder ever so slightly (2 seconds of stun was kinda a lot).
Min

## Why / Balance
Bugs

## Technical details
Reparented colossus to BaseMob instead of BaseSimpleMob to get rid of stamina component. Minor code tweaks.

## Media
Tested, works.

## Requirements
Yes

## Breaking changes
Yesn't

**Changelog**
:cl:
- fix: Entropic colossus now takes holy damage.
- fix: Entropic colossus is no longer vulnerable to CQC.
- fix: Entropic colossus no longer pushes ghosts.
- tweak: Entropic Colossus min playercount 25 -> 40.