### PR TITLE
give borg types specific skills

### DIFF
--- a/Content.Shared/Silicons/Borgs/SharedBorgSystem.cs
+++ b/Content.Shared/Silicons/Borgs/SharedBorgSystem.cs
@@ -185,6 +185,8 @@ public abstract partial class SharedBorgSystem : EntitySystem
         // <Trauma>
         var ev = new BorgBrainInsertedEvent(chassis, args.Entity);
         RaiseLocalEvent(args.Entity, ref ev);
+        var borgEv = new BrainInsertedIntoBorgEvent(args.Entity);
+        RaiseLocalEvent(chassis, ref borgEv);
         // </Trauma>
     }
 
@@ -211,6 +213,8 @@ public abstract partial class SharedBorgSystem : EntitySystem
 
         var ev = new BorgBrainRemovedEvent(chassis, args.Entity);
         RaiseLocalEvent(args.Entity, ref ev);
+        var borgEv = new BrainRemovedFromBorgEvent(args.Entity);
+        RaiseLocalEvent(chassis, ref borgEv);
         // </Trauma>
     }
 

--- a/Content.Trauma.Common/Silicons/Borgs/BorgBrainEvents.cs
+++ b/Content.Trauma.Common/Silicons/Borgs/BorgBrainEvents.cs
@@ -13,3 +13,15 @@ public record struct BorgBrainInsertedEvent(EntityUid Chassis, EntityUid Brain);
 /// </summary>
 [ByRefEvent]
 public record struct BorgBrainRemovedEvent(EntityUid Chassis, EntityUid Brain);
+
+/// <summary>
+/// Raised on the chassis after a borg has a MMI/posibrain inserted.
+/// </summary>
+[ByRefEvent]
+public record struct BrainInsertedIntoBorgEvent(EntityUid Brain);
+
+/// <summary>
+/// Raised on the chassis after a borg has its MMI/posibrain removed.
+/// </summary>
+[ByRefEvent]
+public record struct BrainRemovedFromBorgEvent(EntityUid Brain);

--- a/Content.Trauma.Shared/Knowledge/Components/KnowledgeGrantOnWearComponent.cs
+++ b/Content.Trauma.Shared/Knowledge/Components/KnowledgeGrantOnWearComponent.cs
@@ -7,10 +7,13 @@ using Robust.Shared.Prototypes;
 namespace Content.Trauma.Shared.Knowledge.Components;
 
 /// <summary>
-/// Grants some knowledge when used in hand.
+/// Grants some knowledge when either:
+/// 1. clothing is worn (to the wearer)
+/// 2. organ is installed (to the body)
+/// 3. borg chassis has a mmi/pb inserted (to the brain)
 /// </summary>
 [RegisterComponent, NetworkedComponent]
-[AutoGenerateComponentState]
+[AutoGenerateComponentState(fieldDeltas: true)]
 public sealed partial class KnowledgeGrantOnWearComponent : Component
 {
     /// <summary>
@@ -28,7 +31,7 @@ public sealed partial class KnowledgeGrantOnWearComponent : Component
     /// <summary>
     /// Skills that will be added or boosted upon use.
     /// </summary>
-    [DataField, AlwaysPushInheritance]
+    [DataField, AutoNetworkedField, AlwaysPushInheritance]
     public Dictionary<EntProtoId, int> Skills = new();
 
     /// <summary>
@@ -42,5 +45,4 @@ public sealed partial class KnowledgeGrantOnWearComponent : Component
     /// </summary>
     [DataField, AlwaysPushInheritance]
     public Dictionary<EntProtoId, bool> Blocked = new();
-
 }

--- a/Content.Trauma.Shared/Knowledge/Components/ModifyKnowledgeGrantComponent.cs
+++ b/Content.Trauma.Shared/Knowledge/Components/ModifyKnowledgeGrantComponent.cs
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Trauma.Shared.Knowledge.Systems;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Trauma.Shared.Knowledge.Components;
+
+/// <summary>
+/// Adds to the skills of <see cref="KnowledgeGrantOnWearComponent"/> on mapinit then removes itself.
+/// If this entity has a knowledge container it will also be applied immediately.
+/// </summary>
+[RegisterComponent, NetworkedComponent, Access(typeof(SharedKnowledgeSystem))]
+public sealed partial class ModifyKnowledgeGrantComponent : Component
+{
+    [DataField(required: true)]
+    public Dictionary<EntProtoId, int> Skills = new();
+}

--- a/Content.Trauma.Shared/Knowledge/Systems/SharedKnowledgeSystem.OnWear.cs
+++ b/Content.Trauma.Shared/Knowledge/Systems/SharedKnowledgeSystem.OnWear.cs
@@ -3,8 +3,10 @@
 using Content.Shared.Body;
 using Content.Shared.Clothing;
 using Content.Shared.EntityConditions;
+using Content.Trauma.Common.Silicons.Borgs;
 using Content.Trauma.Shared.Knowledge.Components;
 using Content.Trauma.Shared.MartialArts.Components;
