### PR TITLE
fix secret doubling the gamerules

### DIFF
--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -138,19 +138,10 @@
     - secret
     - sekrit
   name: secret-title
-  showInVote: true # Trauma
+  showInVote: true
   description: secret-description
   rules:
-  # <Trauma> - completely changed every rule
   - Secret
-  - BasicRoundstartVariation
-  - SpaceTrafficControlEventScheduler
-  - BasicStationEventScheduler
-  - BasicAntagEventScheduler
-  - ModerateAntagEventScheduler
-  - Insurgency # Always some shitters for sec to deal with
-  - SubTraitorRandom # Always 50% chance of at least one traitor
-  # </Trauma>
 
 - type: gamePreset
   id: Sandbox


### PR DESCRIPTION
armok added dupe rules to secret ages ago, this reverts secret game preset yml to upstream

fixes #1347

:cl:
- fix: Fixed secret having double the events that it should have.