### PR TITLE
mech system cleanup and fixing

### DIFF
--- a/Content.Goobstation.Server/Mech/Equipment/EntitySystems/MechGunSystem.cs
+++ b/Content.Goobstation.Server/Mech/Equipment/EntitySystems/MechGunSystem.cs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+using Content.Trauma.Common.Mech;
 using Content.Server.Mech.Systems;
 using Content.Shared.Mech.Components;
 using Content.Shared.Mech.EntitySystems;
@@ -18,10 +19,11 @@ public sealed class MechGunSystem : EntitySystem
     public override void Initialize()
     {
         base.Initialize();
-        SubscribeLocalEvent<MechEquipmentComponent, HandleMechEquipmentBatteryEvent>(OnHandleMechEquipmentBattery);
+
+        SubscribeLocalEvent<MechEquipmentComponent, MechGunFiredEvent>(OnGunFired);
     }
 
-    private void OnHandleMechEquipmentBattery(EntityUid uid, MechEquipmentComponent component, HandleMechEquipmentBatteryEvent args)
+    private void OnGunFired(EntityUid uid, MechEquipmentComponent component, ref MechGunFiredEvent args)
     {
         if (component.EquipmentOwner == null || !TryComp<BatteryComponent>(uid, out var battery))
             return;

--- a/Content.Shared/Mech/EntitySystems/SharedMechSystem.Trauma.cs
+++ b/Content.Shared/Mech/EntitySystems/SharedMechSystem.Trauma.cs
@@ -1,0 +1,119 @@
+using Content.Goobstation.Common.CCVar;
+using Content.Shared._vg.TileMovement;
+using Content.Shared.Emag.Systems;
+using Content.Shared.Hands.Components;
+using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Interaction.Components;
+using Content.Shared.Inventory.VirtualItem;
+using Content.Shared.Mech.Components;
+using Content.Shared.Mech.Equipment.Components;
+using Content.Shared.Weapons.Ranged.Events;
+using Content.Trauma.Common.Mech;
+using Robust.Shared.Configuration;
+using Robust.Shared.Containers;
+
+namespace Content.Shared.Mech.EntitySystems;
+
+public abstract partial class SharedMechSystem
+{
+    [Dependency] private readonly EmagSystem _emag = default!;
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
+    [Dependency] private readonly SharedHandsSystem _hands = default!;
+    [Dependency] private readonly SharedVirtualItemSystem _virtualItem = default!;
+    [Dependency] private readonly EntityQuery<TileMovementComponent> _tileQuery = default!;
+
+    private bool _canUseMechGunOutside;
+
+    private void InitializeTrauma()
+    {
+        SubscribeLocalEvent<MechEquipmentComponent, ShotAttemptedEvent>(OnShotAttempted);
+        SubscribeLocalEvent<MechPilotComponent, EntGotRemovedFromContainerMessage>(OnEntGotRemovedFromContainer);
+        SubscribeLocalEvent<MechComponent, GotEmaggedEvent>(OnEmagged);
+
+        Subs.CVar(_cfg, GoobCVars.MechGunOutsideMech, value => _canUseMechGunOutside = value, true);
+    }
+
+    // TODO: this has no reason to be here
+    private void OnShotAttempted(EntityUid uid, MechEquipmentComponent component, ref ShotAttemptedEvent args)
+    {
+        if (!_canUseMechGunOutside &&
+            (component.EquipmentOwner is not {} mech ||
+            !HasComp<MechComponent>(mech)))
+        {
+            args.Cancel();
+            return;
+        }
+
+        // TODO: this should not be in an attempt event
+        var ev = new MechGunFiredEvent();
+        RaiseLocalEvent(uid, ref ev);
+    }
+
+    // TODO: this has no reason to be here
+    private void OnEntGotRemovedFromContainer(EntityUid uid, MechPilotComponent component, EntGotRemovedFromContainerMessage args)
+    {
+        // Fixes scram implants or teleports locking the pilot out of being able to move.
+        TryEject(component.Mech, pilot: uid);
+    }
+
+    // TODO: this has no reason to be here
+    private void OnEmagged(EntityUid uid, MechComponent component, ref GotEmaggedEvent args)
+    {
+        if (!component.BreakOnEmag || !_emag.CompareFlag(args.Type, EmagType.Interaction))
+            return;
+        args.Handled = true;
+        component.EquipmentWhitelist = null;
+        Dirty(uid, component);
+    }
+
+    private void CopyTileMovement(EntityUid mech, EntityUid pilot)
+    {
+        if (!_tileQuery.HasComp(pilot))
+            return;
+
+        var tile = EnsureComp<TileMovementComponent>(mech);
+        tile.FromMech = true;
+        Dirty(mech, tile);
+    }
+
+    private void ResetTileMovement(EntityUid mech)
+    {
+        if (_tileQuery.TryComp(mech, out var tile) && tile.FromMech)
+            RemComp(mech, tile);
+    }
+
+    private void BlockHands(Entity<HandsComponent?> ent, EntityUid mech)
+    {
+        if (!Resolve(ent, ref ent.Comp, false))
+            return;
+
+        var freeHands = 0;
+        foreach (var hand in _hands.EnumerateHands(ent))
+        {
+            if (!_hands.TryGetHeldItem(ent, hand, out var held))
+            {
+                freeHands++;
+                continue;
+            }
+
+            // Is this entity removable? (they might have handcuffs on)
+            if (HasComp<UnremoveableComponent>(held) && held != mech)
+                continue;
+
+            _hands.DoDrop(ent, hand);
+            freeHands++;
+            if (freeHands == 2)
+                break;
+        }
+        if (_virtualItem.TrySpawnVirtualItemInHand(mech, ent.Owner, out var virtItem1))
+            EnsureComp<UnremoveableComponent>(virtItem1.Value);
+
+        if (_virtualItem.TrySpawnVirtualItemInHand(mech, ent.Owner, out var virtItem2))
+            EnsureComp<UnremoveableComponent>(virtItem2.Value);
+    }
+
+    private void FreeHands(EntityUid uid, EntityUid mech)
+    {
+        _virtualItem.DeleteInHandsMatching(uid, mech);
+    }
+}

--- a/Content.Shared/Mech/EntitySystems/SharedMechSystem.cs
+++ b/Content.Shared/Mech/EntitySystems/SharedMechSystem.cs
@@ -1,37 +1,7 @@
-// SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2023 Leon Friedrich <60421075+ElectroJr@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2023 Rane <60792108+Elijahrane@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2023 TemporalOroboros <TemporalOroboros@gmail.com>
-// SPDX-FileCopyrightText: 2023 brainfood1183 <113240905+brainfood1183@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2023 deltanedas <39013340+deltanedas@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2023 deltanedas <@deltanedas:kde.org>
-// SPDX-FileCopyrightText: 2023 keronshb <keronshb@live.com>
-// SPDX-FileCopyrightText: 2023 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2023 themias <89101928+themias@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 Arendian <137322659+Arendian@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 NULL882 <gost6865@yandex.ru>
-// SPDX-FileCopyrightText: 2024 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 Plykiya <58439124+Plykiya@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 ScyronX <166930367+ScyronX@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 Tayrtahn <tayrtahn@gmail.com>
-// SPDX-FileCopyrightText: 2024 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 nikthechampiongr <32041239+nikthechampiongr@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
-// SPDX-FileCopyrightText: 2025 Ilya246 <57039557+Ilya246@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2025 Ilya246 <ilyukarno@gmail.com>
-// SPDX-FileCopyrightText: 2025 Misandry <mary@thughunt.ing>
-// SPDX-FileCopyrightText: 2025 Piras314 <p1r4s@proton.me>
-// SPDX-FileCopyrightText: 2025 gluesniffler <linebarrelerenthusiast@gmail.com>
-// SPDX-FileCopyrightText: 2025 gus <august.eymann@gmail.com>
-//
-// SPDX-License-Identifier: AGPL-3.0-or-later
-
+// <Trauma>
+using Content.Goobstation.Common.Mech;
+// </Trauma>
 using System.Linq;
-using Content.Goobstation.Common.CCVar; // Goob Edit
-using Content.Goobstation.Common.Mech; // Goobstation
-using Content.Shared._vg.TileMovement; // Goobstation
 using Content.Shared.Access.Components;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Actions;
@@ -55,13 +25,6 @@ using Robust.Shared.Network;
 using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
 
-using Content.Shared.Emag.Systems;
-using Content.Shared.Weapons.Ranged.Events;
-using Content.Shared.Hands.Components;
-using Content.Shared.Hands.EntitySystems;
-using Content.Shared.Inventory.VirtualItem;
-using Robust.Shared.Configuration;
-
 namespace Content.Shared.Mech.EntitySystems;
 
 /// <summary>
@@ -80,13 +43,6 @@ public abstract partial class SharedMechSystem : EntitySystem
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
-    [Dependency] private readonly EmagSystem _emag = default!; // Goobstation change
-    [Dependency] private readonly SharedHandsSystem _hands = default!; // Goobstation Change
-    [Dependency] private readonly SharedVirtualItemSystem _virtualItem = default!; // Goobstation Change
-    [Dependency] private readonly IConfigurationManager _config = default!; // Goobstation Change
-
-    // Goobstation: Local variable for checking if mech guns can be used out of them.
-    private bool _canUseMechGunOutside;
 
     /// <inheritdoc/>
     public override void Initialize()
@@ -100,22 +56,13 @@ public abstract partial class SharedMechSystem : EntitySystem
         SubscribeLocalEvent<MechComponent, GetAdditionalAccessEvent>(OnGetAdditionalAccess);
         SubscribeLocalEvent<MechComponent, DragDropTargetEvent>(OnDragDrop);
         SubscribeLocalEvent<MechComponent, CanDropTargetEvent>(OnCanDragDrop);
-        SubscribeLocalEvent<MechComponent, GotEmaggedEvent>(OnEmagged);
 
         SubscribeLocalEvent<MechPilotComponent, GetMeleeWeaponEvent>(OnGetMeleeWeapon);
         SubscribeLocalEvent<MechPilotComponent, CanAttackFromContainerEvent>(OnCanAttackFromContainer);
         SubscribeLocalEvent<MechPilotComponent, AttackAttemptEvent>(OnAttackAttempt);
-        SubscribeLocalEvent<MechPilotComponent, EntGotRemovedFromContainerMessage>(OnEntGotRemovedFromContainer);
-        SubscribeLocalEvent<MechEquipmentComponent, ShotAttemptedEvent>(OnShotAttempted); // Goobstation
-        Subs.CVar(_config, GoobCVars.MechGunOutsideMech, value => _canUseMechGunOutside = value, true); // Goobstation
 
+        InitializeTrauma(); // Trauma
         InitializeRelay();
-    }
-
-    // GoobStation: Fixes scram implants or teleports locking the pilot out of being able to move.
-    private void OnEntGotRemovedFromContainer(EntityUid uid, MechPilotComponent component, EntGotRemovedFromContainerMessage args)
-    {
-        TryEject(component.Mech, pilot: uid);
     }
 
     private void OnToggleEquipmentAction(EntityUid uid, MechComponent component, MechToggleEquipmentEvent args)
