### PR TITLE
save stunprod

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/stunprod.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/stunprod.yml
@@ -28,19 +28,21 @@
         Shock: 5
   - type: Stunbaton
     energyPerUse: 120
-  - type: MeleeWeapon # goob edited
-    angle: 0
+  - type: MeleeWeapon
     wideAnimationRotation: -135
     damage:
       types:
         Blunt: 9
+    angle: 0 # Trauma - was 60, git gud
     animation: WeaponArcThrust
-  - type: StaminaDamageOnHit # goob edited
-    damage: 15
+  - type: StaminaDamageOnHit
+    lightAttackDamageMultiplier: 4 # Trauma
+    damage: 15 # Trauma - was 35, more overtime damage instead
     overtime: 40
-    lightAttackDamageMultiplier: 4
-    lightAttackOvertimeDamageMultiplier: 0
     sound: /Audio/Weapons/egloves.ogg
+  #- type: StaminaDamageOnCollide # Trauma - throwing batongs being guaranteed stun is dogshit
+  #  damage: 35
+  #  sound: /Audio/Weapons/egloves.ogg
   - type: DelayedKnockdownOnHit # Goobstation
     useDelay: stunbaton
   - type: UseDelayBlockMelee # Goobstation


### PR DESCRIPTION
removed the 0 multiplier on leftclick stamina damage over time, because why the fuck

it goes from 15 per hit to 55 per hit, so 2 quick hits are actually able to stun (LIKE STUN PROD, STUN!!!) someone

:cl:
- fix: Fixed stunprod not being able to stun anything.