### PR TITLE
Tweak vending machine food

### DIFF
--- a/Resources/Prototypes/_Trauma/Reagents/Consumable/Food/food.yml
+++ b/Resources/Prototypes/_Trauma/Reagents/Consumable/Food/food.yml
@@ -15,16 +15,21 @@
     Digestion:
       metabolismRate: 0.01 # Effectively one unit every 100 seconds.
       metabolites:
-        Microplastics: 0.01 # magic
+        LabGrownNutriment: 1
       effects:
       - !type:SatiateHunger
         factor: 0.015 # same as regular nutriment per u
-      - !type:Vomit
-        probability: 0.005
+    Bloodstream:
+      metabolismRate: 0.01
+      conditions:
+      - !type:MetabolizerTypeCondition
+        type: [ Vox, Slime ] # Vox literally eat trash, and slimes are highly resistant to various poisons
+        inverted: true
+      effects:
       - !type:HealthChange
         damage:
           types:
-            Poison: 0.05
+            Cellular: 0.04 # 4 damage per snack. Not great, not terrible
       - !type:PopupMessage
         type: Local
         messages: [ "reagent-popup-lab-grown-nutriment" ]


### PR DESCRIPTION
## About the PR
Food from vending machines no longer makes you vomit, deals cellular instead of poison, has no negative effect on vox and slimes.

## Why / Balance
Vomiting doesn't feel fitting for cheap food, and makes it entirely useless since vomiting drains hunger. Now it's at least guaranteed to actually satiate you.
Poison damage is too easy to treat, cellular is more evil. Maybe chem will finally start making anti-cellular meds.
Vox can literally eat trash, and one of the slime's main perks is (or, well, was) high poison and cellular resists, so it makes sense for them not to be affected.

## Technical details
YAML tweaks

**Changelog**
:cl:
- tweak: Food from vendors no longer makes you vomit. It still deals damage, though.
