### PR TITLE
Kill Armos

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -638,7 +638,7 @@
   components:
   - type: StationEvent
     earliestStart: 30
-    weight: 50 # Trauma, was 8
+    weight: 8
     minimumPlayers: 15
     maxOccurrences: 1 # can only happen once per round
     startAnnouncement: station-event-communication-interception


### PR DESCRIPTION
## About the PR
Reverted sleeper agents weight to upstream values (50 -> 8)

## Why / Balance
I understand that syndies are a good antag, and giving antags to living players is cool and all, but let's maybe not have them basically guaranteed to happen every round? Not to mention that they're still the highest weight by far among major antags (which they are), so they're still far more likely to roll than other antags. Also something something variety, syndies every round is kinda boring.

## Technical details
One line change

**Changelog**
:cl:
- fix: Sleeper agents are no longer 50 times more likely to happen than other midround antags.
