### PR TITLE
Increase lobby time a bit

### DIFF
--- a/Content.Shared/CCVar/CCVars.Game.cs
+++ b/Content.Shared/CCVar/CCVars.Game.cs
@@ -30,7 +30,7 @@ public sealed partial class CCVars
     ///     Controls the duration of the lobby timer in seconds. Defaults to 2 minutes and 30 seconds.
     /// </summary>
     public static readonly CVarDef<int>
-        GameLobbyDuration = CVarDef.Create("game.lobbyduration", 210, CVar.ARCHIVE); // Trauma, was 150
+        GameLobbyDuration = CVarDef.Create("game.lobbyduration", 150, CVar.ARCHIVE);
 
     /// <summary>
     ///     Controls if players can latejoin at all.

--- a/Resources/ConfigPresets/_Trauma/trauma.toml
+++ b/Resources/ConfigPresets/_Trauma/trauma.toml
@@ -2,6 +2,7 @@
 role_timers = true
 role_timer_override = "Trauma"
 round_end_pvs_overrides = true
+lobbyduration = 210
 
 [chat]
 max_announcement_length = 512


### PR DESCRIPTION
## About the PR
150 seconds (2.5 minutes) -> 210 seconds (3.5 minutes)

## Why / Balance
2.5 minutes is way too short, considering our longer-than-usual rounds. Also the game takes so long to load on weak PCs (like mine, which qualifies this as mald PR), that you can't even join in time after a server restart.

## Technical details
Changed 1 (one) Cvar

**Changelog**
:cl:
- tweak: Lobby time has been increased from 150 seconds (2.5 minutes) to 210 seconds (3.5 minutes)