@@ -185,8 +132,7 @@ public abstract partial class SharedMechSystem : EntitySystem
 
         var rider = EnsureComp<MechPilotComponent>(pilot);
 
-        if (HasComp<TileMovementComponent>(pilot)) // Goob change - Prevent mech jank.
-            EnsureComp<TileMovementComponent>(mech);
+        CopyTileMovement(mech, pilot); // Trauma
 
         // Warning: this bypasses most normal interaction blocking components on the user, like drone laws and the like.
         var irelay = EnsureComp<InteractionRelayComponent>(pilot);
@@ -202,13 +148,12 @@ public abstract partial class SharedMechSystem : EntitySystem
         _actions.AddAction(pilot, ref component.MechCycleActionEntity, component.MechCycleAction, mech);
         _actions.AddAction(pilot, ref component.MechUiActionEntity, component.MechUiAction, mech);
         _actions.AddAction(pilot, ref component.MechEjectActionEntity, component.MechEjectAction, mech);
-        _actions.AddAction(pilot, ref component.ToggleActionEntity, component.ToggleAction, mech); //Goobstation Mech Lights toggle action
+        _actions.AddAction(pilot, ref component.ToggleActionEntity, component.ToggleAction, mech); // Trauma
     }
 
     private void RemoveUser(EntityUid mech, EntityUid pilot)
     {
-        if (HasComp<TileMovementComponent>(mech)) // Goob change - Prevent mech jank.
-            RemComp<TileMovementComponent>(mech);
+        ResetTileMovement(mech); // Trauma
 
         if (!RemComp<MechPilotComponent>(pilot))
             return;
@@ -450,12 +395,12 @@ public abstract partial class SharedMechSystem : EntitySystem
         SetupUser(uid, toInsert.Value);
         _container.Insert(toInsert.Value, component.PilotSlot);
         UpdateAppearance(uid, component);
-        // <Goobstation>
-        UpdateHands(toInsert.Value, uid, true);
+        // <Trauma>
+        BlockHands(toInsert.Value, uid);
 
         var ev = new MechInsertedEvent(uid);
         RaiseLocalEvent(toInsert.Value, ev);
-        // </Goobstation>
+        // </Trauma>
         return true;
     }
 
