### PR TITLE
fix rev propaganda doafter being hidden

### DIFF
--- a/Content.Shared/_EinsteinEngines/Revolutionary/RevolutionaryConverterSystem.cs
+++ b/Content.Shared/_EinsteinEngines/Revolutionary/RevolutionaryConverterSystem.cs
@@ -129,7 +129,7 @@ public sealed class RevolutionaryConverterSystem : EntitySystem
                 converter.Owner,
                 target: target,
                 used: converter.Owner,
-                showTo: converter.Owner)
+                showTo: user)
             {
                 Hidden = !converter.Comp.VisibleDoAfter,
                 BreakOnMove = false,


### PR DESCRIPTION
fixes #1361

the doafter was only shown to the propaganda... fucking amazing

:cl:
- fix: Fixed headrevs not seeing the conversion doafter.