### PR TITLE
run unit + map tests in separate runners

### DIFF
--- a/.github/workflows/build-test-debug.yml
+++ b/.github/workflows/build-test-debug.yml
@@ -93,6 +93,7 @@ jobs:
     # never seen it fail once IDC about archiving it
 
   # Run every test except map loading tests, they take a little while
+  # Any test with Category("MapTests") is excluded
   test-main:
     needs: build
     if: github.event.pull_request.draft == false
@@ -126,7 +127,7 @@ jobs:
     - name: Run main Content.IntegrationTests
       run: |
         DOTNET_gcServer=1 dotnet test bin/Content.IntegrationTests/Content.IntegrationTests.dll -- \
-          NUnit.Where="test !~ PostMapInitTest && test !~ StationPowerTests" \
+          NUnit.Where="cat != MapTests" \
           NUnit.ConsoleOut=0 NUnit.MapWarningTo=Failed NUnit.TestOutputXml="logs" NUnit.WorkDirectory="$(pwd)/test_results"
 
     - name: Archive NUnit3 test results
@@ -138,7 +139,8 @@ jobs:
         retention-days: 7
         compression-level: 9
 
-  # Test all the maps seperately
+  # Test all the map tests seperately
+  # Any test with Category("MapTests") is used
   test-maps:
     needs: build
     if: github.event.pull_request.draft == false
@@ -170,11 +172,11 @@ jobs:
         name: build-output
         path: bin/
 
-    - name: Run map-related IntegrationTests
+    - name: Run MapTests
       run: |
-        DOTNET_gcServer=1 dotnet test bin/Content.IntegrationTests/Content.IntegrationTests.dll \
-          --filter "PostMapInitTest|StationPowerTests" \
-          -- NUnit.ConsoleOut=0 NUnit.MapWarningTo=Failed NUnit.TestOutputXml="logs" NUnit.WorkDirectory="$(pwd)/test_results"
+        DOTNET_gcServer=1 dotnet test bin/Content.IntegrationTests/Content.IntegrationTests.dll -- \
+          NUnit.Where="cat == MapTests" \
+          NUnit.ConsoleOut=0 NUnit.MapWarningTo=Failed NUnit.TestOutputXml="logs" NUnit.WorkDirectory="$(pwd)/test_results"
 
     - name: Archive NUnit3 test results
       if: always()

--- a/Content.IntegrationTests/Tests/PostMapInitTest.cs
+++ b/Content.IntegrationTests/Tests/PostMapInitTest.cs
@@ -27,7 +27,7 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
 namespace Content.IntegrationTests.Tests
 {
-    [TestFixture]
+    [TestFixture, Category("MapTests")] // Trauma - only run these in map tests job
     public sealed class PostMapInitTest
     {
         private const bool SkipTestMaps = true;

--- a/Content.IntegrationTests/Tests/Power/StationPowerTests.cs
+++ b/Content.IntegrationTests/Tests/Power/StationPowerTests.cs
@@ -13,6 +13,7 @@ using Robust.Shared.EntitySerialization;
 
 namespace Content.IntegrationTests.Tests.Power;
 
+[TestFixture, Category("MapTests")] // Trauma - only run these in map tests job
 public sealed class StationPowerTests
 {
     /// <summary>


### PR DESCRIPTION
please bill gates i need this

tests can now be reran with a little more granularity, map tests take 8 minutes to rerun
integration tests no longer wait for unit tests to finish...

## Media

the maps test only runs the map related tests

<img width="1062" height="396" alt="14:02:37" src="https://github.com/user-attachments/assets/b1ec07da-b1ee-4202-a984-4a50a210c622" />

tests for a fresh commit go from 20m

<img width="850" height="334" alt="17:06:29" src="https://github.com/user-attachments/assets/963e38de-0e98-40d8-92b7-984c20aede73" />


to 14m!

<img width="974" height="386" alt="17:06:00" src="https://github.com/user-attachments/assets/5dd767e8-bafc-4db1-97fc-01efa8cef691" />

