### PR TITLE
Heretic balance and qol

### DIFF
--- a/Content.Server/Speech/EntitySystems/SpeakOnActionSystem.cs
+++ b/Content.Server/Speech/EntitySystems/SpeakOnActionSystem.cs
@@ -63,6 +63,6 @@ public sealed class SpeakOnActionSystem : SharedSpeakOnActionSystem
         if (string.IsNullOrWhiteSpace(speech))
             return;
 
-        _chat.TrySendInGameICMessage(user, Loc.GetString(speech), InGameICChatType.Speak, false);
+        _chat.TrySendInGameICMessage(user, Loc.GetString(speech), ent.Comp.ChatType, false); // Trauma - use ent.Comp.ChatType
     }
 }

--- a/Content.Shared/Access/Systems/SharedAccessSystem.cs
+++ b/Content.Shared/Access/Systems/SharedAccessSystem.cs
@@ -67,12 +67,15 @@ namespace Content.Shared.Access.Systems
         ///     Replaces the set of access tags we have with the provided set.
         /// </summary>
         /// <param name="access">The new access tags</param>
-        public bool TrySetTags(EntityUid uid, IEnumerable<ProtoId<AccessLevelPrototype>> newTags, AccessComponent? access = null)
+        public bool TrySetTags(EntityUid uid, IEnumerable<ProtoId<AccessLevelPrototype>> newTags, AccessComponent? access = null, bool overwrite = true) // Trauma - added overwrite
         {
             if (!Resolve(uid, ref access))
                 return false;
 
-            access.Tags.Clear();
+            // <Trauma>
+            if (overwrite)
+                access.Tags.Clear();
+            // </Trauma>
             access.Tags.UnionWith(newTags);
             Dirty(uid, access);
 

--- a/Content.Shared/Speech/Components/SpeakOnActionComponent.Trauma.cs
+++ b/Content.Shared/Speech/Components/SpeakOnActionComponent.Trauma.cs
@@ -1,0 +1,9 @@
+using Content.Shared.Chat;
+
+namespace Content.Shared.Speech.Components;
+
+public sealed partial class SpeakOnActionComponent
+{
+    [DataField]
+    public InGameICChatType ChatType = InGameICChatType.Speak;
+}

--- a/Content.Trauma.Server/Heretic/Abilities/HereticAbilitySystem.cs
+++ b/Content.Trauma.Server/Heretic/Abilities/HereticAbilitySystem.cs
@@ -68,8 +68,6 @@ public sealed partial class HereticAbilitySystem : SharedHereticAbilitySystem
 
     #endregion
 
-    public static ProtoId<CollectiveMindPrototype> MansusLinkMind = "MansusLink";
-
     public override void Initialize()
     {
         base.Initialize();

--- a/Content.Trauma.Server/Heretic/Systems/PathSpecific/AristocratSystem.cs
+++ b/Content.Trauma.Server/Heretic/Systems/PathSpecific/AristocratSystem.cs
@@ -68,7 +68,7 @@ public sealed class AristocratSystem : EntitySystem
     private static readonly ProtoId<ContentTileDefinition> SnowTilePrototype = "FloorAstroSnow";
     private static readonly ProtoId<TagPrototype> Window = "Window";
 
-    private static readonly TimeSpan ConduitDelay = TimeSpan.FromSeconds(1);
+    private static readonly TimeSpan ConduitDelay = TimeSpan.FromSeconds(2);
     private TimeSpan _nextUpdate = TimeSpan.Zero;
 
     private readonly HashSet<Entity<FreezableWallComponent>> _walls = new();

--- a/Content.Trauma.Server/Heretic/Systems/PathSpecific/LeechingWalkSystem.cs
+++ b/Content.Trauma.Server/Heretic/Systems/PathSpecific/LeechingWalkSystem.cs
@@ -68,15 +68,15 @@ public sealed class LeechingWalkSystem : EntitySystem
 
             _damageableQuery.TryComp(uid, out var damageable);
 
-            var multiplier = 2f;
+            var multiplier = 1.5f;
             var shouldHeal = true;
             if (_hereticQuery.TryComp(mindContainer.Mind, out var heretic))
             {
                 if (heretic.PathStage >= 7)
                 {
-                    if (heretic.Ascended)
+                    if (heretic is {Ascended: true, CurrentPath: HereticPath.Rust})
                     {
-                        multiplier = 5f;
+                        multiplier = 3.5f;
                         if (_respiratorQuery.TryComp(uid, out var respirator))
                         {
                             _respirator.UpdateSaturation(uid,
@@ -92,11 +92,11 @@ public sealed class LeechingWalkSystem : EntitySystem
                         }
                     }
                     else
-                        multiplier = 3f;
+                        multiplier = 2f;
                 }
             }
             else if (_ghoulQuery.HasComp(uid))
-                multiplier = 3f;
+                multiplier = 2f;
 
             RemCompDeferred<DelayedKnockdownComponent>(uid);
 

--- a/Content.Trauma.Shared/Heretic/Components/PathSpecific/Lock/EldritchIdCardComponent.cs
+++ b/Content.Trauma.Shared/Heretic/Components/PathSpecific/Lock/EldritchIdCardComponent.cs
@@ -42,13 +42,11 @@ public sealed class EldritchIdConfiguration(
     string? jobTitle,
     ProtoId<JobIconPrototype> jobIcon,
     List<ProtoId<DepartmentPrototype>> departments,
-    HashSet<ProtoId<AccessLevelPrototype>> tags,
     EntProtoId cardPrototype)
 {
     public readonly string? FullName = fullName;
     public readonly string? JobTitle = jobTitle;
     public readonly ProtoId<JobIconPrototype> JobIcon = jobIcon;
-    public readonly HashSet<ProtoId<AccessLevelPrototype>> AccessTags = tags;
     public readonly List<ProtoId<DepartmentPrototype>> Departments = departments;
     public readonly EntProtoId CardPrototype = cardPrototype;
 
@@ -61,7 +59,6 @@ public sealed class EldritchIdConfiguration(
                JobTitle == other.JobTitle &&
                JobIcon.Id == other.JobIcon.Id &&
                CardPrototype.Id == other.CardPrototype.Id &&
-               AccessTags.SetEquals(other.AccessTags) &&
                Departments.SequenceEqual(other.Departments);
     }
 
@@ -73,12 +70,6 @@ public sealed class EldritchIdConfiguration(
         hash.Add(JobTitle);
         hash.Add(JobIcon.Id);
         hash.Add(CardPrototype.Id);
-
-        hash.Add(AccessTags.Count);
-        foreach (var tag in AccessTags.OrderBy(x => x.Id))
-        {
-            hash.Add(tag);
-        }
 
         hash.Add(Departments.Count);
         foreach (var dept in Departments)

--- a/Content.Trauma.Shared/Heretic/Components/PathSpecific/Void/VoidConduitComponent.cs
+++ b/Content.Trauma.Shared/Heretic/Components/PathSpecific/Void/VoidConduitComponent.cs
@@ -31,7 +31,7 @@ public sealed partial class VoidConduitComponent : Component
     {
         DamageDict =
         {
-            { "Structural", 30 },
+            { "Structural", 50 },
         },
     };
 

--- a/Content.Trauma.Shared/Heretic/Events/HereticAbilities.cs
+++ b/Content.Trauma.Shared/Heretic/Events/HereticAbilities.cs
@@ -210,13 +210,13 @@ public sealed partial class HereticVoidPullEvent : InstantActionEvent
     };
 
     [DataField]
-    public TimeSpan StunTime = TimeSpan.FromSeconds(0.5);
+    public bool DropItems;
 
     [DataField]
-    public TimeSpan KnockDownTime = TimeSpan.FromSeconds(3);
+    public TimeSpan KnockDownTime = TimeSpan.FromSeconds(4);
 
     [DataField]
-    public float Radius = 3f;
+    public float Radius = 2f;
 
     [DataField]
     public EntProtoId InEffect = "EffectVoidBlinkIn";
@@ -467,6 +467,7 @@ public sealed partial class EventHereticRealignment : InstantActionEvent
 
 // ascensions
 public sealed partial class HereticAscensionCosmosEvent : HereticKnowledgeEvent;
+public sealed partial class HereticAscensionLockEvent : HereticKnowledgeEvent;
 #endregion
 
 public abstract partial class InstantWorldTargetActionEvent : WorldTargetActionEvent;

--- a/Content.Trauma.Shared/Heretic/Systems/Abilities/SharedHereticAbilitySystem.Cosmos.cs
+++ b/Content.Trauma.Shared/Heretic/Systems/Abilities/SharedHereticAbilitySystem.Cosmos.cs
@@ -18,13 +18,13 @@ public abstract partial class SharedHereticAbilitySystem
         SubscribeLocalEvent<EventHereticCosmicRune>(OnCosmicRune);
         SubscribeLocalEvent<EventHereticStarBlast>(OnStarBlast);
         SubscribeLocalEvent<EventHereticCosmicExpansion>(OnExpansion);
-        SubscribeLocalEvent<HereticAscensionCosmosEvent>(OnAscension);
+        SubscribeLocalEvent<HereticAscensionCosmosEvent>(OnAscensionCosmos);
 
         SubscribeLocalEvent<StarBlastComponent, ProjectileHitEvent>(OnHit);
         SubscribeLocalEvent<StarBlastComponent, EntityTerminatingEvent>(OnEntityTerminating);
     }
 
-    private void OnAscension(HereticAscensionCosmosEvent args)
+    private void OnAscensionCosmos(HereticAscensionCosmosEvent args)
     {
         _eye.SetDrawFov(args.Heretic, args.Negative);
     }

--- a/Content.Trauma.Shared/Heretic/Systems/Abilities/SharedHereticAbilitySystem.Lock.cs
+++ b/Content.Trauma.Shared/Heretic/Systems/Abilities/SharedHereticAbilitySystem.Lock.cs
@@ -1,10 +1,25 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+using Content.Shared._Starlight.CollectiveMind;
+using Content.Trauma.Shared.Heretic.Events;
+
 namespace Content.Trauma.Shared.Heretic.Systems.Abilities;
 
 public abstract partial class SharedHereticAbilitySystem
 {
     protected virtual void SubscribeLock()
     {
+        SubscribeLocalEvent<HereticAscensionLockEvent>(OnAscensionLock);
+    }
+
+    private void OnAscensionLock(HereticAscensionLockEvent args)
+    {
+        _eye.SetDrawFov(args.Heretic, args.Negative);
+
+        var collectiveMind = EnsureComp<CollectiveMindComponent>(args.Heretic);
+        if (args.Negative)
+            collectiveMind.Channels.Remove(MansusLinkMind);
+        else
+            collectiveMind.Channels.Add(MansusLinkMind);
     }
 }

--- a/Content.Trauma.Shared/Heretic/Systems/Abilities/SharedHereticAbilitySystem.Void.cs
+++ b/Content.Trauma.Shared/Heretic/Systems/Abilities/SharedHereticAbilitySystem.Void.cs
@@ -118,7 +118,6 @@ public abstract partial class SharedHereticAbilitySystem
                 targetPart: TargetBodyPart.All,
                 canMiss: false);
 
-            _stun.TryUpdateParalyzeDuration(pookie.Owner, args.StunTime);
             _stun.TryKnockdown(pookie.Owner, args.KnockDownTime, refresh: true);
 
             if (condition)

--- a/Content.Trauma.Shared/Heretic/Systems/Abilities/SharedHereticAbilitySystem.cs
+++ b/Content.Trauma.Shared/Heretic/Systems/Abilities/SharedHereticAbilitySystem.cs
@@ -3,6 +3,7 @@
 using Content.Goobstation.Common.Religion;
 using Content.Medical.Common.Damage;
 using Content.Medical.Common.Targeting;
+using Content.Shared._Starlight.CollectiveMind;
 using Content.Shared.Actions;
 using Content.Shared.Actions.Events;
 using Content.Shared.Body;
@@ -117,6 +118,8 @@ public abstract partial class SharedHereticAbilitySystem : EntitySystem
             { "Holy", 1 },
         },
     };
