### PR TITLE
nukies need more skill for eshield/esword

### DIFF
--- a/Resources/Prototypes/_Trauma/Entities/Objects/Specific/BrainChips/nukies.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Objects/Specific/BrainChips/nukies.yml
@@ -9,7 +9,7 @@
   - type: KnowledgeGrantOnWear
     skills:
       # Nukies are well-trained
-      MeleeKnowledge: 40
+      MeleeKnowledge: 50
       ShootingKnowledge: 40
       StrengthKnowledge: 40
       WeaponsKnowledge: 40


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
boosting nukie melee to from 40-50 so they can now parry with some melee weapons round start.

## Why / Balance
its silly that they cant

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl: 
- tweak: Changed nukies melee skillchip from 40 -> 50 round start so they can properly reflect/parry with an energy sword and shield.
