### PR TITLE
disable xp gain

### DIFF
--- a/Content.Trauma.Shared/Knowledge/Systems/SharedKnowledgeSystem.cs
+++ b/Content.Trauma.Shared/Knowledge/Systems/SharedKnowledgeSystem.cs
@@ -58,7 +58,7 @@ public abstract partial class SharedKnowledgeSystem : CommonKnowledgeSystem
 
     private TimeSpan _nextUpdate;
     private TimeSpan _updateDelay = TimeSpan.FromSeconds(1);
-    private float _learnChance = 0.2f;
+    //private float _learnChance = 0.2f;
 
     /// <inheritdoc/>
     public override void Initialize()


### PR DESCRIPTION
its too fucked currently since theres no distinguishing shit vs godly sources of xp (fist fighting a goliath vs beating up sheets of steel on the floor which is more rewarding hmm)

:cl:
- remove: Disabled XP gain, you are stuck with your roundstart picked skills until a better system is made.