### PR TITLE
trauma specific role requirements

### DIFF
--- a/Resources/Prototypes/_Trauma/Roles/requirement_overrides.yml
+++ b/Resources/Prototypes/_Trauma/Roles/requirement_overrides.yml
@@ -18,7 +18,7 @@
       role: JobChiefMedicalOfficer
       time: 1h
     - !type:RoleTimeRequirement
-      role: JobQuarterMaster
+      role: JobQuartermaster
       time: 1h
     - !type:RoleTimeRequirement
       role: JobResearchDirector
@@ -38,7 +38,7 @@
       - Human
     HeadOfPersonnel:
     - !type:DepartmentTimeRequirement
-      department: Service
+      department: Civilian
       time: 3h
     - !type:SpeciesRequirement
       species:
@@ -94,7 +94,7 @@
       inverted: true
     ServiceWorker:
     - !type:DepartmentTimeRequirement
-      department: Service
+      department: Civilian
       time: 3h
       inverted: true
     #Cargo - No intern role, so no limits lmao.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->
new roletimer restrictions. armok thumbs up of approval.
Heads of staff now requires 3 hours in their respective departments.
Captain now requires an hour as each department head, minus HoP as service is mostly self-managing.
NTR now required 3 hours as command.
Intern roles are now locked after 3 hours in their respective departments.
antag role requirements will be done in a seperate pr (when I care or am reminded)
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
delta is going to shoot me if I did this on main files, go my merge conflict generator!

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
i aint doin allat, if da test runs it runs.
## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Role playtime restrictions have been largely reduced.