@@ -464,76 +409,35 @@ public abstract partial class SharedMechSystem : EntitySystem
     /// </summary>
     /// <param name="uid"></param>
     /// <param name="component"></param>
-    /// <param name="pilot">The pilot to eject</param>
     /// <returns>Whether or not the pilot was ejected.</returns>
-    public bool TryEject(EntityUid uid, MechComponent? component = null, EntityUid? pilot = null)
+    public bool TryEject(EntityUid uid, MechComponent? component = null,
+        EntityUid pilot = default) // Trauma
     {
         if (!Resolve(uid, ref component))
             return false;
 
-        if (component.PilotSlot.ContainedEntity != null)
-            pilot = component.PilotSlot.ContainedEntity.Value;
+        // <Trauma> - take pilot from the arg and only use the current pilot as a fallback
+        if (!pilot.IsValid())
+        {
+            if (component.PilotSlot.ContainedEntity is not {} currentPilot)
+                return false;
 
-        if (pilot == null)
-            return false;
+            pilot = currentPilot;
+        }
+        // </Trauma>
 
-        RemoveUser(uid, pilot.Value);
-        _container.RemoveEntity(uid, pilot.Value);
+        RemoveUser(uid, pilot);
+        _container.RemoveEntity(uid, pilot);
         UpdateAppearance(uid, component);
-        // <Goobstation>
-        UpdateHands(pilot.Value, uid, false);
+        // <Trauma>
+        FreeHands(pilot, uid);
 
         var ev = new MechEjectedEvent(uid);
-        RaiseLocalEvent(pilot.Value, ev);
-        // </Goobstation>
+        RaiseLocalEvent(pilot, ev);
+        // </Trauma>
         return true;
     }
 
