### PR TITLE
Nukies Can use Injectors without doafter

### DIFF
--- a/Resources/Prototypes/_Trauma/Entities/Objects/Specific/BrainChips/nukies.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Objects/Specific/BrainChips/nukies.yml
@@ -16,3 +16,4 @@
       WallsKnowledge: 26
       InfrastructureKnowledge: 26
       ElectronicsKnowledge: 26
+      FirstAidKnowledge: 26


### PR DESCRIPTION
So they can use injectors without doafter

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->
gave nukies 26 (average) first aid

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
so they can use injectors without doafter, i imagine these guys are trained to do this shit
## Technical details
<!-- Summary of code changes for easier review. -->


## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Gave Nukies Average first aid skill


-->
