### PR TITLE
fix gun wield popup

### DIFF
--- a/Content.Shared/Wieldable/SharedWieldableSystem.cs
+++ b/Content.Shared/Wieldable/SharedWieldableSystem.cs
@@ -102,7 +102,7 @@ public abstract class SharedWieldableSystem : EntitySystem
             var time = _timing.CurTime;
             if (time > component.LastPopup + component.PopupCooldown &&
                 //!(HasComp<MeleeWeaponComponent>(uid) && // Trauma - many guns have melee for barrel/stock hits
-                !HasComp<MeleeRequiresWieldComponent>(uid)))
+                !HasComp<MeleeRequiresWieldComponent>(uid))
             {
                 component.LastPopup = time;
                 var message = Loc.GetString("wieldable-component-requires", ("item", uid));


### PR DESCRIPTION
so many guns have a melee attack so it was wrongfully removing the wield required popup

fixes #985

:cl:
- fix: Fixed guns that need wielding not having a popup when trying to shoot them.