### PR TITLE
Quick yaml PR

### DIFF
--- a/Resources/Prototypes/_DV/CosmicCult/Mobs/colossus.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/Mobs/colossus.yml
@@ -225,6 +225,9 @@
       - Ghost
       - CosmicCult
       - CosmicColossus
+  - type: InnateWaypointer
+    waypointerProtoIds:
+    - NTStationWaypointer
 
 - type: entity
   parent: [ MobCosmicColossusBase ]

--- a/Resources/Prototypes/_Trauma/Entities/Markers/Spawners/Random/maintscloset.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Markers/Spawners/Random/maintscloset.yml
@@ -4,6 +4,13 @@
   name: maintenance closet
   suffix: Random Filled/Mimic
   components:
+  - type: Sprite
+    layers:
+      - state: red
+      - sprite: Structures/Storage/closet.rsi
+        state: generic
+      - sprite: Structures/Storage/closet.rsi
+        state: generic_door
   - type: RandomSpawner
     prototypes:
     - ClosetMaintenanceFilledRandom


### PR DESCRIPTION
## About the PR
1. Entropic colossus gets a waypointer
2. Maints locker/mimic spawner has a sprite now (maints locker with a red cross)

## Why / Balance
Resolves #1717.
1. It's supposed to be thrown at the station at mach FUCK when it spawns, but it's broken and I can't figure out why (hopefuly will fix in patch 2), so this is a band-aid fix.
2. I spent much more time than I would like to admit trying to figure out why maints lockers disappear on kilotrain when I save it. And then there were 8 lockers per tile. Needless to say, invisible spawners are bad,

## Technical details
YAMLops

## Media
Tested works

## Requirements
Technically I broke the Pull Request and Changelog Guidelines by putting 2 unrelated thins in one PR :trollface:

**Changelog**
:cl:
- fix: Entropic Colossus now knows where the station is
