### PR TITLE
fix toughness breaking suicide

### DIFF
--- a/Content.Trauma.Shared/Knowledge/Systems/DamageModifyKnowledgeSystem.cs
+++ b/Content.Trauma.Shared/Knowledge/Systems/DamageModifyKnowledgeSystem.cs
@@ -14,11 +14,11 @@ public sealed class DamageModifyKnowledgeSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<KnowledgeHolderComponent, BeforeDamageChangedEvent>(_knowledge.RelayActiveEvent);
-        SubscribeLocalEvent<DamageModifyKnowledgeComponent, BeforeDamageChangedEvent>(OnBeforeDamageChanged);
+        SubscribeLocalEvent<KnowledgeHolderComponent, DamageModifyEvent>(_knowledge.RelayActiveEvent);
+        SubscribeLocalEvent<DamageModifyKnowledgeComponent, DamageModifyEvent>(OnDamageModify);
     }
 
-    private void OnBeforeDamageChanged(Entity<DamageModifyKnowledgeComponent> ent, ref BeforeDamageChangedEvent args)
+    private void OnDamageModify(Entity<DamageModifyKnowledgeComponent> ent, ref DamageModifyEvent args)
     {
         // most environment things like radiation should have no origin?
         if (args.Damage.GetTotal() <= 0 || args.Origin == null)


### PR DESCRIPTION
it was using the wrong event

## Media
/suicide with toughness 100

<img width="318" height="344" alt="09:19:20" src="https://github.com/user-attachments/assets/82a727a3-ef86-47f2-ad58-0f11c5efdb96" />


**Changelog**
:cl:
- fix: Fixed toughness skill decreasing AP damage like AP ammo and /suicide