### PR TITLE
ntr scanning no longer deletes/teleports items

### DIFF
--- a/Content.Goobstation.Server/NTR/Scan/BriefcaseScannerSystem.cs
+++ b/Content.Goobstation.Server/NTR/Scan/BriefcaseScannerSystem.cs
@@ -96,7 +96,7 @@ namespace Content.Goobstation.Server.NTR.Scan
             }
             else
             {
-                var current = new Dictionary<string, FixedPoint2>
+                var currency = new Dictionary<string, FixedPoint2>
                 {
                     { "NTLoyaltyPoint", FixedPoint2.New(points) }
                 };


### PR DESCRIPTION
sec having to keep contra secured crazy
antags having more reasons to raid sec for their stolen goodies
if you really want to delete shit sell/cremate it chud

there would be an exploit if refunds ever got added for traitors but hopefully nobody will ever do that, there would be other exploits too

:cl:
- tweak: NTR scanning no longer teleports items to CentComm, lock up your contraband.