### PR TITLE
knowledge construction hiding rewrite + inheritance

### DIFF
--- a/Content.Client/Construction/UI/ConstructionMenu.Trauma.xaml.cs
+++ b/Content.Client/Construction/UI/ConstructionMenu.Trauma.xaml.cs
@@ -13,32 +13,50 @@ public sealed partial class ConstructionMenu
 
     private readonly CommonKnowledgeSystem _knowledge = default!;
 
+    // TODO: make this an event a trauma.client system injects with
     public void AddSkillRequirements(ConstructionPrototype proto)
     {
-        var skills = proto.Practical ?? proto.Theory;
-        if (skills.Count <= 0)
+        var same = proto.Practical == null;
+        RecipeConstructionList.AddChild(new Label()
         {
-            var text = Loc.GetString("construction-menu-requirement-none");
-            var label = new RichTextLabel
+            Text = Loc.GetString("construction-menu-requirement-theory", ("same", same))
+        });
+        AddSkills(proto.Theory);
+
+        if (proto.Practical is {} practical)
+        {
+            RecipeConstructionList.AddChild(new Label()
             {
-                Text = text,
-            };
-            RecipeConstructionList.AddChild(label);
-            return;
+                Text = Loc.GetString("construction-menu-requirement-practical")
+            });
+            AddSkills(practical);
+        }
+    }
+
+    private void AddSkills(Dictionary<EntProtoId, int> skills)
+    {
+        if (skills.Count == 0)
+        {
+            RecipeConstructionList.AddChild(new Label()
+            {
+                Text = Loc.GetString("construction-menu-requirement-none")
+            });
         }
 
         foreach (var (id, amount) in skills)
         {
+            // TODO: use AllSkills
             if (!_proto.Resolve(id, out var prototype) || !prototype.TryGetComponent<KnowledgeComponent>("Knowledge", out var skill))
                 continue;
 
-            var text = Loc.GetString("construction-menu-requirement-display", ("name", prototype.Name), ("amount", _knowledge.GetMasteryString(amount)));
-            var label = new RichTextLabel
+            var text = Loc.GetString("construction-menu-requirement-display",
+                ("name", prototype.Name),
+                ("amount", _knowledge.GetMasteryString(amount)));
+            RecipeConstructionList.AddChild(new Label()
             {
                 Text = text,
                 Modulate = skill.Color
-            };
-            RecipeConstructionList.AddChild(label);
+            });
         }
     }
 }

--- a/Content.Client/Construction/UI/ConstructionMenu.xaml.cs
+++ b/Content.Client/Construction/UI/ConstructionMenu.xaml.cs
@@ -44,7 +44,8 @@ namespace Content.Client.Construction.UI
         event EventHandler ClearAllGhosts;
 
         void ClearRecipeInfo();
-        void SetRecipeInfo(string name, string description, EntityPrototype? targetPrototype, bool isItem, bool isFavorite, ConstructionPrototype proto); // Trauma - added proto to method
+        void SetRecipeInfo(string name, string description, EntityPrototype? targetPrototype, bool isItem, bool isFavorite,
+            bool understands, ConstructionPrototype proto); // Trauma
         void ResetPlacement();
 
         #region Window Control
@@ -170,9 +171,15 @@ namespace Content.Client.Construction.UI
             EntityPrototype? targetPrototype,
             bool isItem,
             bool isFavorite,
-            ConstructionPrototype proto) // Trauma
+            // <Trauma>
+            bool understands,
+            ConstructionPrototype proto)
+            // </Trauma>
         {
-            BuildButton.Disabled = false;
+            // <Trauma> - disable button if you lack the theory, show the requirements
+            BuildButton.Disabled = !understands;
+            AddSkillRequirements(proto);
+            // </Trauma>
             BuildButton.Text = Loc.GetString(isItem ? "construction-menu-place-ghost" : "construction-menu-craft");
             TargetName.SetMessage(name);
             TargetDesc.SetMessage(description);
@@ -180,9 +187,6 @@ namespace Content.Client.Construction.UI
             FavoriteButton.Visible = true;
             FavoriteButton.Text = Loc.GetString(
                             isFavorite ? "construction-add-favorite-button" : "construction-remove-from-favorite-button");
-            // <Trauma>
-            AddSkillRequirements(proto);
-            // </Trauma>
         }
 
         public void ClearRecipeInfo()

