### PR TITLE
queen one shove stun

### DIFF
--- a/Content.Trauma.Shared/Xenomorph/NeurotoxinGlandComponent.cs
+++ b/Content.Trauma.Shared/Xenomorph/NeurotoxinGlandComponent.cs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 using Robust.Shared.GameStates;
-using Robust.Shared.Prototypes; // Goobstation
+using Robust.Shared.Prototypes;
 
 namespace Content.Trauma.Shared.Xenomorph;
 

--- a/Content.Trauma.Shared/Xenomorph/NeurotoxinGlandSystem.cs
+++ b/Content.Trauma.Shared/Xenomorph/NeurotoxinGlandSystem.cs
@@ -2,6 +2,7 @@
 
 using Content.Shared._White.Xenomorphs;
 using Content.Shared.Actions;
+using Content.Shared.Body;
 using Content.Shared.Popups;
 using Content.Shared.Weapons.Ranged.Events;
 
@@ -31,8 +32,8 @@ public sealed class NeurotoxinGlandSystem : EntitySystem
     private void OnShotAttempted(Entity<NeurotoxinGlandComponent> ent, ref ShotAttemptedEvent args)
     {
         // Prevent shooting if the gland is not active. It still lets them shove.
-        if (!ent.Comp.Active)
-            args.Cancel();
+        if (!ent.Comp.Active && TryComp<OrganComponent>(ent, out var organ) && args.User == organ.Body)
+        args.Cancel();
     }
 
     private void OnToggleAcidSpit(Entity<NeurotoxinGlandComponent> ent, ref ToggleAcidSpitEvent args)

--- a/Resources/Prototypes/_Trauma/Actions/neurotoxintoggle.yml
+++ b/Resources/Prototypes/_Trauma/Actions/neurotoxintoggle.yml
@@ -1,0 +1,12 @@
+- type: entity
+  id: ActionAcidSpit
+  parent: BaseAction
+  name: Acid spit
+  description: Toggle the ability to spit neurotoxin. When enabled, use (M2) to shoot.
+  components:
+  - type: Action
+    useDelay: 1
+    itemIconStyle: BigAction
+    icon: { sprite: _White/Interface/Actions/xenomorph.rsi, state: acid } # TODO: Custom sprite
+  - type: InstantAction
+    event: !type:ToggleAcidSpitEvent

--- a/Resources/Prototypes/_White/Actions/xenomorph.yml
+++ b/Resources/Prototypes/_White/Actions/xenomorph.yml
@@ -254,17 +254,3 @@
     event: !type:PromotionActionEvent
   - type: PlasmaCostAction
     plasmaCost: 500
-
-# Goobstation - Toggleable acid spit action
-- type: entity
-  id: ActionAcidSpit
-  parent: BaseAction
-  name: Acid spit
-  description: Toggle the ability to spit neurotoxin. When enabled, use (M2) to shoot.
-  components:
-  - type: Action
-    useDelay: 1
-    itemIconStyle: BigAction
-    icon: { sprite: _White/Interface/Actions/xenomorph.rsi, state: acid } # TODO: Custom sprite
-  - type: InstantAction
-    event: !type:ToggleAcidSpitEvent

--- a/Resources/Prototypes/_White/Body/Species/base.yml
+++ b/Resources/Prototypes/_White/Body/Species/base.yml
@@ -272,6 +272,7 @@
       availableModes:
       - FullAuto
       soundGunshot: /Audio/Weapons/Xeno/alien_spitacid.ogg
+    - type: NeurotoxinGland
 
 - type: entity
   parent: [ OrganBaseInternal, OrganXenomorphInternal ]

--- a/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/praetorian.yml
+++ b/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/praetorian.yml
@@ -15,7 +15,6 @@
     - map: [ "pocket2" ]
   - type: Xenomorph
     caste: Praetorian
-  - type: NeurotoxinGland
   - type: TailLash
     tailDamage:
       types:

--- a/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/queen.yml
+++ b/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/queen.yml
@@ -56,7 +56,6 @@
         Piercing: 20
   - type: XenomorphShoveTracker
     shoveThreshold: 1
-  - type: NeurotoxinGland
   - type: Deathgasp
     prototype: XenomorphQueenDeathgasp
   - type: Speech

--- a/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/sentinel.yml
+++ b/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/sentinel.yml
@@ -19,7 +19,6 @@
       visible: false
   - type: Xenomorph
     caste: Sentinel
-  - type: NeurotoxinGland
   - type: VentCrawler
   - type: Cuffable
   - type: MobThresholds


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->
queens shove stuns in one hit, also ported the neurotoxin spit changes from https://github.com/Goob-Station/Goob-Station/pull/5551
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
why is the queen weak?
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
--> 🆑 assripper.

 - tweak: the xenomorph queen now stuns in one shove, neurotoxin spit is also toggleable now