+using Robust.Shared.Prototypes;
 
 namespace Content.Trauma.Shared.Knowledge.Systems;
 
@@ -18,6 +20,11 @@ public abstract partial class SharedKnowledgeSystem
         SubscribeLocalEvent<KnowledgeGrantOnWearComponent, OrganGotRemovedEvent>(OnRemoveKnowledgeOrgan);
         SubscribeLocalEvent<KnowledgeGrantOnWearComponent, ClothingGotEquippedEvent>(OnGrantKnowledgeWear);
         SubscribeLocalEvent<KnowledgeGrantOnWearComponent, ClothingGotUnequippedEvent>(OnRemoveKnowledgeWear);
+        SubscribeLocalEvent<KnowledgeGrantOnWearComponent, BrainInsertedIntoBorgEvent>(OnBrainInsertedIntoBorg);
+        SubscribeLocalEvent<KnowledgeGrantOnWearComponent, BrainRemovedFromBorgEvent>(OnBrainRemovedFromBorg);
+
+        SubscribeLocalEvent<ModifyKnowledgeGrantComponent, MapInitEvent>(OnModifyGrantMapInit,
+            after: [ typeof(InitialBodySystem) ]); // TODO: move this to a partial of KnowledgeGrantSystem bruh...
     }
 
     private void OnGrantKnowledgeOrgan(Entity<KnowledgeGrantOnWearComponent> ent, ref OrganGotInsertedEvent args)
@@ -32,10 +39,22 @@ public abstract partial class SharedKnowledgeSystem
     private void OnRemoveKnowledgeWear(Entity<KnowledgeGrantOnWearComponent> ent, ref ClothingGotUnequippedEvent args)
         => RemoveKnowledgeModifiers(args.Wearer, ent);
 
+    private void OnBrainInsertedIntoBorg(Entity<KnowledgeGrantOnWearComponent> ent, ref BrainInsertedIntoBorgEvent args)
+        => ApplyKnowledgeModifiers(args.Brain, ent);
+
+    private void OnBrainRemovedFromBorg(Entity<KnowledgeGrantOnWearComponent> ent, ref BrainRemovedFromBorgEvent args)
+        => RemoveKnowledgeModifiers(args.Brain, ent);
+
+    private void OnModifyGrantMapInit(Entity<ModifyKnowledgeGrantComponent> ent, ref MapInitEvent args)
+    {
+        AddGrantedSkills(ent.Owner, user: ent.Owner, ent.Comp.Skills);
+        RemComp(ent, ent.Comp);
+    }
+
     private void ApplyKnowledgeModifiers(EntityUid wearer, Entity<KnowledgeGrantOnWearComponent> ent)
     {
         ent.Comp.Applied = _conditions.TryConditions(wearer, ent.Comp.Conditions);
-        Dirty(ent);
+        DirtyField(ent, ent.Comp, nameof(KnowledgeGrantOnWearComponent.Applied));
         if (!ent.Comp.Applied || GetContainer(wearer) is not { } brain)
             return;
 
@@ -78,7 +97,7 @@ public abstract partial class SharedKnowledgeSystem
             return;
 
         ent.Comp.Applied = false;
-        Dirty(ent);
+        DirtyField(ent, ent.Comp, nameof(KnowledgeGrantOnWearComponent.Applied));
 
         // Remove Skills
         foreach (var (id, level) in ent.Comp.Skills)
@@ -116,6 +135,35 @@ public abstract partial class SharedKnowledgeSystem
             {
                 martial.Blocked = --martial.TemporaryBlockedCounter == 0;
                 Dirty(unit, martial);
+            }
+        }
+    }
+
+    /// <summary>
+    /// One-time adjustment to skills.
+    /// Stores the new skills but also adds them to the current user.
+    /// </summary>
+    public void AddGrantedSkills(Entity<KnowledgeGrantOnWearComponent?> ent, EntityUid user, Dictionary<EntProtoId, int> skills)
+    {
+        if (!Resolve(ent, ref ent.Comp))
+            return;
+
+        foreach (var (id, level) in skills)
+        {
+            ent.Comp.Skills[id] = ent.Comp.Skills.GetValueOrDefault(id) + level;
+        }
+        DirtyField(ent, ent.Comp, nameof(KnowledgeGrantOnWearComponent.Skills));
+
+        // adjust immediately if it was applied already, if it wasn't applied it will be handled later
+        if (!ent.Comp.Applied || GetContainer(user) is not { } brain)
+            return;
+
+        foreach (var (id, level) in skills)
+        {
+            if (EnsureKnowledge(brain, id) is { } unit)
+            {
+                unit.Comp.TemporaryLevel += level;
+                Dirty(unit);
             }
         }
     }

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -32,6 +32,13 @@
   - type: MiningPoints # for mining borgs mostly
   - type: SpeechSynthesis
     voice: Borg
