### PR TITLE
genetics rarity and nerf sequence fail damage a bit

### DIFF
--- a/Content.Trauma.Client/Genetics/UI/SequenceButtons.xaml.cs
+++ b/Content.Trauma.Client/Genetics/UI/SequenceButtons.xaml.cs
@@ -51,10 +51,12 @@ public sealed partial class SequenceButtons : ScrollContainer
         {
             var sequence = _sequences[i];
             var index = (uint) i;
+            var rarity = RarityChar(sequence.Rarity);
+            var text = Loc.GetString("genetics-console-sequence-text", ("rarity", rarity), ("number", sequence.Number));
             var button = new Button()
             {
                 // TODO: use a wrapping shader or something to do helix animated button
-                Text = sequence.Number.ToString(),
+                Text = text,
                 ToggleMode = true,
                 HorizontalExpand = true
             };
@@ -62,11 +64,20 @@ public sealed partial class SequenceButtons : ScrollContainer
             button.OnPressed += _ => OnSelected?.Invoke(index);
             /*button.AddChild(new Label()
             {
-                Text = sequence.Number.ToString(),
+                Text = text,
                 HorizontalAlignment = HAlignment.Center
             });*/
             _buttons.Add(button);
             Buttons.AddChild(button);
         }
     }
+
+    private char RarityChar(MutationRarity rarity)
+        => rarity switch
+        {
+            MutationRarity.Common => 'C',
+            MutationRarity.Rare => 'R',
+            MutationRarity.Mythical => 'M',
+            _ => '?'
+        };
 }

--- a/Content.Trauma.Shared/Genetics/Console/GeneticsConsoleComponent.cs
+++ b/Content.Trauma.Shared/Genetics/Console/GeneticsConsoleComponent.cs
@@ -71,7 +71,8 @@ public sealed partial class GeneticsConsoleComponent : Component
     {
         DamageDict = new()
         {
-            { "Cellular", 50 }
+            { "Cellular", 20 },
+            { "Radiation", 15 }
         }
     };
 

--- a/Content.Trauma.Shared/Genetics/Mutations/MutationComponent.cs
+++ b/Content.Trauma.Shared/Genetics/Mutations/MutationComponent.cs
@@ -2,6 +2,7 @@
 
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
 
 namespace Content.Trauma.Shared.Genetics.Mutations;
 
@@ -30,6 +31,13 @@ public sealed partial class MutationComponent : Component
     /// </summary>
     [DataField]
     public int Difficulty = 8;
+
+    /// <summary>
+    /// Rarity value shown on the genetics scanner.
+    /// No functional effect.
+    /// </summary>
+    [DataField]
+    public MutationRarity Rarity;
 
     /// <summary>
     /// The target mob this mutation is from.
@@ -69,3 +77,14 @@ public record struct MutationAddedEvent(Entity<MutatableComponent> Target, Entit
 /// </summary>
 [ByRefEvent]
 public record struct MutationRemovedEvent(Entity<MutatableComponent> Target, Entity<MutationComponent> Mutation, EntProtoId<MutationComponent> Id, EntityUid? User, bool Automatic, bool Predicted);
+
+/// <summary>
+/// Rarity tier shown in the scanner UI.
+/// </summary>
+[Serializable]
+public enum MutationRarity : byte
+{
+    Common,
+    Rare,
+    Mythical
+}

--- a/Content.Trauma.Shared/Genetics/Mutations/MutationSystem.cs
+++ b/Content.Trauma.Shared/Genetics/Mutations/MutationSystem.cs
@@ -297,6 +297,12 @@ public sealed partial class MutationSystem : CommonMutationSystem
         => GetRoundData(GetID(uid));
 
     /// <summary>
+    /// Returns the rarity of a mutation, throwing if the id is invalid.
+    /// </summary>
+    public MutationRarity GetRarity([ForbidLiteral] EntProtoId<MutationComponent> id)
+        => AllMutations[id].Rarity;
+
+    /// <summary>
     /// Gets the ID of a mutation, or throws if it isn't valid.
     /// </summary>
     public EntProtoId<MutationComponent> GetID(EntityUid mutation)

--- a/Content.Trauma.Shared/Genetics/Mutations/ScannedGenomeComponent.cs
+++ b/Content.Trauma.Shared/Genetics/Mutations/ScannedGenomeComponent.cs
@@ -44,4 +44,4 @@ public partial record struct UnknownBase(uint Index, char Value = 'X');
 
 // EntProtoId? doesnt work properly with Serializable for some reason, so using string
 [Serializable, NetSerializable]
-public record struct SequenceState(string Bases, string OriginalBases, int Number, string? Mutation);
+public record struct SequenceState(string Bases, string OriginalBases, int Number, MutationRarity Rarity, string? Mutation);

--- a/Content.Trauma.Shared/Genetics/Mutations/ScannedGenomeSystem.cs
+++ b/Content.Trauma.Shared/Genetics/Mutations/ScannedGenomeSystem.cs
@@ -181,7 +181,8 @@ public sealed class ScannedGenomeSystem : EntitySystem
                 continue;
             }
 
