### PR TITLE
remove paralyze from goliath tentacle

### DIFF
--- a/Content.Shared/Stunnable/SharedStunSystem.cs
+++ b/Content.Shared/Stunnable/SharedStunSystem.cs
@@ -129,7 +129,7 @@ public abstract partial class SharedStunSystem : EntitySystem
         if (_entityWhitelist.IsWhitelistPass(ent.Comp.Blacklist, args.OtherEntity))
             return;
 
-        TryUpdateStunDuration(args.OtherEntity, ent.Comp.Duration);
+        //TryUpdateStunDuration(args.OtherEntity, ent.Comp.Duration); // Trauma - only knockdown chud
         TryKnockdown(args.OtherEntity, ent.Comp.Duration, force: true);
     }
 


### PR DESCRIPTION
fixes #1603 

2 goliaths no longer fucking murder you if you get stunned once (which you can bypass with office chair my beloved anyway)
knockdown is bad but not instant death if the ai doesnt shit itself as it usually does

:cl:
- tweak: Goliaths no longer stun you, they only knock you down.