--- a/Content.Client/Construction/UI/ConstructionMenuPresenter.Trauma.cs
+++ b/Content.Client/Construction/UI/ConstructionMenuPresenter.Trauma.cs
@@ -1,0 +1,38 @@
+using Content.Goobstation.Common.CCVar;
+using Content.Shared.Construction.Prototypes;
+using Content.Trauma.Common.Knowledge.Systems;
+using Robust.Shared.Configuration;
+using Robust.Shared.Prototypes;
+
+namespace Content.Client.Construction.UI;
+
+internal sealed partial class ConstructionMenuPresenter
+{
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
+    private CommonKnowledgeSystem _knowledge = default!;
+
+    private bool _autoFocusSearch;
+    private bool _useSkills;
+    private Dictionary<EntProtoId, int> _skills = new();
+
+    private void InitializeTrauma()
+    {
+        _knowledge = _entManager.System<CommonKnowledgeSystem>();
+
+        _cfg.OnValueChanged(GoobCVars.AutoFocusSearchOnBuildMenu, x => _autoFocusSearch = x, true);
+    }
+
+    bool CanUnderstand(ConstructionPrototype recipe)
+    {
+        if (!_useSkills)
+            return true; // for mobs that dont use the knowledge system, let them build anything
+
+        foreach (var (id, needed) in recipe.Theory)
+        {
+            if (!_skills.TryGetValue(id, out var mastery) || mastery < needed)
+                return false;
+        }
+
+        return true;
+    }
+}

--- a/Content.Client/Construction/UI/ConstructionMenuPresenter.cs
+++ b/Content.Client/Construction/UI/ConstructionMenuPresenter.cs
@@ -1,8 +1,3 @@
-// <Trauma>
-using Content.Goobstation.Common.CCVar;
-using Content.Trauma.Common.Knowledge.Systems;
-using Robust.Shared.Configuration;
-// </Trauma>
 using System.Linq;
 using System.Numerics;
 using Content.Client.Lobby;
@@ -26,12 +21,8 @@ namespace Content.Client.Construction.UI
     /// model. This is where the bulk of UI work is done, either calling functions in the model to change state, or collecting
     /// data out of the model to *present* to the screen though the UI framework.
     /// </summary>
