### PR TITLE
throwing not slop anymore

### DIFF
--- a/Content.Shared/Throwing/ThrowingSystem.Trauma.cs
+++ b/Content.Shared/Throwing/ThrowingSystem.Trauma.cs
@@ -10,7 +10,6 @@ namespace Content.Shared.Throwing;
 public sealed partial class ThrowingSystem
 {
     [Dependency] private readonly CommonKnowledgeSystem _knowledge = default!;
-    [Dependency] private readonly SharedGunSystem _gun = default!;
 
     private static readonly EntProtoId StrengthKnowledge = "StrengthKnowledge";
     private static readonly EntProtoId ThrowingKnowledge = "ThrowingKnowledge";


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
got rid of stupid chud random angle + throwing properly defaults to one if you're under 2 strength now

## Why / Balance
stupid chud

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Throwing no longer has a random direction based on throwing skill
- tweak: Throwing no longer throws slower when you have low strength