+  - type: KnowledgeGrantOnWear # gets added to the brain, modified when picking borg type
+    skills:
+      # robot basic stuff
+      FabricationKnowledge: 20
+      WallsKnowledge: 10
+      InfrastructureKnowledge: 10
+      ElectronicsKnowledge: 10
   # </Trauma>
   - type: Reactive
     groups:
@@ -619,7 +626,7 @@
   - type: BypassLock
     bypassDelay: 15 # We don't want people to easily be able to remove xenoborg brains.
   # <Trauma>
-  - type: KnowledgeGrant
+  - type: KnowledgeGrantOnWear # gets added to the brain
     skills:
       MeleeKnowledge: 26
       ShootingKnowledge: 26

--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -21,6 +21,18 @@
   radioChannels:
   - Science
 
+  # <Trauma>
+  addComponents:
+  - type: ModifyKnowledgeGrant
+    skills:
+      ScienceKnowledge: 50 # not good at much else
+      MaterialsKnowledge: 10
+      BotsKnowledge: 50
+      InfrastructureKnowledge: 20
+      WallsKnowledge: 20 # containing anoms or whatever
+      WindowsKnowledge: 20
+  # </Trauma>
+
   # Visual
   inventoryTemplateId: borgShort
   spriteBodyState: robot
@@ -60,6 +72,28 @@
   - Engineering
   - Science
 
+  # <Trauma>
+  addComponents:
+  - type: ModifyKnowledgeGrant
+    skills:
+      # crafting
+      FabricationKnowledge: 60
+      MetalworkingKnowledge: 40
+      CarvingKnowledge: 40
+      MechanicsKnowledge: 40
+      # recipes
+      MaterialsKnowledge: 50
+      DoorsKnowledge: 50
+      AirlocksKnowledge: 50
+      BotsKnowledge: 30
+      InfrastructureKnowledge: 50
+      FurnitureKnowledge: 50
+      ElectronicsKnowledge: 50
+      WallsKnowledge: 50
+      ScienceKnowledge: 10 # sciborg is better
+      WindowsKnowledge: 50
+  # </Trauma>
+
   # Visual
   inventoryTemplateId: borgShort
   spriteBodyState: engineer
@@ -98,10 +132,16 @@
   - Supply
   - Science
 
-  addComponents: # Goobstation
+  # <Trauma>
+  addComponents:
   - type: NoWieldNeeded
-  - type: SlavedBorg # Goobstation: Special AI labeling for salv borgs.
+  - type: SlavedBorg # Special AI labeling for salv borgs.
     law: ObeyAI
+  - type: ModifyKnowledgeGrant
+    skills:
+      MeleeKnowledge: 30 # TODO: mining skill
+      ShootingKnowledge: 20 # for pka module??
+  # </Trauma>
 
   lawset: Salvage # DeltaV: Custom lawset
 
@@ -141,6 +181,16 @@
   radioChannels:
   - Science
   - Service
+
+  # <Trauma>
+  addComponents:
+  - type: ModifyKnowledgeGrant
+    skills:
+      JanitorKnowledge: 100 # mankind is dead. trash is fuel. disposals is full.
+      MaterialsKnowledge: 10
+      InfrastructureKnowledge: 10
+      WallsKnowledge: 10
+  # </Trauma>
 
   lawset: Janitor # DeltaV: Custom lawset
 
@@ -186,6 +236,7 @@
   - Science
   - Medical
 
+
   addComponents:
   - type: SolutionScanner
   - type: ShowHealthBars
@@ -194,10 +245,16 @@
   - type: ShowHealthIcons
     damageContainers:
     - Biological
+  # <Trauma>
+  - type: ModifyKnowledgeGrant
+    skills:
+      FirstAidKnowledge: 50
+      SurgeryKnowledge: 80 # robots are unsurprisingly good at making cuts
   - type: Sanitized # Shitmed
   - type: SurgeryIgnoreClothing
   - type: SurgerySpeedModifier
     speedModifier: 1.5
+  # </Trauma>
 
   # Visual
   inventoryTemplateId: borgDutch
@@ -244,6 +301,14 @@
   radioChannels:
   - Science
   - Service
+
+  # <Trauma>
+  addComponents:
+  - type: ModifyKnowledgeGrant
+    skills:
+      ToysKnowledge: 80 # the clown's bitch
+      BotsKnowledge: 50 # honk
+  # </Trauma>
 
   # Visual
   inventoryTemplateId: borgTall


### PR DESCRIPTION
borgs gain bonus skills relevant to their type
bonus skills are lost when removed from the chassis

## Media
medborg
<img width="545" height="442" alt="13:13:44" src="https://github.com/user-attachments/assets/318e5af4-2f5d-43cf-9749-a32c6e05df7e" />


engiborg, theres a lot of crafting shit
<img width="561" height="488" alt="13:14:18" src="https://github.com/user-attachments/assets/988bfcda-dac3-4717-95c7-2cf587d91cde" />


**Changelog**
:cl:
- add: Borg subtypes now get their job's knowledge.