### PR TITLE
remove random station decals

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Decals/splatters.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Decals/splatters.yml
@@ -80,7 +80,7 @@
     - toolbox
     - uboa
     radius: 0.5
-    randomRotation: false # Trauma - fuck you derotates your graffiti
+    randomRotation: true
     maxDecals: 1
     zIndex: 2
     randomColorList:

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -594,7 +594,7 @@
     - id: SolarPanelDamageVariationPass
     - id: SolarPanelEmptyVariationPass
     - id: BasicDecalDirtVariationPass
-    - id: BasicDecalGraffitiVariationPass
+    #- id: BasicDecalGraffitiVariationPass # Trauma - looks shit
     - id: BasicDecalBurnsVariationPass
       prob: 0.50
       orGroup: monospaceDecals


### PR DESCRIPTION
a pr to surpass the other one

closes #816

<img width="644" height="106" alt="image" src="https://github.com/user-attachments/assets/ab56ebea-2f1f-4185-921b-66c49b1110a5" />


:cl:
- remove: No more roundstart random graffiti decals.