### PR TITLE
disable the worst disabilities for command/sec

### DIFF
--- a/Resources/Prototypes/Traits/disabilities.yml
+++ b/Resources/Prototypes/Traits/disabilities.yml
@@ -38,6 +38,12 @@
   whitelist:
     components:
       - Blindable
+  # <Trauma>
+  blacklist:
+    components:
+    - CommandStaff
+    - SecurityStaff
+  # </Trauma>
   components:
     - type: PermanentBlindness
 
@@ -59,6 +65,12 @@
   name: trait-narcolepsy-name
   description: trait-narcolepsy-desc
   category: Disabilities
+  # <Trauma>
+  blacklist:
+    components:
+    - CommandStaff
+    - SecurityStaff
+  # </Trauma>
   components:
     - type: Narcolepsy
       maxTimeBetweenIncidents: 600
@@ -90,6 +102,10 @@
   category: Disabilities
   blacklist:
     components:
+      # <Trauma>
+      - CommandStaff
+      - SecurityStaff
+      # </Trauma>
       - BorgChassis
   components:
     - type: Muted
@@ -133,5 +149,11 @@
   description: trait-impaired-mobility-desc
   traitGear: OffsetCane
   category: Disabilities
+  # <Trauma>
+  blacklist:
+    components:
+    - CommandStaff
+    - SecurityStaff
+  # </Trauma>
   components:
   - type: ImpairedMobility


### PR DESCRIPTION
resolves #1374

blind: holy antag bait
mute: rulebreaking for not communicating
narcoleptic: holy antag bait
wheelchair bound: shove cap and now he can barely crawl, antag bait

it doesnt make sense that NT would hire any of these to critical positions, so out of the kindness of their hearts they cured you <3

:cl:
- tweak: Command and Security can no longer be blind, mute, narcoleptic or wheelchair bound.