### PR TITLE
Added ingredients beacon for chefs

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Civilian/chef.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/chef.yml
@@ -116,9 +116,9 @@
     id: ChefPDA
     ears: ClothingHeadsetService
     belt: ClothingBeltChefFilled
-    storage:
-      back:
-      - IngredientsBeacon # Traumastation
+  storage:
+     back:
+     - IngredientsBeacon #Trauma
 
 - type: chameleonOutfit
   id: ChefChameleonOutfit

--- a/Resources/Prototypes/Roles/Jobs/Civilian/chef.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/chef.yml
@@ -118,7 +118,7 @@
     belt: ClothingBeltChefFilled
   storage:
     back:
-    - IngredientsBeacon #Trauma
+    - IngredientsBeacon # Trauma
 
 - type: chameleonOutfit
   id: ChefChameleonOutfit

--- a/Resources/Prototypes/Roles/Jobs/Civilian/chef.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/chef.yml
@@ -116,9 +116,9 @@
     id: ChefPDA
     ears: ClothingHeadsetService
     belt: ClothingBeltChefFilled
-  #storage:
-    #back:
-    #- Stuff
+    storage:
+      back:
+      - IngredientsBeacon # Traumastation
 
 - type: chameleonOutfit
   id: ChefChameleonOutfit

--- a/Resources/Prototypes/Roles/Jobs/Civilian/chef.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/chef.yml
@@ -117,8 +117,8 @@
     ears: ClothingHeadsetService
     belt: ClothingBeltChefFilled
   storage:
-     back:
-     - IngredientsBeacon #Trauma
+    back:
+    - IngredientsBeacon #Trauma
 
 - type: chameleonOutfit
   id: ChefChameleonOutfit

--- a/Resources/Prototypes/Roles/Jobs/Fun/visitors_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/visitors_startinggear.yml
@@ -1073,7 +1073,7 @@
   inhand:
   #- ClothingMaskItalianMoustache         #Chefs now start with the space italian implant.
   - DrinkWineBottleFull
-  - IngredientsBeacon # Traumastation
+  - IngredientsBeacon #Trauma
 
 - type: startingGear
   id: VisitorChefAlt

--- a/Resources/Prototypes/Roles/Jobs/Fun/visitors_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/visitors_startinggear.yml
@@ -1073,7 +1073,7 @@
   inhand:
   #- ClothingMaskItalianMoustache         #Chefs now start with the space italian implant.
   - DrinkWineBottleFull
-  - IngredientsBeacon #Trauma
+  - IngredientsBeacon # Trauma
 
 - type: startingGear
   id: VisitorChefAlt

--- a/Resources/Prototypes/Roles/Jobs/Fun/visitors_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/visitors_startinggear.yml
@@ -1073,6 +1073,7 @@
   inhand:
   #- ClothingMaskItalianMoustache         #Chefs now start with the space italian implant.
   - DrinkWineBottleFull
+  - IngredientsBeacon # Traumastation
 
 - type: startingGear
   id: VisitorChefAlt

--- a/Resources/Prototypes/_Trauma/Catalog/pods.yml
+++ b/Resources/Prototypes/_Trauma/Catalog/pods.yml
@@ -54,6 +54,7 @@
   components:
   - type: SpawnTableOnDespawn
     table: !type:AllSelector
+      children:
       - !type:AllSelector
         rolls: 3
         children:
@@ -64,6 +65,7 @@
         - id: FoodCorn
         - id: FoodCabbage
 
+
 - type: entity
   id: SpawnIngredientsFruits
   categories: [ HideSpawnMenu ]
@@ -72,6 +74,7 @@
   components:
   - type: SpawnTableOnDespawn
     table: !type:AllSelector
+      children:
       - !type:AllSelector
         rolls: 3
         children:

--- a/Resources/Prototypes/_Trauma/Catalog/pods.yml
+++ b/Resources/Prototypes/_Trauma/Catalog/pods.yml
@@ -1,0 +1,93 @@
+- type: entity
+  id: SpawnIngredientsBaking
+  categories: [ HideSpawnMenu ]
+  name: baking supplies
+  parent: SpawnSupplyEmpty
+  components:
+  - type: SpawnTableOnDespawn
+    table: !type:AllSelector
+      children:
+      - id: FoodSnackRaisins
+        amount: 4
+      - id: FoodSnackChocolate
+        amount: 4
+      - id: ReagentContainerFlour
+      - id: ReagentContainerSugar
+      - id: FoodContainerEgg
+      - id: DrinkMilkCarton
+
+- type: entity
+  id: SpawnIngredientsExoticMeat
+  categories: [ HideSpawnMenu ]
+  name: exotic meats
+  parent: SpawnSupplyEmpty
+  components:
+  - type: SpawnTableOnDespawn
+    table: !type:AllSelector
+      children:
+      - id: FoodMeatXeno
+        amount: 4
+      - id: FoodMeatCrab
+        amount: 2
+      - id: FoodMeatDuck
+      - id: FoodMeatBear
+      - id: FoodMeatPenguin
+
+- type: entity
+  id: SpawnIngredientsMeat
+  categories: [ HideSpawnMenu ]
+  name: bulk meats
+  parent: SpawnSupplyEmpty
+  components:
+  - type: SpawnTableOnDespawn
+    table: !type:AllSelector
+      children:
+      - id: FoodMeat
+        amount: 10
+      - id: FoodMeatHuman
+
+- type: entity
+  id: SpawnIngredientsVegetables
+  categories: [ HideSpawnMenu ]
+  name: vegetables
+  parent: SpawnSupplyEmpty
+  components:
+  - type: SpawnTableOnDespawn
+    table: !type:AllSelector
+      children:
+      - id: FoodCarrot
+        amount: 3
+      - id: FoodChiliPepper
+        amount: 3
+      - id: FoodTomato
+        amount: 3
+      - id: FoodPotato
+        amount: 3
+      - id: FoodCorn
+        amount: 3
+      - id: FoodCabbage
+        amount: 3
+
+- type: entity
+  id: SpawnIngredientsFruits
+  categories: [ HideSpawnMenu ]
+  name: fruits
+  parent: SpawnSupplyEmpty
+  components:
+  - type: SpawnTableOnDespawn
+    table: !type:AllSelector
+      children:
+      - id: FoodBerries
+        amount: 3
+      - id: FoodGrape
+        amount: 3
+      - id: FoodCherry
+        amount: 3
+      - id: FoodLemon
+        amount: 3
+      - id: FoodApple
+        amount: 3
+      - id: FoodOrange
+        amount: 3
+      - id: FoodBanana
+        amount: 3

--- a/Resources/Prototypes/_Trauma/Catalog/pods.yml
+++ b/Resources/Prototypes/_Trauma/Catalog/pods.yml
@@ -54,14 +54,15 @@
   components:
   - type: SpawnTableOnDespawn
     table: !type:AllSelector
-      roll: 3
-      children:
-      - id: FoodCarrot
-      - id: FoodChiliPepper
-      - id: FoodTomato
-      - id: FoodPotato
-      - id: FoodCorn
-      - id: FoodCabbage
+      - !type:AllSelector
+        rolls: 3
+        children:
+        - id: FoodCarrot
+        - id: FoodChiliPepper
+        - id: FoodTomato
+        - id: FoodPotato
+        - id: FoodCorn
+        - id: FoodCabbage
 
 - type: entity
   id: SpawnIngredientsFruits
@@ -71,12 +72,13 @@
   components:
   - type: SpawnTableOnDespawn
     table: !type:AllSelector
-      roll: 3
-      children:
-      - id: FoodBerries
-      - id: FoodGrape
-      - id: FoodCherry
-      - id: FoodLemon
-      - id: FoodApple
-      - id: FoodOrange
-      - id: FoodBanana
+      - !type:AllSelector
+        rolls: 3
+        children:
+        - id: FoodBerries
+        - id: FoodGrape
+        - id: FoodCherry
+        - id: FoodLemon
+        - id: FoodApple
+        - id: FoodOrange
+        - id: FoodBanana

--- a/Resources/Prototypes/_Trauma/Catalog/pods.yml
+++ b/Resources/Prototypes/_Trauma/Catalog/pods.yml
@@ -54,14 +54,16 @@
   components:
   - type: SpawnTableOnDespawn
     table: !type:AllSelector
-      roll: 3
       children:
-      - id: FoodCarrot
-      - id: FoodChiliPepper
-      - id: FoodTomato
-      - id: FoodPotato
-      - id: FoodCorn
-      - id: FoodCabbage
+      - !type:AllSelector
+        rolls: 3
+        children:
+        - id: FoodCarrot
+        - id: FoodChiliPepper
+        - id: FoodTomato
+        - id: FoodPotato
+        - id: FoodCorn
+        - id: FoodCabbage
 
 - type: entity
   id: SpawnIngredientsFruits
@@ -71,12 +73,14 @@
   components:
   - type: SpawnTableOnDespawn
     table: !type:AllSelector
-      roll: 3
       children:
-      - id: FoodBerries
-      - id: FoodGrape
-      - id: FoodCherry
-      - id: FoodLemon
-      - id: FoodApple
-      - id: FoodOrange
-      - id: FoodBanana
+      - !type:AllSelector
+        rolls: 3
+        children:
+        - id: FoodBerries
+        - id: FoodGrape
+        - id: FoodCherry
+        - id: FoodLemon
+        - id: FoodApple
+        - id: FoodOrange
+        - id: FoodBanana

--- a/Resources/Prototypes/_Trauma/Catalog/pods.yml
+++ b/Resources/Prototypes/_Trauma/Catalog/pods.yml
@@ -54,19 +54,14 @@
   components:
   - type: SpawnTableOnDespawn
     table: !type:AllSelector
+      roll: 3
       children:
       - id: FoodCarrot
-        amount: 3
       - id: FoodChiliPepper
-        amount: 3
       - id: FoodTomato
-        amount: 3
       - id: FoodPotato
-        amount: 3
       - id: FoodCorn
-        amount: 3
       - id: FoodCabbage
-        amount: 3
 
 - type: entity
   id: SpawnIngredientsFruits
@@ -76,18 +71,12 @@
   components:
   - type: SpawnTableOnDespawn
     table: !type:AllSelector
+      roll: 3
       children:
       - id: FoodBerries
-        amount: 3
       - id: FoodGrape
-        amount: 3
       - id: FoodCherry
-        amount: 3
       - id: FoodLemon
-        amount: 3
       - id: FoodApple
-        amount: 3
       - id: FoodOrange
-        amount: 3
       - id: FoodBanana
-        amount: 3

--- a/Resources/Prototypes/_Trauma/Catalog/pods.yml
+++ b/Resources/Prototypes/_Trauma/Catalog/pods.yml
@@ -54,16 +54,14 @@
   components:
   - type: SpawnTableOnDespawn
     table: !type:AllSelector
+      roll: 3
       children:
-      - !type:AllSelector
-        rolls: 3
-        children:
-        - id: FoodCarrot
-        - id: FoodChiliPepper
-        - id: FoodTomato
-        - id: FoodPotato
-        - id: FoodCorn
-        - id: FoodCabbage
+      - id: FoodCarrot
+      - id: FoodChiliPepper
+      - id: FoodTomato
+      - id: FoodPotato
+      - id: FoodCorn
+      - id: FoodCabbage
 
 - type: entity
   id: SpawnIngredientsFruits
@@ -73,14 +71,12 @@
   components:
   - type: SpawnTableOnDespawn
     table: !type:AllSelector
+      roll: 3
       children:
-      - !type:AllSelector
-        rolls: 3
-        children:
-        - id: FoodBerries
-        - id: FoodGrape
-        - id: FoodCherry
-        - id: FoodLemon
-        - id: FoodApple
-        - id: FoodOrange
-        - id: FoodBanana
+      - id: FoodBerries
+      - id: FoodGrape
+      - id: FoodCherry
+      - id: FoodLemon
+      - id: FoodApple
+      - id: FoodOrange
+      - id: FoodBanana

--- a/Resources/Prototypes/_Trauma/Catalog/pods.yml
+++ b/Resources/Prototypes/_Trauma/Catalog/pods.yml
@@ -65,7 +65,6 @@
         - id: FoodCorn
         - id: FoodCabbage
 
-
 - type: entity
   id: SpawnIngredientsFruits
   categories: [ HideSpawnMenu ]

--- a/Resources/Prototypes/_Trauma/Entities/Objects/Specific/Service/chef_beacon.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Objects/Specific/Service/chef_beacon.yml
@@ -1,8 +1,8 @@
 - type: entity
