### PR TITLE
kill the larp

### DIFF
--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -534,7 +534,6 @@ namespace Content.Server.GameTicking
             var listOfPlayerInfo = new List<RoundEndMessageEvent.RoundEndPlayerInfo>();
             // Grab the great big book of all the Minds, we'll need them for this.
             var allMinds = EntityQueryEnumerator<MindComponent>();
-            var pvsOverride = _cfg.GetCVar(CCVars.RoundEndPVSOverrides);
             while (allMinds.MoveNext(out var mindId, out var mind))
             {
                 // TODO don't list redundant observer roles?
@@ -565,7 +564,7 @@ namespace Content.Server.GameTicking
                 else if (mind.CurrentEntity != null && TryName(mind.CurrentEntity.Value, out var icName))
                     playerIcName = icName;
 
-                if (TryGetEntity(mind.OriginalOwnedEntity, out var entity) && pvsOverride)
+                if (TryGetEntity(mind.OriginalOwnedEntity, out var entity))
                 {
                     _pvsOverride.AddGlobalOverride(entity.Value);
                 }

--- a/Content.Shared/CCVar/CCVars.Game.cs
+++ b/Content.Shared/CCVar/CCVars.Game.cs
@@ -377,13 +377,13 @@ public sealed partial class CCVars
     public static readonly CVarDef<string> RoundEndSoundCollection =
         CVarDef.Create("game.round_end_sound_collection", "RoundEnd", CVar.SERVERONLY);
 
-    /// <summary>
-    ///     Whether or not to add every player as a global override to PVS at round end.
-    ///     This will allow all players to see their clothing in the round screen player list screen,
-    ///     but may cause lag during round end with very high player counts.
-    /// </summary>
-    public static readonly CVarDef<bool> RoundEndPVSOverrides =
-        CVarDef.Create("game.round_end_pvs_overrides", true, CVar.SERVERONLY);
+    // /// <summary>
+    // ///     Whether or not to add every player as a global override to PVS at round end.
+    // ///     This will allow all players to see their clothing in the round screen player list screen,
+    // ///     but may cause lag during round end with very high player counts.
+    // /// </summary>
+    // public static readonly CVarDef<bool> RoundEndPVSOverrides =
+    //     CVarDef.Create("game.round_end_pvs_overrides", true, CVar.SERVERONLY); - Trauma holy larp
 
     /// <summary>
     ///     If true, players can place objects onto tabletop games like chess boards.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
Removed the round_end_pvs_overrides ccvar as its larp

## Why / Balance
it's only the round end and it's only clientside peformance + literally every other fucking server has it turned on ++++ i just realized almost everyone is gonna be on evac so it hardly fucking changes anything 

this also fixes people being naked in the credit's window

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


:cl:
- fix: Fixed people being naked in the round end credit's scene
