### PR TITLE
[April Fools] The second dose of bullshit has hit the branch

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/Plushies/plushies.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/Plushies/plushies.yml
@@ -740,10 +740,11 @@
   description: A large stuffed doll of the elder god Ratvar.
   components:
   - type: Sprite
-    sprite: Mobs/Demons/ratvar.rsi
-    state: ratvar
+    sprite: Objects/Fun/Plushies/ratvar.rsi
+    state: icon
   - type: Item
     size: Normal
+    sprite: Objects/Fun/Plushies/ratvar.rsi
   - type: MultiHandedItem
   - type: Clothing
     quickEquip: false
@@ -761,10 +762,11 @@
   description: A large stuffed doll of the elder goddess Nar'Sie.
   components:
   - type: Sprite
-    sprite: Mobs/Demons/narsie.rsi
-    state: narsie
+    sprite: Objects/Fun/Plushies/narsie.rsi
+    state: icon
   - type: Item
     size: Normal
+    sprite: Objects/Fun/Plushies/narsie.rsi
   - type: MultiHandedItem
   - type: Clothing
     quickEquip: false

--- a/Resources/Prototypes/_DV/CosmicCult/Mobs/cosmicgod.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/Mobs/cosmicgod.yml
@@ -6,8 +6,10 @@
   components:
   - type: Sprite
     noRot: true
-    sprite: _DV/CosmicCult/Objects/unknownplushie.rsi
-    state: plushie_cosmic
+    sprite: _DV/CosmicCult/Mobs/cosmicgod.rsi
+    offset: 0, 2
+    drawdepth: Ghosts
+    scale: 2,2
     layers:
     - state: god
       shader: unshaded
@@ -53,6 +55,9 @@
   id: MobCosmicGod
   components:
   - type: CargoSellBlacklist
+  # big mob needs to see everything
+  - type: ContentEye
+    maxZoom: 2.2,2.2
   - type: Eye
     drawFov: false
   - type: Fixtures

--- a/Resources/Prototypes/_DV/CosmicCult/Objects/unknownplushie.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/Objects/unknownplushie.yml
@@ -9,10 +9,8 @@
   - type: Item
     size: Normal
   - type: Sprite
-    sprite: _DV/CosmicCult/Mobs/cosmicgod.rsi
-    offset: 0, 2
-    drawdepth: Ghosts
-    scale: 2,2
+    sprite: _DV/CosmicCult/Objects/unknownplushie.rsi
+    state: plushie_cosmic
   - type: EmitSoundOnUse
     sound: &PlushieUnknownSound
       path: /Audio/_DV/CosmicCult/ascendant_noise.ogg
@@ -30,9 +28,3 @@
     soundHit: *PlushieUnknownSound
   - type: CosmicTransmutable
     transmuteTo: null # No reforging
-  - type: AmbientSound
-    enabled: true
-    volume: 0
-    range: 25
-    sound:
-      path: /Audio/_DV/CosmicCult/god_ambient.ogg


### PR DESCRIPTION
~~God plushies (Nar'Sie, Ratvar, the Unknown) now look just like the real thing. The Unknown now looks like the plushie.~~ I'm apparently to stupid to do that.
Entropic colossus is now too fat to fit through 1 tile holes. Insert a "yo mama" joke here.
Most tips are fucked up now. I dunno if they're even formatted, but if not, having random backslashes will be even funnier.