### PR TITLE
fix felinid deletion

### DIFF
--- a/Content.Medical.Shared/Body/Systems/BodyStatusSystem.cs
+++ b/Content.Medical.Shared/Body/Systems/BodyStatusSystem.cs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 using Content.Medical.Shared.Wounds;
+using Content.Shared.Body;
 using Content.Shared.Mobs;
 using Robust.Shared.Network;
 using Robust.Shared.Serialization;
@@ -17,6 +18,8 @@ public sealed class BodyStatusSystem : EntitySystem
 
         SubscribeLocalEvent<BodyStatusComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<BodyStatusComponent, MobStateChangedEvent>(OnMobStateChange);
+        SubscribeLocalEvent<BodyStatusComponent, OrganInsertedIntoEvent>(OnOrganInserted);
+        SubscribeLocalEvent<BodyStatusComponent, OrganRemovedFromEvent>(OnOrganRemoved);
     }
 
     private void OnMapInit(Entity<BodyStatusComponent> ent, ref MapInitEvent args)
@@ -25,6 +28,16 @@ public sealed class BodyStatusSystem : EntitySystem
     }
 
     private void OnMobStateChange(Entity<BodyStatusComponent> ent, ref MobStateChangedEvent args)
+    {
+        UpdateStatus(ent.AsNullable());
+    }
+
+    private void OnOrganInserted(Entity<BodyStatusComponent> ent, ref OrganInsertedIntoEvent args)
+    {
+        UpdateStatus(ent.AsNullable());
+    }
+
+    private void OnOrganRemoved(Entity<BodyStatusComponent> ent, ref OrganRemovedFromEvent args)
     {
         UpdateStatus(ent.AsNullable());
     }

--- a/Content.Medical.Shared/Body/Systems/UnremoveableOrganSystem.cs
+++ b/Content.Medical.Shared/Body/Systems/UnremoveableOrganSystem.cs
@@ -30,7 +30,7 @@ public sealed class UnremoveableOrganSystem : EntitySystem
             return; // all good if it's being deleted or leaving pvs range
 
         // if you intentionally deleted the root part, please delete the body instead chud
-        if (!TerminatingOrDeleted(ent))
+        if (!TerminatingOrDeleted(ent) && !HasComp<ChildOrganComponent>(ent))
         {
             Log.Warning($"{ToPrettyString(ent)} was deleted instead of the body, {ToPrettyString(args.Target)}!");
             PredictedQueueDel(args.Target);

--- a/Content.Medical.Shared/Surgery/SharedSurgerySystem.Steps.cs
+++ b/Content.Medical.Shared/Surgery/SharedSurgerySystem.Steps.cs
@@ -311,14 +311,15 @@ public abstract partial class SharedSurgerySystem
 
     private void OnRemovePartStep(Entity<SurgeryRemovePartStepComponent> ent, ref SurgeryStepEvent args)
     {
-        if (!_organQuery.TryComp(args.Part, out var organ) || organ.Body != args.Body)
+        if (!_organQuery.TryComp(args.Part, out var organ) ||
+            organ.Body != args.Body ||
+            _part.GetParentPart(args.Part) is not {} parent)
             return;
 
-        if (_part.GetParentPart(args.Part) is not {} parent)
-            return;
-
-        _wounds.AmputateWoundableSafely(parent, args.Part);
-        _hands.TryPickupAnyHand(args.User, args.Part);
+        if (_wounds.AmputateWoundableSafely(parent, args.Part))
+            _hands.TryPickupAnyHand(args.User, args.Part);
+        else
+            _popup.PopupClient(Loc.GetString("surgery-popup-step-SurgeryStepRemovePart-failed"), args.User, args.User);
     }
 
     private void OnRemovePartCheck(Entity<SurgeryRemovePartStepComponent> ent, ref SurgeryStepCompleteCheckEvent args)

--- a/Resources/Locale/en-US/_Shitmed/surgery/surgery-popup.ftl
+++ b/Resources/Locale/en-US/_Shitmed/surgery/surgery-popup.ftl
@@ -73,6 +73,7 @@ surgery-popup-step-SurgeryStepLobotomize = {$user} is lobotomizing {$target}!
 surgery-popup-step-SurgeryStepMendBrainTissue = {$user} is mending the brain tissue on {$target}'s {$part}.
 
 surgery-popup-step-SurgeryStepRemoveOrgan-failed = You couldn't remove the organ for some reason...
+surgery-popup-step-SurgeryStepRemovePart-failed = You couldn't remove the part for some reason...
 
 surgery-step-acid-popup = Acidic blood squirts out of {$target}'s {$part}!
 surgery-popup-step-SurgeryStepXenoCutExoskeleton = {$user} is scoring the exoskeleton of {$target}'s {$part}.


### PR DESCRIPTION
twofold fix:
- only delete root parts not just any unremovable organ if container system removes it
- make remove part step not just ignore remove organ attempt event failing

## Media
<img width="436" height="157" alt="17:18:11" src="https://github.com/user-attachments/assets/22d93273-2a37-4c92-89bc-bc211494b6a1" />


**Changelog**
:cl:
- fix: Fixed being able to delete felinids by pulling their tails.