### PR TITLE
Kill station random rotation

### DIFF
--- a/Content.Shared/Maps/GameMapPrototype.cs
+++ b/Content.Shared/Maps/GameMapPrototype.cs
@@ -30,7 +30,7 @@ public sealed partial class GameMapPrototype : IPrototype
     [DataField] public bool IsGrid;
 
     [DataField]
-    public bool RandomRotation = true;
+    public bool RandomRotation; // Trauma - make false by default
 
     /// <summary>
     /// Name of the map to use in generic messages, like the map vote.


### PR DESCRIPTION
## About the PR
Stations are no longer rotated randomly on roundstart

## Why / Balance
Literally does nothing but cause issues

## Technical details
Set the default to false

## Media
No

## Requirements
Can't be bothered to test a one line change

**Changelog**
Too minor
