### PR TITLE
Change heretic round end summary text

### DIFF
--- a/Resources/Locale/en-US/_Goobstation/Heretic/game-ticking/game-presets/preset-heretic.ftl
+++ b/Resources/Locale/en-US/_Goobstation/Heretic/game-ticking/game-presets/preset-heretic.ftl
@@ -13,7 +13,7 @@ heretic-roundend-name = heretic
 roundend-prepend-heretic-ascension-success = {$name} [color=green]has Ascended![/color]
 roundend-prepend-heretic-ascension-fail = {$name} [color=red]has failed to Ascend![/color]
 roundend-prepend-heretic-ascension-fail-owls = {$name} [color=red]has forsaken Ascension and thus failed![/color]
-roundend-prepend-heretic-knowledge-named = [color=white]{$name}[/color] researched the most knowledges, having [color=purple]{$number}[/color] total. 
+roundend-prepend-heretic-knowledge-named = [color=white]{$name}[/color] researched the most knowledges, having [color=purple]{$number}[/color] total.
 
 heretic-gamemode-title = Heretics
 heretic-gamemode-description =


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
Changes some text for the round end summary for heretics. I'll probably change more later if I can figure it out.

## Why / Balance
Old version had weird grammar.

## Media
<img width="832" height="120" alt="image" src="https://github.com/user-attachments/assets/c41909a0-8ea2-4587-91f0-4a222589f696" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Changed round end summary for heretics slightly.
