### PR TITLE
fix eshields not working

### DIFF
--- a/Content.Trauma.Shared/Blocking/RechargeableBlockingComponent.cs
+++ b/Content.Trauma.Shared/Blocking/RechargeableBlockingComponent.cs
@@ -26,5 +26,5 @@ public sealed partial class RechargeableBlockingComponent : Component
     public float RechargePercentage = 0.1f;
 
     [DataField, AutoNetworkedField]
-    public bool Discharged = true;
+    public bool Discharged;
 }


### PR DESCRIPTION
fixes #1367

wd always had discharged start as true idk why it was a thing
just made it started enabled by default...

:cl:
- fix: Fixed energy shields not working.