### PR TITLE
allow making med scanner board

### DIFF
--- a/Resources/Prototypes/_Trauma/Recipes/Lathes/Packs/genetics.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Lathes/Packs/genetics.yml
@@ -2,5 +2,6 @@
   id: GeneticsStatic
   recipes:
   - GeneticsConsoleCircuitboard
+  - MedicalScannerMachineCircuitboard
   - GeneticsDisk
   - HandheldGeneticsScanner

--- a/Resources/Prototypes/_Trauma/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Lathes/electronics.yml
@@ -1,0 +1,7 @@
+- type: latheRecipe
+  parent: [ BaseGoldCircuitboardRecipe, BaseResearchMachineRecipeCategory ]
+  id: MedicalScannerMachineCircuitboard
+  result: MedicalScannerMachineCircuitboard
+  icon:
+    sprite: Structures/Machines/scanner.rsi
+    state: open


### PR DESCRIPTION
forgot about it when nuking cloning

:cl:
- add: Scifab can now print medical scanner boards for expanding genetics.