### PR TITLE
fix unidentified corpses being alive part 2

### DIFF
--- a/Content.Trauma.Shared/Damage/DefaultBodyDamageComponent.cs
+++ b/Content.Trauma.Shared/Damage/DefaultBodyDamageComponent.cs
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Shared.Damage;
+using Robust.Shared.GameStates;
+
+namespace Content.Trauma.Shared.Damage;
+
+/// <summary>
+/// Deals damage to a mob on body init.
+/// Does nothing to non mobs, use <c>Damageable.damage</c> instead
+/// </summary>
+[RegisterComponent, NetworkedComponent, Access(typeof(DefaultBodyDamageSystem))]
+public sealed partial class DefaultBodyDamageComponent : Component
+{
+    [DataField(required: true)]
+    public DamageSpecifier Damage = new();
+}

--- a/Content.Trauma.Shared/Damage/DefaultBodyDamageSystem.cs
+++ b/Content.Trauma.Shared/Damage/DefaultBodyDamageSystem.cs
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Medical.Common.Body;
+using Content.Medical.Common.Targeting;
+using Content.Shared.Body;
+using Content.Shared.Damage.Systems;
+
+namespace Content.Trauma.Shared.Damage;
+
+public sealed class DefaultBodyDamageSystem : EntitySystem
+{
+    [Dependency] private readonly BodySystem _body = default!;
+    [Dependency] private readonly DamageableSystem _damage = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<DefaultBodyDamageComponent, BodyInitEvent>(OnBodyInit); // needs the parts to exist to damage them
+    }
+
+    private void OnBodyInit(Entity<DefaultBodyDamageComponent> ent, ref BodyInitEvent args)
+    {
+        var damage = ent.Comp.Damage * _body.GetVitalBodyPartRatio(ent.Owner);
+        _damage.ChangeDamage(ent.Owner, damage, ignoreResistances: true, targetPart: TargetBodyPart.All);
+    }
+}

--- a/Resources/Prototypes/Entities/Mobs/NPCs/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/human.yml
@@ -83,7 +83,7 @@
   components:
   - type: RandomHumanoidAppearance
     randomizeName: false
-  - type: Damageable
+  - type: DefaultBodyDamage # Trauma - damage the body on mapinit, dont set Damageable.damage directly
     damage:
       types:
         Bloodloss: 49


### PR DESCRIPTION
broken by damage refactor
now it applies damage to each bodypart on map init, very dead

fixes #1625

## Media
<img width="275" height="152" alt="11:58:09" src="https://github.com/user-attachments/assets/79fb6398-c157-4c7c-9bea-41dbe2efa742" />

VERY dead

<img width="306" height="472" alt="11:58:24" src="https://github.com/user-attachments/assets/16357e48-78cc-4447-98b0-00701f77f604" />

**Changelog**
:cl:
- fix: Fixed unidentified corpses being alive...