### PR TITLE
remove emp damage from brain chip

### DIFF
--- a/Resources/Prototypes/_Trauma/Entities/Objects/Specific/BrainChips/base.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Objects/Specific/BrainChips/base.yml
@@ -24,6 +24,8 @@
     name: brainchip-rename # they get anonymized once installed so health analyzer etc can't out you
   - type: Cybernetics
     disableChance: 0.1 # should be a rare funny thing rather than common huge annoyance
+    empDamage:
+      types: {} # losing your skills is the focus
   # TODO: skills guide examine
 
 - type: entity


### PR DESCRIPTION
some chuds were getting mystery killed by it, the point of it is to lose your skills not fucking die

:cl:
- tweak: Removed shock damage from your skillchip being EMP'd, now it only disables the skills.