-    internal sealed class ConstructionMenuPresenter : IDisposable
+    internal sealed partial class ConstructionMenuPresenter : IDisposable // Trauma - made partial
     {
-        // <Trauma>
-        [Dependency] private readonly IConfigurationManager _cfg = default!;
-        private readonly CommonKnowledgeSystem _knowledge;
-        // </Trauma>
         [Dependency] private readonly EntityManager _entManager = default!;
         [Dependency] private readonly IEntitySystemManager _systemManager = default!;
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
@@ -52,7 +43,6 @@ namespace Content.Client.Construction.UI
         private List<ConstructionPrototype> _favoritedRecipes = [];
         private readonly Dictionary<string, ContainerButton> _recipeButtons = new();
         private string _selectedCategory = string.Empty;
-        private bool _autoFocusSearch = false; // Goobstation
         private const string FavoriteCatName = "construction-category-favorites";
         private const string ForAllCategoryName = "construction-category-all";
 
@@ -99,10 +89,10 @@ namespace Content.Client.Construction.UI
         {
             // This is a lot easier than a factory
             IoCManager.InjectDependencies(this);
+            InitializeTrauma(); // Trauma
             _constructionView = new ConstructionMenu();
             _whitelistSystem = _entManager.System<EntityWhitelistSystem>();
             _spriteSystem = _entManager.System<SpriteSystem>();
-            _knowledge = _entManager.System<CommonKnowledgeSystem>(); // Trauma
             _sawmill = _logManager.GetSawmill("construction.ui");
 
             // This is required so that if we load after the system is initialized, we can bind to it immediately
@@ -134,14 +124,7 @@ namespace Content.Client.Construction.UI
 
             SetFavorites(_preferencesManager.Preferences?.ConstructionFavorites ?? []);
             OnViewPopulateRecipes(_constructionView, (string.Empty, string.Empty));
-
-            // <Goob>
-            _autoFocusSearch = _cfg.GetCVar(GoobCVars.AutoFocusSearchOnBuildMenu);
-            _cfg.OnValueChanged(GoobCVars.AutoFocusSearchOnBuildMenu, UpdateAutoFocus, false);
-            // </Goob>
         }
-
-        private void UpdateAutoFocus(bool value) { _autoFocusSearch = value; } // Goobstation EDIT
 
         public void OnHudCraftingButtonToggled(BaseButton.ButtonToggledEventArgs args)
         {
@@ -281,22 +264,6 @@ namespace Content.Client.Construction.UI
             var isEmptyCategory = string.IsNullOrEmpty(category) || category == ForAllCategoryName;
             _selectedCategory = isEmptyCategory ? string.Empty : category;
 
-            // <Trauma>
-            if (_playerManager.LocalEntity is not { } player)
-                return recipes;
-            var useKnowledge = _constructionSystem!.IsKnowledgeHolder(player);
-            var skills = _knowledge.GetSkillMasteries(player);
-            bool CanUnderstand(ConstructionPrototype recipe)
-            {
-                foreach (var (id, needed) in recipe.Theory)
-                {
-                    if (!skills.TryGetValue(id, out var mastery) || mastery < needed)
-                        return false;
-                }
-                return true;
-            }
-            // </Trauma>
-
             foreach (var recipe in _prototypeManager.EnumeratePrototypes<ConstructionPrototype>())
             {
                 if (recipe.Hide)
@@ -306,14 +273,6 @@ namespace Content.Client.Construction.UI
                     || _playerManager.LocalEntity == null
                     || _whitelistSystem.IsWhitelistFail(recipe.EntityWhitelist, _playerManager.LocalEntity.Value))
                     continue;
-
-                // <Trauma> - don't allow a recipe if the user is missing any skills needed to understand it
-                if (useKnowledge && !CanUnderstand(recipe))
-                {
-                    // TODO: if its off by 1 or something, maybe say it could be made if you were better
-                    continue;
-                }
-                // </Trauma>
 
                 if (!string.IsNullOrEmpty(search) && (recipe.Name is { } name &&
                                                       !name.Contains(search.Trim(),
@@ -424,7 +383,10 @@ namespace Content.Client.Construction.UI
                 proto,
                 prototype.Type != ConstructionType.Item,
                 !_favoritedRecipes.Contains(prototype),
-                prototype); // Trauma
+                // <Trauma>
+                CanUnderstand(prototype),
+                prototype);
+                // </Trauma>
 
             var stepList = _constructionView.RecipeStepList;
             GenerateStepList(prototype, stepList);
@@ -657,6 +619,13 @@ namespace Content.Client.Construction.UI
             }
             else
             {
+                // <Trauma> - update recipes whenever opening the window
+                if (_playerManager.LocalEntity is { } player)
+                {
+                    _useSkills = _constructionSystem!.IsKnowledgeHolder(player);
+                    _skills = _knowledge.GetSkillMasteries(player);
+                }
+                // </Trauma>
                 WindowOpen = true;
                 _uiManager.GetActiveUIWidget<GameTopMenuBar>()
                     .CraftingButton.SetClickPressed(true); // This does not call CraftingButtonToggled

--- a/Content.Goobstation.Client/Factory/UI/ConstructorBUI.cs
+++ b/Content.Goobstation.Client/Factory/UI/ConstructorBUI.cs
@@ -56,6 +56,7 @@ public sealed class ConstructorBUI : BoundUserInterface
                 _id = item.Prototype.ID;
                 _menu.SetRecipeInfo(item.Prototype.Name ?? "", item.Prototype.Description ?? "", item?.TargetPrototype,
                     item!.Prototype.Type != ConstructionType.Item, true, // TODO: favourites
+                    true,
                     item.Prototype);
 
                 GenerateStepList(item.Prototype);

--- a/Content.Shared/Construction/Prototypes/ConstructionPrototype.Trauma.cs
+++ b/Content.Shared/Construction/Prototypes/ConstructionPrototype.Trauma.cs
@@ -1,10 +1,17 @@
 using Content.Trauma.Common.Quality;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Array;
 
 namespace Content.Shared.Construction.Prototypes;
 
 public sealed partial class ConstructionPrototype
 {
+    [ParentDataField(typeof(AbstractPrototypeIdArraySerializer<ConstructionPrototype>))]
+    public string[]? Parents { get; private set; }
+
+    [AbstractDataField, NeverPushInheritance]
+    public bool Abstract { get; private set; }
+
     /// <summary>
     /// Knowledge masteries that are required to be able to make this craft.
     /// Mastery is from 0-5.

--- a/Content.Shared/Construction/Prototypes/ConstructionPrototype.cs
+++ b/Content.Shared/Construction/Prototypes/ConstructionPrototype.cs
@@ -5,7 +5,7 @@ using Robust.Shared.Prototypes;
 namespace Content.Shared.Construction.Prototypes;
 
 [Prototype]
-public sealed partial class ConstructionPrototype : IPrototype
+public sealed partial class ConstructionPrototype : IPrototype, IInheritingPrototype // Trauma - use inheritance
 {
     [DataField("conditions")] private List<IConstructionCondition> _conditions = new();
 

--- a/Resources/Locale/en-US/_Trauma/knowledge/construction.ftl
+++ b/Resources/Locale/en-US/_Trauma/knowledge/construction.ftl
@@ -1,4 +1,7 @@
-construction-menu-requirement-main-skill = Uses: {$name} at {$amount}
+construction-menu-requirement-theory = {$same ->
+    [true] Theory and practical skills
+    *[false] Theory knowledge
+} required:
+construction-menu-requirement-practical = Practical skills required:
 construction-menu-requirement-display = {$name}: {$amount}
 construction-menu-requirement-none = No skills used.
-construction-menu-requirement-extra-skill = Secondary Skills:

--- a/Resources/Prototypes/_Goobstation/Recipes/Crafting/filters.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Crafting/filters.yml
@@ -1,71 +1,49 @@
 - type: construction
+  abstract: true
+  id: BaseAutomationFilter
+  graph: AutomationFilter
+  category: construction-category-misc
+  objectType: Item
+  theory:
+    ElectronicsKnowledge: 1
+  useQuality: false
+
+- type: construction
+  parent: BaseAutomationFilter
   id: AutomationFilterLabel
-  graph: AutomationFilter
   targetNode: label
-  category: construction-category-misc
-  objectType: Item
-  theory:
-    ElectronicsKnowledge: 1
 
 - type: construction
+  parent: BaseAutomationFilter
   id: AutomationFilterName
-  graph: AutomationFilter
   targetNode: name
-  category: construction-category-misc
-  objectType: Item
-  theory:
-    ElectronicsKnowledge: 1
 
 - type: construction
+  parent: BaseAutomationFilter
   id: AutomationFilterStack
-  graph: AutomationFilter
   targetNode: stack
-  category: construction-category-misc
-  objectType: Item
-  theory:
-    ElectronicsKnowledge: 1
 
 - type: construction
+  parent: BaseAutomationFilter
   id: AutomationFilterPressure
-  graph: AutomationFilter
   targetNode: pressure
-  category: construction-category-misc
-  objectType: Item
-  theory:
-    ElectronicsKnowledge: 1
 
 - type: construction
+  parent: BaseAutomationFilter
   id: AutomationFilterCombined
-  graph: AutomationFilter
   targetNode: combined
-  category: construction-category-misc
-  objectType: Item
-  theory:
-    ElectronicsKnowledge: 1
 
 - type: construction
+  parent: BaseAutomationFilter
   id: AutomationFilterAnchor
-  graph: AutomationFilter
   targetNode: anchor
-  category: construction-category-misc
-  objectType: Item
-  theory:
-    ElectronicsKnowledge: 1
 
 - type: construction
+  parent: BaseAutomationFilter
   id: AutomationFilterMob
-  graph: AutomationFilter
   targetNode: mob
-  category: construction-category-misc
-  objectType: Item
-  theory:
-    ElectronicsKnowledge: 1
 
 - type: construction
+  parent: BaseAutomationFilter
   id: AutomationFilterCuff
-  graph: AutomationFilter
   targetNode: cuff
-  category: construction-category-misc
-  objectType: Item
-  theory:
-    ElectronicsKnowledge: 1


### PR DESCRIPTION
- all recipes are shown, but you can only make whatever you have the theory for
- the menu also now shows both theory and practical skills
- construction prototypes now support inheritance in big 26
- made automation filters not use quality and have inheritance

## Media

cant make rev shit me no smart

<img width="552" height="373" alt="11:28:00" src="https://github.com/user-attachments/assets/10aed772-0fc3-411a-bb0b-a5387f558252" />

filters still work

<img width="304" height="342" alt="11:40:01" src="https://github.com/user-attachments/assets/07ade491-f6ec-49b1-8c20-e62442c4b9ab" />


:cl:
- tweak: Changed construction menu so you can see all recipes but only make ones you have the knowledge for.
- tweak: Construction menu now shows both theory and practical skills to make things.