+
+    public static ProtoId<CollectiveMindPrototype> MansusLinkMind = "MansusLink";
 
     public override void Initialize()
     {

--- a/Content.Trauma.Shared/Heretic/Systems/PathSpecific/Lock/LockPortalSystem.cs
+++ b/Content.Trauma.Shared/Heretic/Systems/PathSpecific/Lock/LockPortalSystem.cs
@@ -3,10 +3,13 @@
 using Content.Goobstation.Common.BlockTeleport;
 using Content.Shared.Doors.Components;
 using Content.Shared.Doors.Systems;
+using Content.Shared.Examine;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Movement.Pulling.Systems;
+using Content.Shared.Physics;
 using Content.Shared.Teleportation.Components;
+using Content.Shared.Verbs;
 using Content.Trauma.Common.MartialArts;
 using Content.Trauma.Shared.Heretic.Components.PathSpecific.Lock;
 using Robust.Shared.Audio.Systems;
@@ -14,6 +17,7 @@ using Robust.Shared.Network;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Events;
 using Robust.Shared.Random;
+using Robust.Shared.Utility;
 
 namespace Content.Trauma.Shared.Heretic.Systems.PathSpecific.Lock;
 
@@ -28,13 +32,56 @@ public sealed class LockPortalSystem : EntitySystem
     [Dependency] private readonly SharedDoorSystem _door = default!;
     [Dependency] private readonly SharedHereticSystem _heretic = default!;
 
+    public const int LockPortalMask = (int) CollisionGroup.InteractImpassable;
+
     public override void Initialize()
     {
         base.Initialize();
 
         SubscribeLocalEvent<LockPortalComponent, StartCollideEvent>(OnCollide);
         SubscribeLocalEvent<LockPortalComponent, EndCollideEvent>(OnEndCollide);
+        SubscribeLocalEvent<LockPortalComponent, GetVerbsEvent<AlternativeVerb>>(OnGetVerbs);
+        SubscribeLocalEvent<LockPortalComponent, ExaminedEvent>(OnExamine);
     }
+
+    private void OnExamine(Entity<LockPortalComponent> ent, ref ExaminedEvent args)
+    {
+        if (!_heretic.IsHereticOrGhoul(args.Examiner))
+            return;
+
+        var status = ent.Comp.Inverted
+            ? Loc.GetString("lock-portal-component-examine-inverted")
+            : Loc.GetString("lock-portal-component-examine-not-inverted");
+        args.PushMarkup(Loc.GetString("lock-portal-component-examine-message", ("status", status)));
+    }
+
+    private void OnGetVerbs(Entity<LockPortalComponent> ent, ref GetVerbsEvent<AlternativeVerb> args)
+    {
+        if (!args.CanInteract || !args.CanAccess)
+            return;
+
+        if (!_heretic.IsHereticOrGhoul(args.User))
+            return;
+
+        if (!HasComp<EldritchIdCardComponent>(args.Using))
+            return;
+
+        AlternativeVerb verb = new()
+        {
+            Text = Loc.GetString("lock-portal-component-clear-portals"),
+            Icon = new SpriteSpecifier.Rsi(new ResPath("_Goobstation/Heretic/Effects/effects.rsi"), "realitycrack"),
+            Act = () => ClearPortals(ent),
+        };
+
+        args.Verbs.Add(verb);
+    }
+
+    private void ClearPortals(Entity<LockPortalComponent> ent)
+    {
+        PredictedQueueDel(ent.Comp.LinkedPortal);
+        PredictedQueueDel(ent);
+    }
+
 
     private void OnEndCollide(Entity<LockPortalComponent> ent, ref EndCollideEvent args)
     {
@@ -156,7 +203,8 @@ public sealed class LockPortalSystem : EntitySystem
         List<Entity<DoorComponent, TransformComponent>> possibleDestinations = new();
         while (query.MoveNext(out var uid, out var door, out var body, out var xform))
         {
-            if (!body.CanCollide || uid == ourAirlock || xform.MapID != ourXform.MapID ||
+            if ((body.CollisionLayer & LockPortalMask) == 0 || uid == ourAirlock ||
+                xform.MapID != ourXform.MapID ||
                 xform.GridUid != ourXform.GridUid)
                 continue;
 

--- a/Content.Trauma.Shared/Heretic/Systems/PathSpecific/Lock/SharedEldritchIdCardSystem.cs
+++ b/Content.Trauma.Shared/Heretic/Systems/PathSpecific/Lock/SharedEldritchIdCardSystem.cs
@@ -8,6 +8,7 @@ using Content.Shared.Coordinates;
 using Content.Shared.Doors.Components;
 using Content.Shared.Examine;
 using Content.Shared.Interaction;
+using Content.Shared.Physics;
 using Content.Shared.Popups;
 using Content.Shared.UserInterface;
 using Content.Shared.Verbs;
@@ -61,14 +62,15 @@ public abstract class SharedEldritchIdCardSystem : EntitySystem
             return;
         }
 
-        if (HasComp<LockPortalComponent>(target) && (ent.Comp.PortalOne == target || ent.Comp.PortalTwo == target))
+        if (TryComp(target, out LockPortalComponent? portal))
         {
             args.Handled = true;
-            ClearPortals(ent);
+            InvertPortals((target, portal), args.User);
             return;
         }
 
-        if (!HasComp<DoorComponent>(target) || !TryComp(target, out PhysicsComponent? body) || !body.CanCollide)
+        if (!HasComp<DoorComponent>(target) || !TryComp(target, out PhysicsComponent? body) ||
+            (body.CollisionLayer & LockPortalSystem.LockPortalMask) == 0)
             return;
 
         var coords = Transform(target).Coordinates;
@@ -230,7 +232,6 @@ public abstract class SharedEldritchIdCardSystem : EntitySystem
         _idCard.TryChangeJobDepartment(ent, config.Departments, ent.Comp2);
         _idCard.TryChangeJobTitle(ent, config.JobTitle, ent.Comp2, user);
         _idCard.TryChangeJobIcon(ent, _proto.Index(config.JobIcon), ent.Comp2, user);
-        _access.TrySetTags(ent, config.AccessTags, ent.Comp3);
 
         ent.Comp1.CurrentProto = config.CardPrototype;
         DirtyField(ent.Owner, ent.Comp1, nameof(EldritchIdCardComponent.CurrentProto));
@@ -238,15 +239,15 @@ public abstract class SharedEldritchIdCardSystem : EntitySystem
         UpdateSprite((ent.Owner, ent.Comp1));
     }
 
-    private EldritchIdConfiguration? GetConfig(Entity<IdCardComponent?, AccessComponent?, EldritchIdCardComponent?> ent)
+    private EldritchIdConfiguration? GetConfig(Entity<IdCardComponent?, EldritchIdCardComponent?> ent)
     {
-        if (!Resolve(ent, ref ent.Comp1, ref ent.Comp2, false))
+        if (!Resolve(ent, ref ent.Comp1, false))
             return null;
 
         EntProtoId? proto = null;
 
-        if (Resolve(ent, ref ent.Comp3, false))
-            proto = ent.Comp3.CurrentProto;
+        if (Resolve(ent, ref ent.Comp2, false))
+            proto = ent.Comp2.CurrentProto;
 
         if (proto == null)
         {
@@ -259,22 +260,24 @@ public abstract class SharedEldritchIdCardSystem : EntitySystem
             ent.Comp1.LocalizedJobTitle,
             ent.Comp1.JobIcon,
             ent.Comp1.JobDepartments.ToList(),
-            ent.Comp2.Tags.ToHashSet(),
             proto.Value);
     }
 
-    private void ClearPortals(Entity<EldritchIdCardComponent> ent)
+    private void InvertPortals(Entity<LockPortalComponent> ent, EntityUid user)
     {
-        PredictedQueueDel(ent.Comp.PortalOne);
-        PredictedQueueDel(ent.Comp.PortalTwo);
+        ent.Comp.Inverted = !ent.Comp.Inverted;
+        DirtyField(ent.AsNullable(), nameof(LockPortalComponent.Inverted));
 
-        ent.Comp.PortalOne = null;
-        ent.Comp.PortalTwo = null;
-        DirtyFields(ent.Owner,
-            ent.Comp,
-            null,
-            nameof(EldritchIdCardComponent.PortalOne),
-            nameof(EldritchIdCardComponent.PortalTwo));
+        _popup.PopupClient(Loc.GetString("eldritch-id-card-component-portal-inverted",
+                ("inverted", ent.Comp.Inverted)),
+            user,
+            user);
+
+        if (!Exists(ent.Comp.LinkedPortal) || !TryComp(ent.Comp.LinkedPortal.Value, out LockPortalComponent? portal2))
+            return;
+
+        portal2.Inverted = ent.Comp.Inverted;
+        DirtyField(ent.Comp.LinkedPortal.Value, portal2, nameof(LockPortalComponent.Inverted));
     }
 
     private void EatCard(Entity<EldritchIdCardComponent> ent, Entity<IdCardComponent> idCard, EntityUid user)
@@ -287,6 +290,8 @@ public abstract class SharedEldritchIdCardSystem : EntitySystem
         if (config == null)
             return;
 
+        if (TryComp(idCard, out AccessComponent? access))
+            _access.TrySetTags(ent, access.Tags, overwrite: false);
         ent.Comp.Configs.Add(config);
         DirtyField(ent.Owner, ent.Comp, nameof(EldritchIdCardComponent.Configs));
 

--- a/Resources/Locale/en-US/_Goobstation/Heretic/abilities/heretic.ftl
+++ b/Resources/Locale/en-US/_Goobstation/Heretic/abilities/heretic.ftl
@@ -24,6 +24,7 @@ heretic-ability-fail-mirror-jaunt-no-mirrors = There are no reflective surfaces 
 heretic-ability-lose-focus-shadow-cloak = As you lose your focus, you are pulled out of the shadows!
 heretic-ability-lose-focus-pale-cloak = As you lose your focus, you are pulled out of the light!
 heretic-ability-lose-focus-last-refuge = Without a focus, your refuge weakens and dissipates!
+heretic-ability-fail-other-minds-nearby = Other minds nearby!
 
 heretic-cosmic-rune-fail-star-mark = Blocked by star mark!
 heretic-cosmic-rune-fail-unlinked = No linked rune!

--- a/Resources/Locale/en-US/_Goobstation/Heretic/heretic/eldritch_id.ftl
+++ b/Resources/Locale/en-US/_Goobstation/Heretic/heretic/eldritch_id.ftl
@@ -13,8 +13,24 @@ eldritch-id-card-component-on-invert =
       *[false] no longer
     } creating inverted rifts
 
+eldritch-id-card-component-portal-inverted =
+    portal { $inverted ->
+             [true] inverted
+             *[false] no longer inverted
+           }
+
 eldritch-id-card-component-invert = Invert
 eldritch-id-card-component-invert-message = Make the ID make inverted portals, which teleport you onto a random airlock onstation, while heathens are teleported to the destination or vise versa.
 
 eldritch-id-card-component-link-one = link 1/2
 eldritch-id-card-component-link-two = link 2/2
+
+lock-portal-component-clear-portals = Clear both links
+
+lock-portal-component-examine-inverted = [color=yellow]inverted[/color]
+lock-portal-component-examine-not-inverted = [color=yellow]not inverted[/color]
+
+lock-portal-component-examine-message =
+    Portal is {$status}.
+    Click it using eldritch id to invert it.
+    Alt-click with eldrith id to remove both links.

--- a/Resources/Locale/en-US/_Goobstation/Heretic/store/heretic/heretic-catalog-lock.ftl
+++ b/Resources/Locale/en-US/_Goobstation/Heretic/store/heretic/heretic-catalog-lock.ftl
@@ -1,27 +1,3 @@
-# SPDX-FileCopyrightText: 2020 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2020 DamianX <DamianX@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2020 Visne <vincefvanwijk@gmail.com>
-# SPDX-FileCopyrightText: 2021 Acruid <shatter66@gmail.com>
-# SPDX-FileCopyrightText: 2021 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2021 Galactic Chimp <63882831+GalacticChimp@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
-# SPDX-FileCopyrightText: 2021 RemberBL <timmermanrembrandt@gmail.com>
-# SPDX-FileCopyrightText: 2021 Visne <39844191+Visne@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2022 Flipp Syder <76629141+vulppine@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2022 Leon Friedrich <60421075+ElectroJr@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2022 Paul Ritter <ritter.paul1@googlemail.com>
-# SPDX-FileCopyrightText: 2022 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2022 mirrorcult <lunarautomaton6@gmail.com>
-# SPDX-FileCopyrightText: 2022 wrexbe <81056464+wrexbe@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 Flareguy <78941145+Flareguy@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Piras314 <p1r4s@proton.me>
-# SPDX-FileCopyrightText: 2024 username <113782077+whateverusername0@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 whateverusername0 <whateveremail>
-# SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 Aiden <aiden@djkraz.com>
-#
-# SPDX-License-Identifier: AGPL-3.0-or-later
-
 knowledge-path-lock-s1-name = A Steward's Secret
 knowledge-path-lock-s1-desc =
     The Locked Labyrinth leads to freedom. But only the trapped Stewards know the correct path.
@@ -57,6 +33,7 @@ knowledge-path-lock-s4-desc =
     Click on a pair of airlocks with it to create a pair of portals, which will teleport you between them, but teleport non-heretics randomly.
     You can alt-click the card to invert this behavior for created portals.
     Each card may only sustain a single pair of portals at the same time.
+    Click the existing portal using eldritch id to invert it, alt-click it to remove both links.
     It also functions and appears the same as a regular ID Card.
     Using it on a normal ID card consumes it and gains its access, and you can use it in-hand to change its appearance to a card you fused.
 
@@ -65,13 +42,14 @@ knowledge-path-lock-s5-desc =
     The Concierge scribbled my name into the Handbook. "Welcome to your new home, fellow Steward."
 
     Allows you to transmute a crayon, a wooden plank, and a multitool to create a Labyrinth Handbook.
-    It can materialize a barricade at range that only you and people resistant to magic can pass. Has 5 charges which regenerate over time.
+    It can materialize a barricade at range that noone can pass. Has 5 charges which regenerate over time.
 
 knowledge-path-lock-s6-name = Burglar's Finesse
 knowledge-path-lock-s6-desc =
     Consorting with Burglar spirits is frowned upon, but a Steward will always want to learn about new doors.
 
     Grants you Burglar's Finesse, a single-target spell that puts a random item from the victims backpack into your hand.
+    Doesn't require focus to cast.
 
 knowledge-path-lock-s7-name = Opening Blade
 knowledge-path-lock-s7-desc =
@@ -95,4 +73,4 @@ knowledge-path-lock-s9-desc =
     When completed, you gain the ability to transform into empowered eldritch creatures and your keyblades will become even deadlier.
     In addition, you will create a tear to the Labyrinth's heart; a tear in reality located at the site of this ritual.
     Eldritch creatures will endlessly pour from this rift who are bound to obey your instructions.
-    You also gain x-ray vision as well as immunity to extreme pressure and temperature.
+    You also gain x-ray vision, mansus link hivemind access as well as immunity to extreme pressure and temperature.

--- a/Resources/Prototypes/_Goobstation/Actions/Heretic/path_lock.yml
+++ b/Resources/Prototypes/_Goobstation/Actions/Heretic/path_lock.yml
@@ -22,9 +22,10 @@
     canTargetSelf: false
     event: !type:EventHereticBulglarFinesse
   - type: HereticAction
-    requireMagicItem: true
+    requireMagicItem: false
   - type: SpeakOnAction
     sentence: heretic-speech-bulglar-finesse
+    chatType: Whisper
 
 - type: entity
   parent: BaseAction

--- a/Resources/Prototypes/_Goobstation/Actions/Heretic/path_void.yml
+++ b/Resources/Prototypes/_Goobstation/Actions/Heretic/path_void.yml
@@ -1,12 +1,3 @@
-# SPDX-FileCopyrightText: 2024 Aidenkrz <aiden@djkraz.com>
-# SPDX-FileCopyrightText: 2024 Armok <155400926+ARMOKS@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Piras314 <p1r4s@proton.me>
-# SPDX-FileCopyrightText: 2024 username <113782077+whateverusername0@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 whateverusername0 <whateveremail>
-# SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
-#
-# SPDX-License-Identifier: AGPL-3.0-or-later
-
 - type: entity
   parent: BaseAction
   id: ActionHereticVoidPhase
@@ -97,7 +88,7 @@
   description: Opens a gate to the Void; it releases an intermittent pulse that damages windows and airlocks, while afflicting Heathens with void chill. Affected Heretics instead receive low pressure resistance.
   components:
   - type: Action
-    useDelay: 60
+    useDelay: 90
     itemIconStyle: NoItem
     checkCanInteract: false
     icon:
@@ -110,5 +101,5 @@
   - type: SpeakOnAction
     sentence: heretic-speech-void-conduit
   - type: ChangeUseDelayOnAscension
-    newUseDelay: 30
+    newUseDelay: 45
     requiredPath: Void

--- a/Resources/Prototypes/_Goobstation/Heretic/Entities/Mobs/star_gazer.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Entities/Mobs/star_gazer.yml
@@ -118,7 +118,7 @@
     effect: EffectCosmicSlash
   - type: HealingAura
     componentHealMultipliers:
-      CosmosPassive: 2
+      CosmosPassive: 1.5
   - type: Tag
     tags:
     - CannotSuicide

--- a/Resources/Prototypes/_Goobstation/Heretic/Entities/Objects/Weapons/Melee/heretic_blades.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Entities/Objects/Weapons/Melee/heretic_blades.yml
@@ -151,8 +151,8 @@
   - type: HereticBlade
     bonusEvent: !type:HereticBladeBonusWoundingEvent
       woundingBonus:
-        7: 2
-        10: 3
+        7: 1.25
+        10: 1.5
     probabilities:
       7: 0.35
       10: 0.65

--- a/Resources/Prototypes/_Goobstation/Heretic/Heretic/heretic_knowledge.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Heretic/heretic_knowledge.yml
@@ -580,7 +580,7 @@
   id: UnlockTheLabyrinth
   stage: 10
   path: Lock
-  event: !type:HereticAscensionCosmosEvent # Uses cosmos ascension cause its basically the same (xray vision)
+  event: !type:HereticAscensionLockEvent
     addedComponents:
     - type: SpecialLowTempImmunity
     - type: SpecialHighTempImmunity


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->

Lock blade upgrade wounding nerfed, it was too insane.
Lock eldritch id can invert existing portals by clicking on them and remove portals by alt-clicking.
You now don't need to change eldritch id appearance to swap accesses, it now just gains accesses upon eating the card.
Fixed not being able to place portals on open doors.
Burglars Finesse inovcation is now whisper instead of speech and it doesn't require focus anymore.
Lock ascension gives you mansus link.
Updated some descriptions in locale.
Void conduit nerfed (cd x1.5 and now ticks once per 2 seconds up from 1) it is very evil spell.
Void pull no longer disarms (evil aoe disarm + knockdown + pull + damage), range nerfed 3 -> 2 (idk why it was 3 its 2 in 13) but knockdown time increased to compensate 3 -> 4.
Rust healing nerfed.
Star gazer healing nerfed too cause yeah.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Aviu
- tweak: Rust and stargazer healing nerfed.
- tweak: Void pull and conduit nerfed.
- tweak: Lock blade upgrade wounding nerfed.
- add: Eldritch id can now invert existing portals by clicking on them, alt-click to remove portals.
- add: You don't need to change eldritch id appearance to swap accesses, it combines all accesses from consumed cards.
- tweak: Burglars Finesse no longer requires focus and invocation is whisper now.
- fix: Fix not being able to place portals on open doors using eldritch id.
- add: Lock ascension gives you mansus link access.