### PR TITLE
fix lobby char editor shitcode

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -1316,8 +1316,8 @@ namespace Content.Client.Lobby.UI
                 return;
             }
 
-            _markingsModel.OrganData = _markingManager.GetMarkingData(Profile.Species);
             _markingsModel.OrganProfileData = _markingManager.GetProfileData(Profile.Species, Profile.Sex, Profile.Appearance.SkinColor, Profile.Appearance.EyeColor);
+            _markingsModel.OrganData = _markingManager.GetMarkingData(Profile.Species); // Trauma - moved from above because it was breaking the UI when switching species
             _markingsModel.Markings = Profile.Appearance.Markings;
         }
 


### PR DESCRIPTION
fixes #797

lines were in the wrong order :face_holding_back_tears: so it updated the markings before the parts were changed, so it thought there was no tail part for tail markings etc
switching chars in the editor now works properly

:cl:
- fix: Fixed the lobby character editor breaking if you switched to a different species.