### PR TITLE
[BOUNTY] add area pickup for light replacer

### DIFF
--- a/Content.Trauma.Server/Light/LightReplacerAreaPickupSystem.cs
+++ b/Content.Trauma.Server/Light/LightReplacerAreaPickupSystem.cs
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Server.Light.EntitySystems;
+using Content.Shared.Interaction;
+using Content.Shared.Light.Components;
+using Content.Shared.Popups;
+using Content.Trauma.Shared.Light;
+using Robust.Shared.Audio.Systems;
+
+namespace Content.Trauma.Server.Light;
+
+/// <summary>
+/// Handles area pickup of bulbs/tubes for light replacers.
+/// </summary>
+public sealed class LightReplacerAreaPickupSystem : EntitySystem
+{
+    [Dependency] private readonly EntityLookupSystem _lookup = default!;
+    [Dependency] private readonly LightReplacerSystem _replacer = default!;
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+
+    private HashSet<Entity<LightBulbComponent>> _bulbs = new();
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<LightReplacerAreaPickupComponent, AfterInteractEvent>(OnAfterInteract,
+            before: [ typeof(LightReplacerSystem) ]);
+    }
+
+    private void OnAfterInteract(Entity<LightReplacerAreaPickupComponent> ent, ref AfterInteractEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        _bulbs.Clear();
+        var coords = args.ClickLocation;
+        // does not include bulbs inside boxes
+        _lookup.GetEntitiesInRange(coords, ent.Comp.Range, _bulbs);
+        // dont try to insert broken bulbs
+        _bulbs.RemoveWhere(bulb => bulb.Comp.State != LightBulbState.Normal);
+        if (_bulbs.Count < 2)
+            return; // if its just one let regular pickup logic handle it, 2 minimum
+
+        foreach (var bulb in _bulbs)
+        {
+            args.Handled |= _replacer.TryInsertBulb(ent, bulb, args.User, bulb: bulb.Comp);
+        }
+
+        if (!args.Handled)
+            return; // nothing was inserted..?
+
+        _audio.PlayPvs(ent.Comp.Sound, ent);
+        _popup.PopupEntity(Loc.GetString("light-replacer-area-pickup-popups"), ent, args.User, PopupType.Medium);
+    }
+}

--- a/Content.Trauma.Shared/Light/LightReplacerAreaPickupComponent.cs
+++ b/Content.Trauma.Shared/Light/LightReplacerAreaPickupComponent.cs
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Robust.Shared.Audio;
+using Robust.Shared.GameStates;
+
+namespace Content.Trauma.Shared.Light;
+
+/// <summary>
+/// Allows for area pickup of light bulbs around where you click.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class LightReplacerAreaPickupComponent : Component
+{
+    [DataField]
+    public float Range = 1.25f;
+
+    /// <summary>
+    /// Sound played after doing an area pickup
+    /// </summary>
+    [DataField]
+    public SoundSpecifier? Sound = new SoundPathSpecifier("/Audio/Effects/trashbag1.ogg");
+}

--- a/Resources/Locale/en-US/_Trauma/light/light-replacer.ftl
+++ b/Resources/Locale/en-US/_Trauma/light/light-replacer.ftl
@@ -1,0 +1,1 @@
+light-replacer-area-pickup-popups = You fill up your light replacer.

--- a/Resources/Prototypes/Entities/Objects/Tools/light_replacer.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/light_replacer.yml
@@ -1,29 +1,19 @@
-# SPDX-FileCopyrightText: 2021 Alex Evgrashin <aevgrashin@yandex.ru>
-# SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
-# SPDX-FileCopyrightText: 2022 Rane <60792108+Elijahrane@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2022 Visne <39844191+Visne@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2022 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2022 rolfero <45628623+rolfero@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 Geekyhobo <66805063+Geekyhobo@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 Jeff <velcroboy333@hotmail.com>
-# SPDX-FileCopyrightText: 2023 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 Velcroboy <107660393+IamVelcroboy@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 BombasterDS <115770678+BombasterDS@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Debug <49997488+DebugOk@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Magnus Larsen <i.am.larsenml@gmail.com>
-# SPDX-FileCopyrightText: 2024 metalgearsloth <comedian_vs_clown@hotmail.com>
-# SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 Fishbait <Fishbait@git.ml>
-# SPDX-FileCopyrightText: 2025 fishbait <gnesse@gmail.com>
-#
-# SPDX-License-Identifier: AGPL-3.0-or-later
-
 - type: entity
   parent: BaseItem
   name: light replacer
   id: LightReplacer
   description: An item which uses magnets to easily replace broken lights. Refill by adding more lights into the replacer.
   components:
+  # <Trauma>
+  - type: LightReplacerAreaPickup
+  - type: PhysicalComposition
+    materialComposition:
+      Steel: 25
+      Glass: 125
+  - type: Tag
+    tags:
+    - DroneUsable
+  # </Trauma>
   - type: Sprite
     sprite: Objects/Specific/Janitorial/light_replacer.rsi
     state: icon
@@ -40,13 +30,6 @@
   - type: ContainerContainer
     containers:
       light_replacer_storage: !type:Container
-  - type: PhysicalComposition #Goobstation - Recycle update
-    materialComposition:
-      Steel: 25
-      Glass: 125
-  - type: Tag
-    tags:
-    - DroneUsable # Goobstation
 
 - type: entity
   parent: LightReplacer


### PR DESCRIPTION
clicking a pile of lights now inserts them all

it has a sound and popup

## Media
<img width="116" height="95" alt="12:16:26" src="https://github.com/user-attachments/assets/172082e6-93fb-4507-a3da-b04f0696cc19" />
<img width="399" height="243" alt="12:16:42" src="https://github.com/user-attachments/assets/66740c91-d4f6-4cf6-89eb-668a3d876f40" />

**Changelog**
:cl:
- add: Light replacers now pickup all light bulbs/tubes around where you click.