### PR TITLE
revert 1092. stop merging chud balance changes from chuds.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/baseball_bat.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/baseball_bat.yml
@@ -70,8 +70,6 @@
       types:
         Blunt: 5
         Structural: 10
-  - type: StaminaDamageOnHit # goob - bat makes you hurt and tired (but not as much as the real stun stick)
-    damage: 12 # goob - 8 hits to stamcrit someone with armor vest + helmet
   - type: MeleeThrowOnHit # Goobstation
     distance: 1
     speed: 5
@@ -112,7 +110,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 30
+        damage: 20
       behaviors:
       - !type:PlaySoundBehavior
         sound:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -292,6 +292,10 @@
             max: 1
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
+  - type: DamageOnHit # Do not fucking delete this shit, armok added improvised weapons breaking for a reason
+    damage:
+      types:
+        Blunt: 1
   - type: Damageable
     damageContainer: Inorganic # </Trauma>
 


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Soft reverted 1092, added armok changes to priors.
Improvised weapons were made to break for good reason, its improvised. 
If you want a good spear/shiv, spend time honing your craft. 
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
chud balance
## Technical details
<!-- Summary of code changes for easier review. -->
chud balance
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
chud balance
## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Baseball bats now break in 20 hits instead of 30.
- remove: Stamina damage from baseball bat.
- fix: Reenabled shivs breaking after 10 hits.