### PR TITLE
disable learning language by hearing it

### DIFF
--- a/Content.Trauma.Shared/Knowledge/Systems/SharedKnowledgeSystem.Language.cs
+++ b/Content.Trauma.Shared/Knowledge/Systems/SharedKnowledgeSystem.Language.cs
@@ -18,7 +18,7 @@ public abstract partial class SharedKnowledgeSystem
 {
     //[Dependency] private readonly EntityLookupSystem _lookup = default!;
     [Dependency] private readonly MetaDataSystem _meta = default!;
-    [Dependency] private readonly SharedTransformSystem _transform = default!;
+    //[Dependency] private readonly SharedTransformSystem _transform = default!;
 
     private EntityQuery<LanguageKnowledgeComponent> _langQuery;
 


### PR DESCRIPTION
it was shitcode on multiple fronts so commented it out
- doesnt make any sense that you can just hear someone speak ~5 times and learn the language
- language level doesnt matter right now
- it never made you able to speak the language so monkeys "learned" it but it didnt matter anyway

:cl:
- remove: Removed language learning by hearing someone say it, it was very buggy.