### PR TITLE
Better armor examine

### DIFF
--- a/Content.Shared/Armor/SharedArmorSystem.cs
+++ b/Content.Shared/Armor/SharedArmorSystem.cs
@@ -1,7 +1,7 @@
 // <Trauma>
 using Content.Medical.Common.Body;
+using Content.Shared.Localizations;
 using System.Linq;
-using System.Text;
 // </Trauma>
 using Content.Shared.Clothing.Components;
 using Content.Shared.Damage;
@@ -108,19 +108,12 @@ public abstract class SharedArmorSystem : EntitySystem
         {
             // <Trauma>
             var coveredParts = coverage.Where(coveragePart => coveragePart != BodyPartType.Other).ToList();
-            var coverageText = new StringBuilder();
-            for (var i = 0; i < coveredParts.Count; i++)
-            {
-                coverageText.Append(Loc.GetString("armor-coverage-type-" + coveredParts[i].ToString().ToLower()));
-
-                if (i >= coveredParts.Count - 1) continue; // Last element, no connector
-                coverageText.Append(", ");
-                if (i == coveredParts.Count - 2) // Second-to-last element, also add "and " so it reads nicer
-                    coverageText.Append(Loc.GetString("armor-coverage-end-connector") + ' ');
-            }
+            List<string> coverageText = [];
+            foreach (var part in coveredParts)
+                coverageText.Add(Loc.GetString("armor-coverage-type-" + part.ToString().ToLower()));
 
             msg.PushNewline();
-            msg.AddMarkupOrThrow(Loc.GetString("armor-coverage-value", ("type", coverageText.ToString())));
+            msg.AddMarkupOrThrow(Loc.GetString("armor-coverage-value", ("type", ContentLocalizationManager.FormatList(coverageText))));
             // </Trauma>
         }
 

--- a/Resources/Locale/en-US/_Shitmed/armor/armor-examine.ftl
+++ b/Resources/Locale/en-US/_Shitmed/armor/armor-examine.ftl
@@ -7,4 +7,3 @@ armor-coverage-type-torso = torso
 armor-coverage-type-head = head
 armor-coverage-type-tail = tail
 armor-coverage-type-other = other parts
-armor-coverage-end-connector = and


### PR DESCRIPTION
## About the PR
Armor coverage examine no longer spams 20 lines for each bodypart

## Why / Balance
This armor reduces incoming damage to your torso
This armor reduces incoming damage to your hands
This armor reduces incoming damage to your arms
This armor reduces incoming damage to your legs
This armor reduces incoming damage to your feet
This armor reduces incoming damage to your tail
This armor reduces incoming damage to your wings
This armor reduces incoming damage to your ass
This armor reduces incoming damage to your balls
This armor reduces incoming damage to your left pinky toe
This armor reduces incoming damage to your armor

TLDR This PR reduces incoming damage to my sanity

## Technical details
String builder and locale tweaks

## Media
Before/after
<img width="773" height="394" alt="sas" src="https://github.com/user-attachments/assets/938ad848-adbc-409e-bdae-8a8ef991512e" />


**Changelog**
:cl:
- tweak: Improved armor coverage examine
