### PR TITLE
make last words delay 2s instead of 10s

### DIFF
--- a/Resources/Prototypes/Actions/crit.yml
+++ b/Resources/Prototypes/Actions/crit.yml
@@ -1,13 +1,3 @@
-# SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 Kara <lunarautomaton6@gmail.com>
-# SPDX-FileCopyrightText: 2023 metalgearsloth <comedian_vs_clown@hotmail.com>
-# SPDX-FileCopyrightText: 2024 Leon Friedrich <60421075+ElectroJr@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 nikthechampiongr <32041239+nikthechampiongr@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 slarticodefast <161409025+slarticodefast@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
-#
-# SPDX-License-Identifier: AGPL-3.0-or-later
 # Actions added to mobs in crit.
 - type: entity
   abstract: true
@@ -53,6 +43,7 @@
   description: Whisper your last words to anyone nearby, and then succumb to your fate. You only have 30 characters to work with.
   components:
   - type: Action
+    useDelay: 2 # Trauma - I want to say my last words befote I die rather than after
     icon:
       sprite: Interface/Actions/actions_crit.rsi
       state: lastwords


### PR DESCRIPTION
have to hope my killer wants to let me say my last words because of the chuddy delay
you can /ghost anyway so balance doesnt change

Y-ou-r'e pr-r-e-tty-y g-o-o-d...

:cl:
- tweak: Lowered the delay on saying your last words from 10 to 2 seconds.