### PR TITLE
changelings now copy mutations

### DIFF
--- a/Content.Goobstation.Server/Changeling/ChangelingSystem.cs
+++ b/Content.Goobstation.Server/Changeling/ChangelingSystem.cs
@@ -100,6 +100,7 @@ using Content.Shared.Revolutionary.Components;
 using Content.Shared.Store.Components;
 using Content.Shared.Tag;
 using Content.Shared.Zombies;
+using Content.Trauma.Common.Genetics.Mutations;
 using Robust.Server.GameObjects;
 using Robust.Shared.Audio;
 using Robust.Shared.Player;
@@ -113,6 +114,7 @@ namespace Content.Goobstation.Server.Changeling;
 public sealed partial class ChangelingSystem : SharedChangelingSystem
 {
     // this is one hell of a star wars intro text
+    [Dependency] private readonly CommonMutationSystem _mutation = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly ActionsSystem _actions = default!;
     [Dependency] private readonly StoreSystem _store = default!;
@@ -538,7 +540,8 @@ public sealed partial class ChangelingSystem : SharedChangelingSystem
         {
             Name = Name(target),
             DNA = dna.DNA ?? Loc.GetString("forensics-dna-unknown"),
-            Profile = profile
+            Profile = profile,
+            Mutations = _mutation.GetMutatableData(target)
         };
 
         if (fingerprint.Fingerprint != null)
@@ -598,6 +601,7 @@ public sealed partial class ChangelingSystem : SharedChangelingSystem
             _metaData.SetEntityName(newEnt, data.Name);
             var message = Loc.GetString("changeling-transform-finish", ("target", data.Name));
             Popup.PopupEntity(message, newEnt, newEnt);
+            _mutation.LoadMutatableData(newEnt, data.Mutations);
         }
 
         // otherwise we can only transform once

--- a/Content.Goobstation.Shared/Changeling/Components/ChangelingIdentityComponent.cs
+++ b/Content.Goobstation.Shared/Changeling/Components/ChangelingIdentityComponent.cs
@@ -24,6 +24,7 @@
 
 using Content.Shared.Preferences;
 using Content.Shared.StatusIcon;
+using Content.Trauma.Common.Genetics.Mutations;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
@@ -238,4 +239,10 @@ public sealed partial class TransformData
     /// </summary>
     [DataField]
     public HumanoidCharacterProfile Profile;
+
+    /// <summary>
+    /// Mutations to set for the changeling when transforming.
+    /// </summary>
+    [DataField]
+    public MutatableData Mutations;
 }

--- a/Content.Trauma.Common/Genetics/Mutations/CommonMutationSystem.cs
+++ b/Content.Trauma.Common/Genetics/Mutations/CommonMutationSystem.cs
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+namespace Content.Trauma.Common.Genetics.Mutations;
+
+/// <summary>
+/// Minimal API for other modules to use.
+/// </summary>
+public abstract class CommonMutationSystem : EntitySystem
+{
+    /// <summary>
+    /// Collects mutatable data from a mob.
+    /// Returns empty lists if it isn't mutatable.
+    /// </summary>
+    public abstract MutatableData GetMutatableData(EntityUid mob);
+
+    /// <summary>
+    /// Clears a mob's mutations then loads new ones from a data struct.
+    /// Returns true if the data was loaded.
+    /// </summary>
+    public abstract bool LoadMutatableData(EntityUid mob, MutatableData data);
+}

--- a/Content.Trauma.Common/Genetics/Mutations/MutatableData.cs
+++ b/Content.Trauma.Common/Genetics/Mutations/MutatableData.cs
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+
+namespace Content.Trauma.Common.Genetics.Mutations;
+
+/// <summary>
+/// Complete mutation data for a mob which can easily be applied to a mob.
+/// </summary>
+[DataRecord, Serializable, NetSerializable]
+public partial record struct MutatableData(List<EntProtoId> Dormant, List<EntProtoId> Mutations);


### PR DESCRIPTION
resolves #835

any mutations you had before transforming are cleared, then you get the mutations of whoever's dna you stole.

## Media
<img width="178" height="131" alt="07:56:50" src="https://github.com/user-attachments/assets/fabefced-6b81-40d0-8cf5-041f00feba2e" />


**Changelog**
:cl:
- tweak: Changelings now copy mutations from people they steal DNA from.