### PR TITLE
fix autosurgeons and decap

### DIFF
--- a/Content.Medical.Common/Body/BodyEvents.cs
+++ b/Content.Medical.Common/Body/BodyEvents.cs
@@ -33,4 +33,4 @@ public record struct EyesDamagedEvent(EntityUid Body, int Damage);
 /// Event raised on a mob to decapitate it.
 /// </summary>
 [ByRefEvent]
-public record struct DecapitateEvent(EntityUid? User = null, bool Handled = true);
+public record struct DecapitateEvent(EntityUid? User = null, bool Handled = false);

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Devices/autosurgeon.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Devices/autosurgeon.yml
@@ -17,6 +17,7 @@
     size: Huge
   - type: ItemToggle
     onUse: false
+  - type: InteractionOutline
   - type: DoAfter
   - type: Physics
     bodyType: Dynamic
@@ -105,7 +106,7 @@
   components:
   - type: AutoSurgeon
     entries:
-    - targetCategory: Heart
+    - targetCategory: Torso
       newOrganProto: OrganHeartSandevistan
 
 - type: entity
@@ -139,7 +140,7 @@
   components:
   - type: AutoSurgeon
     entries:
-    - targetCategory: Heart
+    - targetCategory: Torso
       newOrganProto: SyndicateBerserkerHeart
 
 - type: entity
@@ -149,5 +150,5 @@
   components:
   - type: AutoSurgeon
     entries:
-    - targetCategory: Heart
+    - targetCategory: Torso
       newOrganProto: SyndicateJumpstarterHeart


### PR DESCRIPTION
fixes #1304

heart surgeons were trying to install heart onto existing heart instead of torso, so it didnt work

:cl:
- fix: Fixed berserker heart etc autosurgeons not working.
- fix: Fixed decapitations from executions not working.