### PR TITLE
fix insurgent ghost roles

### DIFF
--- a/Resources/Prototypes/_Trauma/Entities/Markers/Spawners/ghost_roles.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Markers/Spawners/ghost_roles.yml
@@ -1,10 +1,11 @@
 - type: entity
   parent: BaseAntagSpawner
-  id: SpawnPointInsurgent
-  name: insurgent spawn point
-  categories: [ Spawner ]
+  id: GhostRoleSpawnerInsurgent
+  name: insurgent ghost role spawner
   components:
   - type: GhostRole
+    name: roles-antag-insurgent-name
+    description: roles-antag-insurgent-objective
     rules: ghost-role-information-rules-team-antagonist
     mindRoles:
     - MindRoleInsurgent
@@ -13,3 +14,5 @@
     layers:
     - state: green
     - state: passenger
+    - sprite: Clothing/Mask/gas.rsi
+      state: icon

--- a/Resources/Prototypes/_Trauma/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Trauma/GameRules/roundstart.yml
@@ -35,7 +35,7 @@
     agentName: insurgent-round-end-agent-name
     definitions:
     - prefRoles: [ Insurgent ]
-      spawnerPrototype: SpawnPointInsurgent
+      spawnerPrototype: GhostRoleSpawnerInsurgent
       startingGear: Insurgent
       unequipOldGear: true
       max: 8


### PR DESCRIPTION
fixes #1659

## Media

<img width="488" height="123" alt="15:13:13" src="https://github.com/user-attachments/assets/2a736e59-64b0-4f79-96f7-7d7962ed29af" />

**Changelog**
:cl:
- fix: Fixed insurgent ghost roles not having a name.