### PR TITLE
Fix rev jammer contraband level

### DIFF
--- a/Resources/Prototypes/_Trauma/Entities/Objects/Revs/gadgets.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Objects/Revs/gadgets.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ RadioJammer, BaseRevMajorContraband ]
+  parent: [ BaseRevMajorContraband, RadioJammer ]
   id: RevRadioJammer
   name: revolutionary radio jammer
   components:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
Formerly were syndie contra, now are rev contra.
Fixes #999

## Technical details
Dependency order issue. Would affect others if their first parent had a contra level

## Media
Before:
<img width="1136" height="270" alt="image" src="https://github.com/user-attachments/assets/fa900fd2-a8b9-4d29-a6d3-fcb25b24c82c" />
Now:
<img width="606" height="216" alt="image" src="https://github.com/user-attachments/assets/599f19c9-4659-4358-bb3f-e9b796730b91" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
:cl:
- fix: Fixed revolutionary radio jammers having the wrong contraband level.
