### PR TITLE
add library access level

### DIFF
--- a/Content.Shared/Access/Components/IdCardConsoleComponent.cs
+++ b/Content.Shared/Access/Components/IdCardConsoleComponent.cs
@@ -80,6 +80,7 @@ public sealed partial class IdCardConsoleComponent : Component
         "Theatre",
         // <Trauma>
         "Journalism",
+        "Library",
         // </Trauma>
     };
 

--- a/Resources/Prototypes/Access/service.yml
+++ b/Resources/Prototypes/Access/service.yml
@@ -47,6 +47,9 @@
 - type: accessGroup
   id: Service
   tags:
+  # <Trauma>
+  - Library
+  # </Trauma>
   - HeadOfPersonnel
   - Bar
   - Kitchen

--- a/Resources/Prototypes/Entities/Objects/Tools/access_configurator.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/access_configurator.yml
@@ -22,6 +22,7 @@
       # <Trauma>
       - Genetics
       - Journalism
+      - Library
       - Robotics
       # </Trauma>
       - Armory
@@ -98,6 +99,7 @@
     # <Trauma>
     - NanotrasenRepresentative
     - Journalism
+    - Library
     - Robotics
     - Genetics
     - Revolutionary

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -1847,7 +1847,7 @@
     - state: panel
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
   - type: AccessReader
-    access: [["Service"]]
+    access: [["Library"]] # Trauma - was Service
 
 - type: entity
   parent: VendingMachine

--- a/Resources/Prototypes/Roles/Jobs/Civilian/librarian.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/librarian.yml
@@ -8,7 +8,8 @@
   supervisors: job-supervisors-hop
   goobcoins: 10 #Goob content
   access:
-  #- Service # Trauma - librarian feeds the mind and soul
+  - Library # Trauma - TODO, remove service after mapping is done
+  - Service
   - Maintenance
   special: # Goobstation start - Librarian should speak most languages.
   - !type:AddImplantSpecial

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -31,6 +31,7 @@
   access:
   # <Trauma>
   - Journalism
+  - Library
   - Robotics
   - Genetics
   # </Trauma>

--- a/Resources/Prototypes/_Trauma/Access/civilian.yml
+++ b/Resources/Prototypes/_Trauma/Access/civilian.yml
@@ -1,0 +1,3 @@
+- type: accessLevel
+  id: Library
+  name: id-card-access-level-library

--- a/Resources/Prototypes/_Trauma/Entities/Objects/Devices/Electronics/door_access.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Objects/Devices/Electronics/door_access.yml
@@ -13,3 +13,11 @@
   components:
   - type: AccessReader
     access: [["Genetics"]]
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsLibrary
+  suffix: Library, Locked
+  components:
+  - type: AccessReader
+    access: [["Library"]]

--- a/Resources/Prototypes/_Trauma/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Structures/Doors/Airlocks/access.yml
@@ -34,3 +34,30 @@
   components:
   - type: Sprite
     sprite: Structures/Doors/Airlocks/Standard/maint.rsi
+
+# Library
+
+- type: entity
+  parent: AirlockScience
+  id: AirlockLibraryLocked
+  suffix: Library, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsLibrary ]
+
+- type: entity
+  parent: AirlockScienceGlass
+  id: AirlockLibraryGlassLocked
+  suffix: Library, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsLibrary ]
+
+- type: entity
+  parent: AirlockLibraryLocked
+  id: AirlockMaintLibraryLocked
+  components:
+  - type: Sprite
+    sprite: Structures/Doors/Airlocks/Standard/maint.rsi

--- a/Resources/Prototypes/_Trauma/Entities/Structures/Doors/windoors.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Structures/Doors/windoors.yml
@@ -15,3 +15,12 @@
   - type: ContainerFill
     containers:
       board: [ DoorElectronicsRobotics ]
+
+- type: entity
+  parent: WindoorServiceLocked
+  id: WindoorLibraryLocked
+  suffix: Library, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsLibrary ]


### PR DESCRIPTION
curadrobe uses library access, added librarian doors for mapping

librarian gets service access back until mapping work is done

resolves #984

:cl:
- add: Added Library access level, currently used by the CuraDrobe.
- fix: Fixed librarians not being able to open their doors.