### PR TITLE
Cosmic cult patch 1.2.1

### DIFF
--- a/Content.Server/_DV/CosmicCult/Abilities/CosmicMonumentSystem.cs
+++ b/Content.Server/_DV/CosmicCult/Abilities/CosmicMonumentSystem.cs
@@ -153,18 +153,20 @@ public sealed class CosmicMonumentSystem : EntitySystem
     }
 
     /// <summary>
-    /// Makes it impossible to place or activate a monument if evac docks to the station.
+    /// Makes it impossible to place or activate a monument if evac docks to the station. Unless the monument is already active, in which case the evac shouldn't come anyway.
     /// </summary>
     private void OnEvacDocked(ref EmergencyShuttleDockedEvent args)
     {
-        RemoveAllMonumentMarks();
-
-        var query = EntityQueryEnumerator<MonumentComponent>(); // REmove any existing monuments
+        var query = EntityQueryEnumerator<MonumentComponent>(); // Remove any existing monuments
         while (query.MoveNext(out var uid, out var comp))
         {
+            if (comp.Active) return; // Should only have one of those at a time, so if one is already active, we don't do anything
+
             Spawn(comp.DespawnVfx, Transform(uid).Coordinates);
             QueueDel(uid);
         }
+
+        RemoveAllMonumentMarks();
     }
 
     //todo this can probably be mostly moved to shared but my brain isn't cooperating w/ that rn

--- a/Content.Server/_DV/CosmicCult/CosmicCultRuleSystem.cs
+++ b/Content.Server/_DV/CosmicCult/CosmicCultRuleSystem.cs
@@ -40,7 +40,7 @@ using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Roles;
-using Content.Shared.Roles.Components;
+using Content.Shared.Zombies;
 using Robust.Server.Audio;
 using Robust.Server.Player;
 using Robust.Shared.Audio;
@@ -462,6 +462,7 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
         EnsureComp<CosmicCultComponent>(uid, out var cultComp);
         EnsureComp<IntrinsicRadioReceiverComponent>(uid);
         EnsureComp<CosmicCultAssociatedRuleComponent>(uid, out var associatedComp);
+        EnsureComp<ZombieImmuneComponent>(uid);
 
         foreach (var influenceProto in _proto.EnumeratePrototypes<InfluencePrototype>().Where(influenceProto => influenceProto.Tier == cultComp.CurrentLevel))
             cultComp.UnlockedInfluences.Add(influenceProto.ID);

--- a/Content.Server/_DV/CosmicCult/MonumentSystem.cs
+++ b/Content.Server/_DV/CosmicCult/MonumentSystem.cs
@@ -1,4 +1,3 @@
-using Content.Goobstation.Shared.Religion;
 using Content.Goobstation.Shared.Religion.Nullrod;
 using Content.Server.Actions;
 using Content.Server.AlertLevel;
@@ -22,7 +21,6 @@ using Content.Shared.Popups;
 using Robust.Server.GameObjects;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map.Components;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 

--- a/Resources/Prototypes/_DV/CosmicCult/Mobs/cosmicgod.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/Mobs/cosmicgod.yml
@@ -16,7 +16,6 @@
 
 # spawn animation, spawns actual god when it ends
 - type: entity
-  categories: [ HideSpawnMenu ]
   parent: MobCosmicGodBase
   id: MobCosmicGodSpawn
   suffix: Spawn


### PR DESCRIPTION
## About the PR
Not a lot this time:
- Cultists are now zombie immune
- Reinforced the evac-to-monument interaction a bit (shouldn't explode when evac docks if the monument is already active).
- The Unknown can be spawned by admins once more, in case something breaks again.

## Why / Balance
Last cult playtest was one of the rounds of all time.

**Changelog**
:cl:
- tweak: Cosmic cultists are now immune to zombie infection.
- fix: Fixed The Monument exploding when evac docks despite being active.
