### PR TITLE
Kill the humble interns

### DIFF
--- a/Content.Shared/Damage/Systems/DamageExamineSystem.cs
+++ b/Content.Shared/Damage/Systems/DamageExamineSystem.cs
@@ -1,14 +1,3 @@
-// SPDX-FileCopyrightText: 2023 Slava0135 <40753025+Slava0135@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 KrasnoshchekovPavel <119816022+KrasnoshchekovPavel@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 Preston Smith <Blackfoot03@outlook.com>
-// SPDX-FileCopyrightText: 2024 beck-thompson <107373427+beck-thompson@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
-// SPDX-FileCopyrightText: 2025 gluesniffler <linebarrelerenthusiast@gmail.com>
-//
-// SPDX-License-Identifier: AGPL-3.0-or-later
-
 using Content.Shared.Damage.Components;
 using Content.Shared.Damage.Events;
 using Content.Shared.Damage.Prototypes;
@@ -17,7 +6,6 @@ using Content.Shared.FixedPoint;
 using Content.Shared.Verbs;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
-using System.Linq; // Goobstation Change
 
 namespace Content.Shared.Damage.Systems;
 
@@ -91,29 +79,6 @@ public sealed class DamageExamineSystem : EntitySystem
             }
         }
 
-        // Goobstation Change
-        var meaningfulDamage = GetTotalMeaningfulDamage(damageSpecifier);
-        if (meaningfulDamage > 0)
-        {
-            msg.PushNewline();
-            msg.AddMarkupOrThrow(Loc.GetString("damage-hits-to-kill", ("count", (100f / (float) meaningfulDamage).ToString("F1"))));
-        }
-
         return msg;
-    }
-
-    // Goobstation Change - Fetches all of the damage that could kill a normal player entity, ignoring helper types.
-    private FixedPoint2 GetTotalMeaningfulDamage(DamageSpecifier damageSpecifier)
-    {
-        var ignoredKeys = new[] { "Structural", "Asphyxiation", "Bloodloss" };
-        var total = FixedPoint2.Zero;
-        foreach (var (key, value) in damageSpecifier.DamageDict)
-        {
-            if (ignoredKeys.Contains(key))
-                continue;
-
-            total += value;
-        }
-        return total;
     }
 }


### PR DESCRIPTION
## About the PR
Removes the "estimated amount of hits to kill an unarmored target" line from damage examine.

## Why / Balance
Short answer:
- Works poorly, totally useless, nobody cares.

Long answer:
- Slop shitting up examine texts (I absolutely do need to read "our humble interns have calculated that blah blah blah..." every fucking time).
- Doesn't take into account a lot of things (damage types, any additional effects like damage markers, etc. etc.), so it's often just straight up wrong.
- Anyone with above room temperature IQ can calculate it in their head in 3 seconds or less (and you often don't care for anything other than "bigger number = more gooder").
- Hardcoded to ignore asphyx damage for some fucking reason (rude, coscult weapons deal that).

## Technical details
Remove evil goob code