### PR TITLE
fix void ritual shitcode not working in space

### DIFF
--- a/Content.Server/_Shitcode/Heretic/EntitySystems/TemperatureTrackerSystem.cs
+++ b/Content.Server/_Shitcode/Heretic/EntitySystems/TemperatureTrackerSystem.cs
@@ -1,5 +1,6 @@
 using Content.Server.Atmos.EntitySystems;
 using Content.Shared._Shitcode.Heretic.Components;
+using Content.Shared.Atmos;
 using Content.Shared.Temperature;
 using Robust.Shared.Timing;
 
@@ -7,6 +8,7 @@ namespace Content.Server._Shitcode.Heretic.EntitySystems;
 
 public sealed class TemperatureTrackerSystem : EntitySystem
 {
+    [Dependency] private readonly AtmosphereSystem _atmos = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
 
     public override void Initialize()
@@ -14,6 +16,24 @@ public sealed class TemperatureTrackerSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<TemperatureTrackerComponent, AtmosExposedUpdateEvent>(OnAtmosExposed);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        // set them to CMB while in space, AtmosExposedUpdateEvent doesn't get raised if you are in space
+        var query = EntityQueryEnumerator<TemperatureTrackerComponent>();
+        var now = _timing.CurTime;
+        while (query.MoveNext(out var uid, out var comp))
+        {
+            if (now < comp.NextUpdate)
+                continue;
+
+            comp.NextUpdate = now + comp.UpdateDelay;
+            var temp = _atmos.GetContainingMixture(uid)?.Temperature ?? Atmospherics.TCMB;
+            SetTemp((uid, comp), temp);
+        }
     }
 
     private void OnAtmosExposed(Entity<TemperatureTrackerComponent> ent, ref AtmosExposedUpdateEvent args)
@@ -24,6 +44,11 @@ public sealed class TemperatureTrackerSystem : EntitySystem
         ent.Comp.NextUpdate = _timing.CurTime + ent.Comp.UpdateDelay;
 
         var temp = args.GasMixture.Temperature;
+        SetTemp(ent, temp);
+    }
+
+    private void SetTemp(Entity<TemperatureTrackerComponent> ent, float temp)
+    {
         if (MathHelper.CloseToPercent(temp, ent.Comp.Temperature))
             return;
 


### PR DESCRIPTION
fixes #1579

## Media

station warm

<img width="346" height="89" alt="12:03:05" src="https://github.com/user-attachments/assets/6e77ab51-7ea9-4a2d-b007-af63c7226224" />

space cold

<img width="346" height="90" alt="12:03:10" src="https://github.com/user-attachments/assets/d617c7e8-3e52-45c1-8e16-ade5135d93ef" />

**Changelog**
:cl:
- fix: Fixed void heretic rituals that need cold not working in space.