### PR TITLE
make salicylic acid usable again

### DIFF
--- a/Resources/Prototypes/_Goobstation/Reagents/medicine.yml
+++ b/Resources/Prototypes/_Goobstation/Reagents/medicine.yml
@@ -794,28 +794,8 @@
       effects:
       - !type:EvenHealthChange
         damage:
-          Brute: -12
+          Brute: -4
         conditions:
-        - !type:TypedDamageCondition
-          damage:
-            types:
-              Blunt: 25
-              Slash: 25
-              Piercing: 25
-        - !type:ReagentCondition
-          reagent: SalicylicAcid
-          max: 25
-      - !type:EvenHealthChange
-        damage:
-          Brute: -3
-        conditions:
-        - !type:TypedDamageCondition
-          damage:
-            types:
-              Blunt: 25
-              Slash: 25
-              Piercing: 25
-          inverted: true
         - !type:ReagentCondition
           reagent: SalicylicAcid
           max: 25


### PR DESCRIPTION
damage specifiers no longer have group so this slop has to be removed

:cl:
- tweak: Made salicylic acid always heal the same midlevel amount, but it no longer has a huge damage requirement to work.