### PR TITLE
[BOUNTY] Let Diona and Nymps see over kudzu.

### DIFF
--- a/Content.Client/Kudzu/KudzuVisualizerSystem.cs
+++ b/Content.Client/Kudzu/KudzuVisualizerSystem.cs
@@ -7,70 +7,21 @@
 
 using Content.Shared.Spreader;
 using Robust.Client.GameObjects;
-using Robust.Client.Player;
-using Content.Shared.DrawDepth;
-using Content.Shared.Humanoid;
-using Content.Shared.Humanoid.Prototypes;
-using Robust.Shared.Prototypes;
-using Robust.Shared.Player;
 
 namespace Content.Client.Kudzu;
 
 public sealed class KudzuVisualsSystem : VisualizerSystem<KudzuVisualsComponent>
 {
-    private static readonly ProtoId<SpeciesPrototype> DionaSpecies = "Diona";
-
-    [Dependency] private readonly IPlayerManager _player = default!;
-
-    public override void Initialize()
-    {
-        base.Initialize();
-
-        SubscribeLocalEvent<LocalPlayerAttachedEvent>(_ => RefreshAllKudzuDrawDepths());
-        SubscribeLocalEvent<LocalPlayerDetachedEvent>(_ => RefreshAllKudzuDrawDepths());
-    }
-
     protected override void OnAppearanceChange(EntityUid uid, KudzuVisualsComponent component, ref AppearanceChangeEvent args)
     {
+
         if (args.Sprite == null)
             return;
-
         if (AppearanceSystem.TryGetData<int>(uid, KudzuVisuals.Variant, out var var, args.Component)
             && AppearanceSystem.TryGetData<int>(uid, KudzuVisuals.GrowthLevel, out var level, args.Component))
         {
             var index = SpriteSystem.LayerMapReserve((uid, args.Sprite), $"{component.Layer}");
             SpriteSystem.LayerSetRsiState((uid, args.Sprite), index, $"kudzu_{level}{var}");
         }
-
-        UpdateKudzuDrawDepth(uid, args.Sprite);
-    }
-
-    private void RefreshAllKudzuDrawDepths()
-    {
-        var query = EntityQueryEnumerator<KudzuVisualsComponent, SpriteComponent>();
-
-        while (query.MoveNext(out var uid, out _, out var sprite))
-        {
-            UpdateKudzuDrawDepth(uid, sprite);
-        }
-    }
-
-    private void UpdateKudzuDrawDepth(EntityUid uid, SpriteComponent sprite)
-    {
-        var drawDepth = LocalPlayerIsDiona()
-            ? (int) Content.Shared.DrawDepth.DrawDepth.HighFloorObjects
-            : (int) Content.Shared.DrawDepth.DrawDepth.Overdoors;
-
-        SpriteSystem.SetDrawDepth((uid, sprite), drawDepth);
-    }
-
-    private bool LocalPlayerIsDiona()
-    {
-        var attached = _player.LocalSession?.AttachedEntity;
-        if (attached == null)
-            return false;
-
-        return TryComp(attached.Value, out HumanoidProfileComponent? profile) &&
-               profile.Species == DionaSpecies;
     }
 }

--- a/Content.Trauma.Client/Kudzu/SeeOverObstacleSystem.cs
+++ b/Content.Trauma.Client/Kudzu/SeeOverObstacleSystem.cs
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Trauma.Common.Kudzu;
+using Robust.Client.GameObjects;
+using Robust.Client.Player;
+using Robust.Shared.Player;
+
+namespace Content.Trauma.Client.Kudzu;
+
+public sealed class SeeOverObstacleSystem : EntitySystem
+{
+    [Dependency] private readonly IPlayerManager _player = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<SeeOverObstacleComponent, ComponentStartup>(OnObstacleStartup);
+        SubscribeLocalEvent<SeeOverObstacleComponent, AppearanceChangeEvent>(OnObstacleAppearanceChange);
+        SubscribeLocalEvent<SeeOverObstacleComponent, RefreshSeeOverObstacleVisualsEvent>(OnObstacleRefresh);
+
+        SubscribeLocalEvent<SeeOverObstaclesComponent, ComponentStartup>(OnViewerStartup);
+        SubscribeLocalEvent<SeeOverObstaclesComponent, ComponentShutdown>(OnViewerShutdown);
+
+        SubscribeLocalEvent<LocalPlayerAttachedEvent>(OnLocalPlayerAttached);
+        SubscribeLocalEvent<LocalPlayerDetachedEvent>(OnLocalPlayerDetached);
+    }
+
+    private void OnObstacleStartup(Entity<SeeOverObstacleComponent> ent, ref ComponentStartup args)
+    {
+        UpdateObstacleDrawDepth(ent);
+    }
+
+    private void OnObstacleAppearanceChange(Entity<SeeOverObstacleComponent> ent, ref AppearanceChangeEvent args)
+    {
+        if (args.Sprite == null)
+            return;
+
+        UpdateObstacleDrawDepth(ent, args.Sprite);
+    }
+
+    private void OnObstacleRefresh(Entity<SeeOverObstacleComponent> ent, ref RefreshSeeOverObstacleVisualsEvent args)
+    {
+        UpdateObstacleDrawDepth(ent);
+    }
+
+    private void OnViewerStartup(Entity<SeeOverObstaclesComponent> ent, ref ComponentStartup args)
+    {
+        if (_player.LocalSession?.AttachedEntity == ent.Owner)
+            RefreshAllObstacles();
+    }
+
+    private void OnViewerShutdown(Entity<SeeOverObstaclesComponent> ent, ref ComponentShutdown args)
+    {
+        if (_player.LocalSession?.AttachedEntity == ent.Owner)
+            RefreshAllObstacles();
+    }
+
+    private void OnLocalPlayerAttached(LocalPlayerAttachedEvent args)
+    {
+        RefreshAllObstacles();
+    }
+
+    private void OnLocalPlayerDetached(LocalPlayerDetachedEvent args)
+    {
+        RefreshAllObstacles();
+    }
+
+    private void RefreshAllObstacles()
+    {
+        var query = EntityQueryEnumerator<SeeOverObstacleComponent>();
+
+        while (query.MoveNext(out var uid, out _))
+        {
+            var ev = new RefreshSeeOverObstacleVisualsEvent();
+            RaiseLocalEvent(uid, ref ev);
+        }
+    }
+
+    private void UpdateObstacleDrawDepth(Entity<SeeOverObstacleComponent> ent, SpriteComponent? sprite = null)
+    {
+        if (!Resolve(ent.Owner, ref sprite, false))
+            return;
+
+        var drawDepth = LocalPlayerCanSeeOverObstacles()
+            ? ent.Comp.SeeOverDrawDepth
+            : ent.Comp.NormalDrawDepth;
+
+        _sprite.SetDrawDepth((ent.Owner, sprite), drawDepth);
+    }
+
+    private bool LocalPlayerCanSeeOverObstacles()
+    {
+        var attached = _player.LocalSession?.AttachedEntity;
+        return attached != null && HasComp<SeeOverObstaclesComponent>(attached.Value);
+    }
+}

