### PR TITLE
Cosmic Cult patch 1.2

### DIFF
--- a/Content.Server/_DV/CosmicCult/CosmicCultRuleSystem.cs
+++ b/Content.Server/_DV/CosmicCult/CosmicCultRuleSystem.cs
@@ -147,6 +147,8 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
     /// </summary>
     private void UpdateCultData(Entity<CosmicCultRuleComponent> rule)
     {
+        if (rule.Comp.Cultists.Count == 0) return; // Everyone is dead no need to check anything
+
         var totalCult = 0;
         var cultistsAtNextLevel = 0;
         foreach (var cultist in rule.Comp.Cultists)
@@ -222,8 +224,7 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
                     _tier2Sound,
                     Color.FromHex("#cae8e8"));
 
-                component.FractureChance = 0.75f; // Most rifts from this point will be fractures instead.
-
+                component.FractureChance = 0.5f;
                 for (var i = 0; i <= component.TotalCrew / 4; i++)
                     SpawnRift(component.FractureChance);
 
@@ -249,8 +250,13 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
                     Color.FromHex("#cae8e8"));
                 _audio.PlayGlobal(_tier3Sound, Filter.Broadcast(), false, AudioParams.Default);
 
+                component.FractureChance = 0.9f;
+                for (var i = 0; i <= component.TotalCrew / 3; i++) // Like, a lot of fractures
+                    SpawnRift(component.FractureChance);
+
                 while (lights.MoveNext(out var light, out _))
-                    _ghost.DoGhostBooEvent(light);
+                    if (_rand.Prob(0.90f))
+                        _ghost.DoGhostBooEvent(light);
 
                 break;
             default:
@@ -258,6 +264,11 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
         }
         UpdateCultData(ent); // Update all the data again
         ent.Comp.IncreasingTier = false;
+
+        var query = EntityQueryEnumerator<CosmicTierConditionComponent>();
+
+        while (query.MoveNext(out _, out var comp))
+            comp.Tier = ent.Comp.CurrentTier;
     }
 
     #endregion
@@ -366,7 +377,6 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
         }
     }
 
-    // TODO: rewrite this fuck
     private void ConfirmWinState(Entity<CosmicCultRuleComponent> ent)
     {
         _sound.StopStationEventMusic(ent, StationEventMusicType.CosmicCult);
@@ -532,7 +542,6 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
         _rejuvenate.PerformRejuvenate(uid);
 
         _role.MindAddRole(mindId, "MindRoleCosmicCult", mind, true);
-        _role.MindHasRole<CosmicCultRoleComponent>(mindId, out var cosmicRole);
 
         if (!_player.TryGetSessionById(mind.UserId, out var session))
             return;

--- a/Resources/Locale/en-US/_DV/cosmiccult/preset-cosmiccult.ftl
+++ b/Resources/Locale/en-US/_DV/cosmiccult/preset-cosmiccult.ftl
@@ -147,8 +147,8 @@ objective-cosmiccult-steward-charactermenu = You must direct the cult to usher i
 
 objective-condition-entropy-title = SIPHON ENTROPY
 objective-condition-entropy-desc = Collectively siphon at least {$count} entropy from the crew.
-objective-condition-culttier-title = EMPOWER THE MONUMENT
-objective-condition-culttier-desc = Ensure that The Monument is brought to full power.
+objective-condition-culttier-title = ATTAIN POWER
+objective-condition-culttier-desc = Gather enough entropy to reach for the end.
 objective-condition-victory-title = USHER IN THE END
 objective-condition-victory-desc = Beckon The Unknown, and herald the final curtain call.
 

--- a/Resources/Prototypes/_DV/CosmicCult/roundstart.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/roundstart.yml
@@ -13,8 +13,8 @@
   - type: AntagSelection
     definitions:
     - prefRoles: [ CosmicAntagCultist ]
-      min: 1 # It just works trust me
-      max: 8
+      min: 2
+      max: 6
       playerRatio: 10
       jobBlacklist: [ Chaplain ] # GOOBSTATION
       blacklist:
@@ -26,3 +26,8 @@
       - type: CosmicCult
       mindRoles:
       - MindRoleCosmicCult
+  - type: AntagPlayerEffects
+    effects:
+    - !type:GrantSkills
+      skills:
+        MeleeKnowledge: 60 # They like, only have melee weapons

--- a/Resources/ServerInfo/_DV/Guidebook/Antagonist/CosmicCult.xml
+++ b/Resources/ServerInfo/_DV/Guidebook/Antagonist/CosmicCult.xml
@@ -16,7 +16,7 @@
   Use [color=#4cabb3]:a[/color] to communicate with fellow cultists through the [color=#4cabb3]Astral Murmur[/color].
 
   ## Objectives
-  - [color=#4cabb3][bold]Siphon Entropy[/bold][/color]  - Collectively siphon a certain amount of Entropy from the crew. The more entropy you siphon, the more you can empower the Monument!
+  - [color=#4cabb3][bold]Siphon Entropy[/bold][/color]  - Collectively siphon a certain amount of Entropy from the crew. The more entropy you siphon, the more powerful you become.
   - [color=#4cabb3][bold]Attain Power[/bold][/color] - The more you gather entropy, the more power the cult gains access to, and the stronger are it's effects on the station.
   - [color=#4cabb3][bold]Usher In The End[/bold][/color] - Once the cult is at full power, summon The Monument and complete the final ritual to beckon the Unknown and destroy the station.
 


### PR DESCRIPTION
## About the PR
All cultists get 60 melee now (no other skills though)
Reduced the amount of fractures at stage 2
Increased the amount of fractures at stage 3, spawn extra rifts at stage 3
There's always at least 2 cultists now
Fixed some text
Fixed objective

## Why / Balance
Issues foud during (very limited so far) playtesting.

## Technical details
No

## Media
Tested, works

## Requirements
Yes

## Breaking changes
No

**Changelog**

:cl:
- tweak: Cosmic cultists now have good melee skill by default.
- fix: Minor fixes to cosmic cult
