### PR TITLE
make digiboard not require access

### DIFF
--- a/Content.Server/Cargo/Systems/CargoSystem.Trauma.cs
+++ b/Content.Server/Cargo/Systems/CargoSystem.Trauma.cs
@@ -15,18 +15,16 @@ public sealed partial class CargoSystem
 
     /// <summary>
     /// Check that the user has the account's approve access.
-    /// Does nothing when emagged with an access breaker.
+    /// Does nothing when emagged with an access breaker or for access-ignoring consoles.
     /// </summary>
     public bool CheckAccessPopup(Entity<CargoOrderConsoleComponent> ent, EntityUid user, CargoAccountPrototype account)
     {
-        if (!_emag.CheckFlag(ent, EmagType.Access) && !_accessReaderSystem.UserHasAccess(user, account.ApproveAccess))
-        {
-            ConsolePopup(user, Loc.GetString("cargo-console-order-not-allowed"));
-            PlayDenySound(ent, ent.Comp);
-            return false;
-        }
+        if (ent.Comp.IgnoreAccess || _emag.CheckFlag(ent, EmagType.Access) || _accessReaderSystem.UserHasAccess(user, account.ApproveAccess))
+            return true;
 
-        return true;
+        ConsolePopup(user, Loc.GetString("cargo-console-order-not-allowed"));
+        PlayDenySound(ent, ent.Comp);
+        return false;
     }
 
     public bool CheckAlertPopup(Entity<CargoOrderConsoleComponent> ent, EntityUid user, CargoOrderData order, EntityUid station)

--- a/Content.Shared/Cargo/Components/CargoOrderConsoleComponent.Trauma.cs
+++ b/Content.Shared/Cargo/Components/CargoOrderConsoleComponent.Trauma.cs
@@ -11,4 +11,10 @@ public sealed partial class CargoOrderConsoleComponent
     [DataField, AutoNetworkedField]
     [Access(Other = AccessPermissions.ReadWriteExecute)]
     public NetEntity? Destination;
+
+    /// <summary>
+    /// Allows disabling access check for the target account.
+    /// </summary>
+    [DataField]
+    public bool IgnoreAccess;
 }

--- a/Resources/Prototypes/Entities/Objects/Misc/folders.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/folders.yml
@@ -460,6 +460,7 @@
           tags:
           - Write
   - type: CargoOrderConsole
+    ignoreAccess: true # Trauma
     removeLimitAccess: [ "Quartermaster" ]
   - type: ActivatableUI
     verbText: qm-clipboard-computer-verb-text


### PR DESCRIPTION
its how it used to work
you can now order shit with cargos account without needing ai or cap if theres no qm, just toolbox the locker

:cl:
- tweak: QM digiboard no longer requires access to order things.