-            sequences.Add(new SequenceState(sequence.Bases, sequence.OriginalBases, data.Number, data.Discovered ? id.ToString() : null));
+            var rarity = _mutation.GetRarity(id);
+            sequences.Add(new SequenceState(sequence.Bases, sequence.OriginalBases, data.Number, rarity, data.Discovered ? id.ToString() : null));
         }
     }
 

--- a/Resources/Locale/en-US/_Trauma/genetics/console.ftl
+++ b/Resources/Locale/en-US/_Trauma/genetics/console.ftl
@@ -51,6 +51,7 @@ genetics-console-sequence-info = Sequence Info
 genetics-console-scan = Scan!
 genetics-console-genome-sequencer = Genome Sequencer™
 genetics-console-sequencer-no-sequence-selected = Select a sequence to work with.
+genetics-console-sequence-text = [{$rarity}] {$number}
 genetics-console-mutation-name = Name:
 genetics-console-mutation-desc = Description:
 genetics-console-mutation-instability = Instability:

--- a/Resources/Prototypes/_Trauma/Genetics/Mutations/adaptation.yml
+++ b/Resources/Prototypes/_Trauma/Genetics/Mutations/adaptation.yml
@@ -6,6 +6,7 @@
   - type: Mutation
     instability: 25
     difficulty: 16
+    rarity: Rare
     conflicts:
     - MutationThermalAdaptation
     - MutationPressureAdaptation
@@ -44,6 +45,7 @@
   - type: Mutation
     instability: 35
     difficulty: 32 # powergamers delight
+    rarity: Mythical
     conflicts:
     - MutationPressureAdaptation
   - type: RemovesMutation

--- a/Resources/Prototypes/_Trauma/Genetics/Mutations/admeme.yml
+++ b/Resources/Prototypes/_Trauma/Genetics/Mutations/admeme.yml
@@ -5,6 +5,7 @@
   components:
   - type: Mutation
     locked: true # no
+    rarity: Mythical
 
 - type: entity
   parent: BaseMutationAdmeme

--- a/Resources/Prototypes/_Trauma/Genetics/Mutations/body.yml
+++ b/Resources/Prototypes/_Trauma/Genetics/Mutations/body.yml
@@ -70,6 +70,7 @@
   - type: Mutation
     instability: 10
     difficulty: 16
+    rarity: Rare
     conflicts:
     - MutationAcromegaly
     - MutationGigantism

--- a/Resources/Prototypes/_Trauma/Genetics/Mutations/chameleon.yml
+++ b/Resources/Prototypes/_Trauma/Genetics/Mutations/chameleon.yml
@@ -7,6 +7,7 @@
   - type: Mutation
     instability: 35
     difficulty: 16
+    rarity: Rare
   - type: ComponentMutation
     added:
     - type: Stealth

--- a/Resources/Prototypes/_Trauma/Genetics/Mutations/cold.yml
+++ b/Resources/Prototypes/_Trauma/Genetics/Mutations/cold.yml
@@ -19,6 +19,7 @@
   - type: Mutation
     instability: 25
     difficulty: 12
+    rarity: Rare
   - type: ActionMutation
     action: ActionMutationCryokinesis
 

--- a/Resources/Prototypes/_Trauma/Genetics/Mutations/farsight.yml
+++ b/Resources/Prototypes/_Trauma/Genetics/Mutations/farsight.yml
@@ -7,5 +7,6 @@
   - type: Mutation
     instability: 10
     difficulty: 16
+    rarity: Rare
   - type: MaxZoomMutation
     modifier: 1.1 # a bit more than 1 tile increase

--- a/Resources/Prototypes/_Trauma/Genetics/Mutations/fire_breath.yml
+++ b/Resources/Prototypes/_Trauma/Genetics/Mutations/fire_breath.yml
@@ -7,4 +7,5 @@
   - type: Mutation
     instability: 25
     difficulty: 12
+    rarity: Rare
     locked: true # need to get it via lizard dormant mutation

