### PR TITLE
no more carp tail movespeed

### DIFF
--- a/Resources/Prototypes/_Shitmed/Body/Species/carp.yml
+++ b/Resources/Prototypes/_Shitmed/Body/Species/carp.yml
@@ -6,8 +6,6 @@
   id: AppearanceCarp
   name: carp appearance
   components:
-  - type: Legs
-    required: 1 # tail
   - type: InitialBody
     organs:
       # Parts
@@ -59,9 +57,6 @@
   name: carp tail
   description: Unique glands in this tail let space carp fly in a vacuum.
   components:
-  - type: MovementBodyPart
-    walkSpeed: 2.5
-    sprintSpeed: 3.5
   - type: Sprite
     layers:
     - state: tail-icon


### PR DESCRIPTION
nobody reworked it so removed pending rework :trollface: 

no longer able to immobilise carp but oh well

dragon keeps it because you have to kill a fucking dragon

## Media
carp can still move

<img width="474" height="197" alt="10:07:36" src="https://github.com/user-attachments/assets/2e6dbb82-d23b-4526-962f-8cd2821d6225" />


**Changelog**
:cl:
- remove: Carp tails no longer make you super fast.