-    // Goobstation Change Start
-    private void UpdateHands(EntityUid uid, EntityUid mech, bool active)
-    {
-        if (!TryComp<HandsComponent>(uid, out var handsComponent))
-            return;
-
-        if (active)
-            BlockHands(uid, mech, handsComponent);
-        else
-            FreeHands(uid, mech);
-    }
-
-    private void BlockHands(EntityUid uid, EntityUid mech, HandsComponent handsComponent)
-    {
-        var freeHands = 0;
-        foreach (var hand in _hands.EnumerateHands((uid, handsComponent)))
-        {
-            if (!_hands.TryGetHeldItem((uid, handsComponent), hand, out var held))
-            {
-                freeHands++;
-                continue;
-            }
-
-            // Is this entity removable? (they might have handcuffs on)
-            if (HasComp<UnremoveableComponent>(held) && held != mech)
-                continue;
-
-            _hands.DoDrop((uid, handsComponent), hand);
-            freeHands++;
-            if (freeHands == 2)
-                break;
-        }
-        if (_virtualItem.TrySpawnVirtualItemInHand(mech, uid, out var virtItem1))
-            EnsureComp<UnremoveableComponent>(virtItem1.Value);
-
-        if (_virtualItem.TrySpawnVirtualItemInHand(mech, uid, out var virtItem2))
-            EnsureComp<UnremoveableComponent>(virtItem2.Value);
-    }
-
-    private void FreeHands(EntityUid uid, EntityUid mech)
-    {
-        _virtualItem.DeleteInHandsMatching(uid, mech);
-    }
-
-    // Goobstation Change End
     private void OnGetMeleeWeapon(EntityUid uid, MechPilotComponent component, GetMeleeWeaponEvent args)
     {
         if (args.Handled)
@@ -556,21 +460,6 @@ public abstract partial class SharedMechSystem : EntitySystem
     {
         if (args.Target == component.Mech)
             args.Cancel();
-    }
-
-    // Goobstation: Prevent guns being used out of mechs if CCVAR is set.
-    private void OnShotAttempted(EntityUid uid, MechEquipmentComponent component, ref ShotAttemptedEvent args)
-    {
-        if (!component.EquipmentOwner.HasValue
-            || !HasComp<MechComponent>(component.EquipmentOwner.Value))
-        {
-            if (!_canUseMechGunOutside)
-                args.Cancel();
-            return;
-        }
-
-        var ev = new HandleMechEquipmentBatteryEvent();
-        RaiseLocalEvent(uid, ev);
     }
 
     private void UpdateAppearance(EntityUid uid, MechComponent? component = null,
@@ -605,15 +494,6 @@ public abstract partial class SharedMechSystem : EntitySystem
 
         args.CanDrop |= !component.Broken && CanInsert(uid, args.Dragged, component);
     }
-
-    private void OnEmagged(EntityUid uid, MechComponent component, ref GotEmaggedEvent args) // Goobstation
-    {
-        if (!component.BreakOnEmag || !_emag.CompareFlag(args.Type, EmagType.Interaction))
-            return;
-        args.Handled = true;
-        component.EquipmentWhitelist = null;
-        Dirty(uid, component);
-    }
 }
 
 /// <summary>
