### PR TITLE
derotate serpentcrest properly

### DIFF
--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -27,5 +27,5 @@
   #- Chloris
   - Cog
   - Reach
-  - Serpentcrest
+  #- Serpentcrest
   - Nume


### PR DESCRIPTION
armory is bad

:cl:
MAPS:
- remove: Derotated Serpentcrest until someone updates its armory.