### PR TITLE
fix ipc not getting radio keys

### DIFF
--- a/Content.Server/Station/Systems/StationSpawningSystem.cs
+++ b/Content.Server/Station/Systems/StationSpawningSystem.cs
@@ -153,7 +153,7 @@ public sealed class StationSpawningSystem : SharedStationSpawningSystem
         if (prototype?.StartingGear != null)
         {
             var startingGear = _prototypeManager.Index<StartingGearPrototype>(prototype.StartingGear);
-            EquipStartingGear(entity.Value, startingGear, raiseEvent: false);
+            EquipStartingGear(entity.Value, startingGear, raiseEvent: true); // Trauma - do raise the event, IPCs need it
         }
 
         var gearEquippedEv = new StartingGearEquippedEvent(entity.Value);


### PR DESCRIPTION
fixes #1790

pov theres 0 tests for it :face_holding_back_tears: 

## Media
yeah
<img width="362" height="54" alt="14:04:59" src="https://github.com/user-attachments/assets/deb49e0f-744f-4116-8dd9-fface7e2e5c5" />


vox internals being on by default, only other thing that used this event, still works
<img width="91" height="73" alt="14:05:54" src="https://github.com/user-attachments/assets/16848729-4257-490a-a45e-8d21765a5f96" />


**Changelog**
:cl:
- fix: Fixed IPCs not getting any radio keys.