### PR TITLE
Remove need for facehuggers to be controlled by a player to hug

### DIFF
--- a/Content.Server/_White/Xenomorphs/FaceHugger/FaceHuggerComponent.cs
+++ b/Content.Server/_White/Xenomorphs/FaceHugger/FaceHuggerComponent.cs
@@ -87,9 +87,6 @@ public sealed partial class FaceHuggerComponent : Component
     [ViewVariables]
     public bool Active = true;
 
-    [DataField]
-    public bool PlayerControlled;
-
     [ViewVariables]
     public TimeSpan InfectIn = TimeSpan.Zero;
 

--- a/Content.Server/_White/Xenomorphs/FaceHugger/FaceHuggerSystem.cs
+++ b/Content.Server/_White/Xenomorphs/FaceHugger/FaceHuggerSystem.cs
@@ -67,29 +67,14 @@ public sealed class FaceHuggerSystem : EntitySystem
         SubscribeLocalEvent<FaceHuggerComponent, StepTriggeredOffEvent>(OnStepTriggered);
         SubscribeLocalEvent<FaceHuggerComponent, GotEquippedEvent>(OnGotEquipped);
         SubscribeLocalEvent<FaceHuggerComponent, BeingUnequippedAttemptEvent>(OnBeingUnequippedAttempt);
-        SubscribeLocalEvent<FaceHuggerComponent, PlayerAttachedEvent>(OnPlayerAttached);
-        SubscribeLocalEvent<FaceHuggerComponent, PlayerDetachedEvent>(OnPlayerDetached);
 
         // Goobstation - Throwing behavior
         SubscribeLocalEvent<ThrowableFacehuggerComponent, ThrownEvent>(OnThrown);
         SubscribeLocalEvent<ThrowableFacehuggerComponent, ThrowDoHitEvent>(OnThrowDoHit);
     }
 
-    private void OnPlayerAttached(EntityUid uid, FaceHuggerComponent component, PlayerAttachedEvent args) // Trauma, player controlled facehuggers
-    {
-        component.PlayerControlled = true;
-    }
-
-    private void OnPlayerDetached(EntityUid uid, FaceHuggerComponent component, PlayerDetachedEvent args) // Trauma, player controlled facehuggers
-    {
-        component.PlayerControlled = false;
-    }
-
     private void OnCollideEvent(EntityUid uid, FaceHuggerComponent component, StartCollideEvent args)
     {
-        if(!component.PlayerControlled) // Trauma, player controlled facehuggers
-            return;
-
         TryEquipFaceHugger(uid, args.OtherEntity, component);
     }
 
@@ -107,7 +92,7 @@ public sealed class FaceHuggerSystem : EntitySystem
 
     private void OnStepTriggered(EntityUid uid, FaceHuggerComponent component, ref StepTriggeredOffEvent args)
     {
-        if (component.Active && component.PlayerControlled) // Trauma, player controlled facehuggers
+        if (component.Active)
             TryEquipFaceHugger(uid, args.Tripper, component);
     }
 
@@ -194,13 +179,10 @@ public sealed class FaceHuggerSystem : EntitySystem
             }
             // Goobstaion end
 
-            if (!faceHugger.PlayerControlled) // Trauma, no auto jumping facehuggers without player
-                return;
-
             if (faceHugger.Active && clothing?.InSlot == null)
             {
                 foreach (var entity in _entityLookup.GetEntitiesInRange<InventoryComponent>(Transform(uid).Coordinates,
-                             1.3f))
+                             1.5f))
                 {
                     if (TryEquipFaceHugger(uid, entity, faceHugger))
                         break;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
title

## Why / Balance
ripper

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Facehuggers no longer need to be player controlled to hug