-  name: ingredients beacon
-  description: Summon ingredients to help you get started cooking
   parent: BaseItem
   id: IngredientsBeacon
+  name: ingredients beacon
+  description: Summon ingredients to help you get started cooking
   components:
   - type: Sprite
     sprite: Objects/Devices/door_remote.rsi

--- a/Resources/Prototypes/_Trauma/Entities/Objects/Specific/Service/chef_beacon.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Objects/Specific/Service/chef_beacon.yml
@@ -1,0 +1,46 @@
+- type: entity
+  name: ingredients beacon
+  description: Summon ingredients to help you get started cooking
+  parent: BaseItem
+  id: IngredientsBeacon
+  components:
+  - type: Sprite
+    sprite: Objects/Devices/door_remote.rsi
+    layers:
+    - state: door_remotebase
+    - state: door_remotelightscolour
+      color: "#58c800"
+    - state: door_remotescreencolour
+      color: "#3a7231"
+  - type: UserInterface
+    interfaces:
+      enum.RadialSelectorUiKey.Key:
+        type: AttachedRadialSelectorMenuBUI
+  - type: ActivatableUI
+    key: enum.RadialSelectorUiKey.Key
+    inHandsOnly: true
+    singleUser: true
+  - type: RadialItemSelector
+    entries:
+    - prototype: SpawnIngredientsBaking
+      icon:
+        sprite: Objects/Consumable/Food/snacks.rsi
+        state: raisins
+    - prototype: SpawnIngredientsExoticMeat
+      icon:
+        sprite: Objects/Consumable/Food/meat.rsi
+        state: xeno
+    - prototype: SpawnIngredientsMeat
+      icon:
+        sprite: Objects/Consumable/Food/meat.rsi
+        state: plain
+    - prototype: SpawnIngredientsVegetables
+      icon:
+        sprite: Objects/Specific/Hydroponics/carrot.rsi
+        state: produce
+    - prototype: SpawnIngredientsFruits
+      icon:
+        sprite: Objects/Specific/Hydroponics/apple.rsi
+        state: produce
+  - type: StaticPrice
+    price: 500

--- a/Resources/Prototypes/_Trauma/Entities/Objects/Specific/Service/chef_beacon.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Objects/Specific/Service/chef_beacon.yml
@@ -5,13 +5,8 @@
   description: Summon ingredients to help you get started cooking
   components:
   - type: Sprite
-    sprite: Objects/Devices/door_remote.rsi
-    layers:
-    - state: door_remotebase
-    - state: door_remotelightscolour
-      color: "#58c800"
-    - state: door_remotescreencolour
-      color: "#3a7231"
+    sprite: _Trauma/Objects/Revs/droppodbeacon.rsi
+    state: icon
   - type: UserInterface
     interfaces:
       enum.RadialSelectorUiKey.Key:

--- a/Resources/Prototypes/_Trauma/Entities/Objects/Specific/Service/chef_beacon.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Objects/Specific/Service/chef_beacon.yml
@@ -1,8 +1,8 @@
 - type: entity
-  parent: BaseItem
-  id: IngredientsBeacon
   name: ingredients beacon
   description: Summon ingredients to help you get started cooking
+  parent: BaseItem
+  id: IngredientsBeacon
   components:
   - type: Sprite
     sprite: Objects/Devices/door_remote.rsi


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->
Added a beacon to give chefs a choice of different ingredients to be dropped to them.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Gives chefs some different options to start cooking with immediately before having to ask cargo/botany for extra food. I mostly saw it in 13 and thought "That looks fun, I wish it was in 14."

It's mostly things you can order through cargo or grow through botany. I'm not sure about some of the exotic meats, but the whole point of that option is to let you cook with things you otherwise might not have a chance to get. There's no mechanical benefit, but Wing Fang Chu is cool.
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
https://github.com/user-attachments/assets/8cb58824-faef-42dc-bd49-50dc8cd9c87c

Video outdated, sprite changed
<img width="955" height="417" alt="image" src="https://github.com/user-attachments/assets/a1573384-ef93-42fe-ab65-17b5751054af" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: RatherUncreativeName
- add: Added an ingredient beacon for chefs.