### PR TITLE
make ntr task ui less shit

### DIFF
--- a/Content.Goobstation.Client/NTR/UI/NtrTaskHistoryEntry.xaml
+++ b/Content.Goobstation.Client/NTR/UI/NtrTaskHistoryEntry.xaml
@@ -15,8 +15,8 @@
                     <RichTextLabel Name="IdLabel" HorizontalAlignment="Right" />
                 </BoxContainer>
             </BoxContainer>
-            <customControls:HSeparator Margin="5 10 5 10"/>
             <RichTextLabel Name="NoticeLabel" />
+            <customControls:HSeparator Margin="5 10 5 10"/>
         </BoxContainer>
     </PanelContainer>
 </BoxContainer>

--- a/Content.Goobstation.Client/NTR/UI/TaskEntry.xaml
+++ b/Content.Goobstation.Client/NTR/UI/TaskEntry.xaml
@@ -28,10 +28,10 @@
                     <RichTextLabel Name="IdLabel" HorizontalAlignment="Right" Margin="0 0 5 0"/>
                 </BoxContainer>
             </BoxContainer>
-            <customControls:HSeparator Margin="5 10 5 10"/>
             <BoxContainer>
                 <RichTextLabel Name="DescriptionLabel"/>
             </BoxContainer>
+            <customControls:HSeparator Margin="5 10 5 10"/>
         </BoxContainer>
     </PanelContainer>
 </BoxContainer>


### PR DESCRIPTION
the lines actually separate entries now
moron child slave

## Media
<img width="516" height="94" alt="12:30:04" src="https://github.com/user-attachments/assets/4289395c-451d-4b7c-8107-dfb8aff6e960" />

**Changelog**
:cl:
- fix: Made NTR tasks window less confusing.