### PR TITLE
fix library access name

### DIFF
--- a/Content.Shared/Access/AccessLevelPrototype.cs
+++ b/Content.Shared/Access/AccessLevelPrototype.cs
@@ -1,19 +1,3 @@
-// SPDX-FileCopyrightText: 2021 Metal Gear Sloth <metalgearsloth@gmail.com>
-// SPDX-FileCopyrightText: 2021 Paul <ritter.paul1+git@googlemail.com>
-// SPDX-FileCopyrightText: 2022 Paul Ritter <ritter.paul1@googlemail.com>
-// SPDX-FileCopyrightText: 2022 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
-// SPDX-FileCopyrightText: 2022 Rinkashikachi <15rinkashikachi15@gmail.com>
-// SPDX-FileCopyrightText: 2022 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2022 mirrorcult <lunarautomaton6@gmail.com>
-// SPDX-FileCopyrightText: 2022 wrexbe <81056464+wrexbe@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2023 Visne <39844191+Visne@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 c4llv07e <38111072+c4llv07e@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 metalgearsloth <comedian_vs_clown@hotmail.com>
-// SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
-//
-// SPDX-License-Identifier: MIT
-
 using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Access
@@ -32,7 +16,7 @@ namespace Content.Shared.Access
         ///     The player-visible name of the access level, in the ID card console and such.
         /// </summary>
         [DataField]
-        public string? Name { get; set; }
+        public LocId? Name; // Trauma - use LocId
 
         /// <summary>
         ///     Denotes whether this access level is intended to be assignable to a crew ID card.

--- a/Resources/Locale/en-US/_Trauma/prototypes/access/accesses.ftl
+++ b/Resources/Locale/en-US/_Trauma/prototypes/access/accesses.ftl
@@ -1,2 +1,3 @@
 id-card-access-level-revolutionary = Revolutionary
 id-card-access-level-genetics = Genetics
+id-card-access-level-library = Library


### PR DESCRIPTION
also make AccessLevelPrototype use locid its 2026

:cl:
- fix: Fixed library access name not being localized.