### PR TITLE
fix reverse bear trap working without a head

### DIFF
--- a/Content.Goobstation.Shared/ReverseBearTrap/ReverseBearTrapSystem.cs
+++ b/Content.Goobstation.Shared/ReverseBearTrap/ReverseBearTrapSystem.cs
@@ -267,9 +267,10 @@ public sealed partial class ReverseBearTrapSystem : EntitySystem
         if (args.Cancelled || args.Target is not { } target || args.Used is not { } used)
             return;
 
+        var user = args.User;
         if (!_inventory.TryGetSlotEntity(target, "head", out var _)
-            && _inventory.TryEquip(target, used, "head", silent: true, predicted: true))
-            ArmTrap(used, trap, target, args.User);
+            && _inventory.TryEquip(user, target, used, "head", predicted: true))
+            ArmTrap(used, trap, target, user);
     }
 
     private void OnWeldFinished(EntityUid uid, ReverseBearTrapComponent trap, WeldFinishedEvent args)


### PR DESCRIPTION
fixes #1425 

it was force equipping for no reason so body couldnt prevent it. also passed the user...

extremely niche bug no cl