--- a/Content.Trauma.Common/Kudzu/RefreshSeeOverObstacleVisualsEvent.cs
+++ b/Content.Trauma.Common/Kudzu/RefreshSeeOverObstacleVisualsEvent.cs
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Content.Trauma.Common.Kudzu;
+
+[ByRefEvent]
+public record struct RefreshSeeOverObstacleVisualsEvent;

--- a/Content.Trauma.Common/Kudzu/SeeOverObstacleComponent.cs
+++ b/Content.Trauma.Common/Kudzu/SeeOverObstacleComponent.cs
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Robust.Shared.GameStates;
+
+namespace Content.Trauma.Common.Kudzu;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class SeeOverObstacleComponent : Component
+{
+    // Keep raw depth values here so Trauma.Common stays decoupled from Content.Shared.
+    [DataField, AutoNetworkedField]
+    public int NormalDrawDepth = 10;
+
+    [DataField, AutoNetworkedField]
+    public int SeeOverDrawDepth = -5;
+}

--- a/Content.Trauma.Common/Kudzu/SeeOverObstaclesComponent.cs
+++ b/Content.Trauma.Common/Kudzu/SeeOverObstaclesComponent.cs
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Robust.Shared.GameStates;
+
+namespace Content.Trauma.Common.Kudzu;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class SeeOverObstaclesComponent : Component;

--- a/Resources/Changelog/TraumaChangelog.yml
+++ b/Resources/Changelog/TraumaChangelog.yml
@@ -5048,6 +5048,7 @@ Entries:
   id: 593
   time: '2026-03-20T18:34:24.0000000+00:00'
   url: https://github.com/Trauma-Station/Trauma-Station/pull/1479
+<<<<<<< HEAD
 - author: deltanedas
   changes:
   - type: Fix
@@ -5121,3 +5122,10 @@ Entries:
   id: 602
   time: '2026-03-21T10:54:39.0000000+00:00'
   url: https://github.com/Trauma-Station/Trauma-Station/pull/1499
+- author: Raze500
+  changes:
+  - type: Fix
+    message: Diona and diona nymphs can now see over kudzu and floral kudzu again.
+  id: 603
+  time: '2026-03-21T18:00:00.0000000+00:00'
+  url: https://github.com/Trauma-Station/Trauma-Station/pull/1491

--- a/Resources/Prototypes/Body/Species/diona.yml
+++ b/Resources/Prototypes/Body/Species/diona.yml
@@ -174,6 +174,7 @@
   - type: BodyEmotes
     soundsId: DionaBodyEmotes
   - type: IgnoreKudzu
+  - type: SeeOverObstacles
   - type: IgniteOnHeatDamage
     fireStacks: 1
     threshold: 12

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -3976,6 +3976,7 @@
   - type: Emoting
   - type: BodyEmotes
     soundsId: Nymph
+  - type: SeeOverObstacles
   - type: Reform
     actionPrototype: DionaReformAction
     reformTime: 10

--- a/Resources/Prototypes/Entities/Objects/Misc/kudzu.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/kudzu.yml
@@ -33,6 +33,7 @@
       sprite: Objects/Misc/kudzu.rsi
       state: kudzu_11
       drawdepth: Overdoors
+    - type: SeeOverObstacle
     - type: KudzuVisuals
     - type: Clickable
     - type: Fixtures
@@ -124,6 +125,9 @@
       drawdepth: HighFloorObjects
       sprite: Objects/Misc/kudzuflower.rsi
       state: kudzu_11
+    - type: SeeOverObstacle
+      normalDrawDepth: -5
+      seeOverDrawDepth: -5
     - type: Kudzu
       spriteVariants: 5
       spreadChance: 0.01


### PR DESCRIPTION
## What this does
- moves the diona-over-kudzu logic out of upstream client code into Trauma-specific common/client code
- uses a marker component so both diona and diona nymphs can see over kudzu
- applies the behavior to normal kudzu and floral kudzu only
- leaves tendons and shadow fog unchanged
- adds a changelog entry

## Verification
- built Content.Trauma.Common.csproj successfully
- built Content.Trauma.Client.csproj successfully

## Demo video