### PR TITLE
fix AO for directional walls

### DIFF
--- a/Content.Client/Light/AmbientOcclusionOverlay.cs
+++ b/Content.Client/Light/AmbientOcclusionOverlay.cs
@@ -101,7 +101,10 @@ public sealed class AmbientOcclusionOverlay : Overlay
 
                     worldHandle.SetTransform(localMatrix);
                     // 4 pixels
-                    worldHandle.DrawRect(Box2.UnitCentered.Enlarged(distance / EyeManager.PixelsPerMeter), Color.White);
+                    // <Trauma> - use the occluder's BoundingBox instead of hardcoded 1x1 box
+                    var box = entry.Component.BoundingBox; // separate line because access is stupid
+                    worldHandle.DrawRect(box.Enlarged(distance / EyeManager.PixelsPerMeter), Color.White);
+                    // </Trauma>
                 }
             }, Color.Transparent);
 


### PR DESCRIPTION
fixes #1595

sloth hardcoded it to a 1x1 box instead of using the ALREADY EXISTING occluder bounding box...
unfortunately it's not a proper mask system so cant have diagonal AO yet, but directional wall is real

threat interactive maldpost

(ignoring my vram corruption or some shit) there are 3 fullres 32bit rgba textures for storing A SINGLE BIT of information, and arguably it could be lower res too and still look fine as the AO is blurred.

<img width="1229" height="155" alt="20:09:15" src="https://github.com/user-attachments/assets/0ee03a61-b386-4ac0-8a09-8dae8f39d209" />

this dogshit is nothing compared to MGSV's glorious Fox Engine, hand crafted by god and hideo kojima

## Media

<img width="256" height="114" alt="20:02:00" src="https://github.com/user-attachments/assets/cc02ef90-70dc-483b-9276-9c590ad0e145" />

AO only

<img width="290" height="325" alt="20:07:13" src="https://github.com/user-attachments/assets/6ae9573e-7721-4e67-a1ba-9b743168948d" />

:cl:
- fix: Fixed directional walls having the wrong shadow shape of a full tile.