--- a/Resources/Prototypes/_Trauma/Genetics/Mutations/hot.yml
+++ b/Resources/Prototypes/_Trauma/Genetics/Mutations/hot.yml
@@ -22,6 +22,7 @@
   - type: Mutation
     instability: 25
     difficulty: 12
+    rarity: Rare
   - type: RemovesMutation
     removes:
     - MutationCryokinesis

--- a/Resources/Prototypes/_Trauma/Genetics/Mutations/hulk.yml
+++ b/Resources/Prototypes/_Trauma/Genetics/Mutations/hulk.yml
@@ -7,6 +7,7 @@
   - type: Mutation
     instability: 35
     difficulty: 16
+    rarity: Mythical
     conflicts:
     - MutationOrk
   - type: ComponentMutation

--- a/Resources/Prototypes/_Trauma/Genetics/Mutations/olfaction.yml
+++ b/Resources/Prototypes/_Trauma/Genetics/Mutations/olfaction.yml
@@ -7,6 +7,7 @@
   - type: Mutation
     instability: 25
     difficulty: 12
+    rarity: Rare
   - type: ComponentMutation
     added:
     - type: ScentTracker

--- a/Resources/Prototypes/_Trauma/Genetics/Mutations/reach.yml
+++ b/Resources/Prototypes/_Trauma/Genetics/Mutations/reach.yml
@@ -7,6 +7,7 @@
   - type: Mutation
     instability: 35
     difficulty: 18
+    rarity: Mythical
   - type: ComponentMutation
     added:
     - type: Telekinesis
@@ -53,6 +54,7 @@
   - type: Mutation
     instability: 35
     difficulty: 24 # good luck chuddy
+    rarity: Mythical
   # TODO: prevent wearing gloves, disable picking up two handed items
   - type: EffectsMutation
     added:

--- a/Resources/Prototypes/_Trauma/Genetics/Mutations/sight.yml
+++ b/Resources/Prototypes/_Trauma/Genetics/Mutations/sight.yml
@@ -40,6 +40,7 @@
   - type: Mutation
     instability: 35
     difficulty: 18
+    rarity: Mythical
     # no conflict with blindness because thats some professor X shit
   - type: ComponentMutation
     added:
@@ -81,4 +82,5 @@
   components:
   - type: Mutation
     difficulty: 16
+    rarity: Mythical
   # TODO: move out of goob hulk

--- a/Resources/Prototypes/_Trauma/Genetics/Mutations/telepathy.yml
+++ b/Resources/Prototypes/_Trauma/Genetics/Mutations/telepathy.yml
@@ -7,6 +7,7 @@
   - type: Mutation
     instability: 10
     difficulty: 12
+    rarity: Rare
   - type: ActionMutation
     action: ActionMutationTelepathy
 

--- a/Resources/Prototypes/_Trauma/Genetics/Mutations/touch.yml
+++ b/Resources/Prototypes/_Trauma/Genetics/Mutations/touch.yml
@@ -7,6 +7,7 @@
   - type: Mutation
     instability: 25
     difficulty: 16
+    rarity: Mythical
   - type: ActionMutation
     action: ActionMutationShockTouch
 
@@ -41,6 +42,7 @@
   - type: Mutation
     instability: 35
     difficulty: 16
+    rarity: Mythical
   #- type: ActionMutation
   #  action: ActionMutationMendingTouch
   # TODO: jesus christ this has a lot of logic

--- a/Resources/Prototypes/_Trauma/Genetics/Mutations/weakness.yml
+++ b/Resources/Prototypes/_Trauma/Genetics/Mutations/weakness.yml
@@ -8,6 +8,7 @@
   - type: Mutation
     instability: -15
     difficulty: 12
+    rarity: Rare
     conflicts:
     - MutationThermalWeakness
 


### PR DESCRIPTION
- added rarity to some mutations, Rare and Mythical. makes them stand out more from accents and shit. you can see rarity letter when looking at sequences
- changed sequence fail damage from 50 to 20 cellular and 15 radiation, makes it usually more forgiving but makes slimepeople less op from their cellular resistances

resolves #1340

i want to make a full scan sheet that lists the bases too later

## Media
<img width="713" height="298" alt="10:12:46" src="https://github.com/user-attachments/assets/df835f89-5ac6-4556-abc9-b809ea1d8ccc" />

a rare mutation with [R]

**Changelog**
:cl:
- add: Mutations now have a rarity letter shown roughly indicating how difficult it is to sequence. Mutations can be Common, Rare or Mythical.
- tweak: Changed genetics console sequence fail damage to be a mix of cellular and radiation.