### PR TITLE
Decrease cameras' health to 45

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/surveillance_camera.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/surveillance_camera.yml
@@ -114,7 +114,7 @@
             acts: [ "Destruction" ]
       - trigger:
           !type:DamageTrigger
-          damage: 75 # Goob
+          damage: 45 # Trauma
         behaviors:
           - !type:DoActsBehavior
             acts: [ "Destruction" ]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
title, inspired by https://github.com/space-wizards/space-station-14/pull/42447

## Why / Balance
Even though Goob decreased it, I feel like it could be lowered more. I picked 45 because it can be destroyed in 3 baseball bat hits, which is quite common for permabrigged prisoners. Cameras are very easily replaced and reported missing if there is an AI.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Lowered surveillance cameras' health.