@@ -639,14 +519,5 @@ public sealed partial class MechExitEvent : SimpleDoAfterEvent
 /// </summary>
 [Serializable, NetSerializable]
 public sealed partial class MechEntryEvent : SimpleDoAfterEvent
-{
-}
-
-/// <summary>
-///     Event raised when an user attempts to fire a mech weapon to check if its battery is drained
-/// </summary>
-
-[Serializable, NetSerializable]
-public sealed partial class HandleMechEquipmentBatteryEvent : EntityEventArgs
 {
 }

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -275,13 +275,18 @@ public abstract partial class SharedMeleeWeaponSystem : EntitySystem // Trauma -
 
         var ev = new GetMeleeDamageEvent(uid, new(component.Damage * Damageable.UniversalMeleeDamageModifier), new(), user, component.ResistanceBypass);
         RaiseLocalEvent(uid, ref ev);
-        // <Goobstation> - raise an event on the user too for strength augments
-        var userEv = new GetUserMeleeDamageEvent(uid, ev.Damage, ev.Modifiers);
-        RaiseLocalEvent(user, ref userEv);
-        // this currently does nothing since they are classes, but it's futureproofing for struct DamageSpecifier.
-        ev.Damage = userEv.Damage;
-        ev.Modifiers = userEv.Modifiers;
-        // </Goobstation>
+        // <Trauma> - raise an event on the user too for strength augments, knowledge, etc
+        // only consider if the user is punching or holding a weapon
+        // non-held weapons are stuff like mechs which don't take physical effort to use, so don't apply strength etc
+        if (uid == user || _hands.IsHolding(user, uid))
+        {
+            var userEv = new GetUserMeleeDamageEvent(uid, ev.Damage, ev.Modifiers);
+            RaiseLocalEvent(user, ref userEv);
+            // this currently does nothing since they are classes, but it's futureproofing for struct DamageSpecifier.
+            ev.Damage = userEv.Damage;
+            ev.Modifiers = userEv.Modifiers;
+        }
+        // </Trauma>
 
         return DamageSpecifier.ApplyModifierSets(ev.Damage, ev.Modifiers);
     }

--- a/Content.Shared/_vg/TileMovementComponent.cs
+++ b/Content.Shared/_vg/TileMovementComponent.cs
@@ -67,4 +67,10 @@ public sealed partial class TileMovementComponent : Component
     /// </summary>
     [AutoNetworkedField]
     public Vector2? LastTickLocalCoordinates;
+
+    /// <summary>
+    /// True if it was added from a mech pilot.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool FromMech;
 }

--- a/Content.Trauma.Common/Mech/MechGunFiredEvent.cs
+++ b/Content.Trauma.Common/Mech/MechGunFiredEvent.cs
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Content.Trauma.Common.Mech;
+
+/// <summary>
+/// Event raised on a mech gun equipment entity after it has been fired.
+/// </summary>
+[ByRefEvent]
+public record struct MechGunFiredEvent();


### PR DESCRIPTION
cleaned up most of mech system shitcode
made mechs knowledge etc no longer affected mech damage. now they only affect your punches and weapons you are directly holding. it's possible theres some niche shit that it should apply to but i cant think of anything
also fixed the mech tile movement logic

fixes #1688

## Media

strength 100, strength mutation and 2 strength augments not changing ripley attack damage from base 25
<img width="178" height="113" alt="19:45:34" src="https://github.com/user-attachments/assets/958ce8c7-97e2-4df8-a33a-de8218bc93f2" />


:cl:
- fix: Fixed strength increasing mech melee damage...