### PR TITLE
rewrite armor examines

### DIFF
--- a/Content.Shared/Armor/SharedArmorSystem.cs
+++ b/Content.Shared/Armor/SharedArmorSystem.cs
@@ -123,9 +123,9 @@ public abstract class SharedArmorSystem : EntitySystem
             {
                 msg.PushNewline();
                 var armorType = Loc.GetString("armor-damage-type-" + coefficientArmor.Key.ToLower());
-                msg.AddMarkupOrThrow(Loc.GetString("armor-coefficient-value",
+                msg.AddMarkupOrThrow(Loc.GetString("armor-coefficient-value-trauma", // Trauma - better locale string
                     ("type", armorType),
-                    ("value", MathF.Round((1f - coefficientArmor.Value) * 100, 1))
+                    ("value", MathF.Abs(1f - coefficientArmor.Value) * 100), ("protect", coefficientArmor.Value < 1f) // Trauma - better values
                 ));
             }
 

--- a/Content.Shared/Damage/Components/StaminaResistanceComponent.cs
+++ b/Content.Shared/Damage/Components/StaminaResistanceComponent.cs
@@ -34,5 +34,5 @@ public sealed partial class StaminaResistanceComponent : Component
     /// Passed <c>value</c> from 0 to 100.
     /// </summary>
     [DataField]
-    public LocId Examine = "stamina-resistance-coefficient-value";
+    public LocId Examine = "stamina-resistance-coefficient-value-trauma"; // Trauma - custom examine
 }

--- a/Content.Shared/Damage/Systems/SharedStaminaSystem.Resistance.cs
+++ b/Content.Shared/Damage/Systems/SharedStaminaSystem.Resistance.cs
@@ -33,6 +33,6 @@ public partial class SharedStaminaSystem
             return;
 
         args.Msg.PushNewline();
-        args.Msg.AddMarkupOrThrow(Loc.GetString(ent.Comp.Examine, ("value", value)));
+        args.Msg.AddMarkupOrThrow(Loc.GetString(ent.Comp.Examine, ("value", MathF.Abs(value)), ("protect", value > 0))); // Trauma - custom examine params
     }
 }

--- a/Resources/Locale/en-US/_Goobstation/armor/armor-examine.ftl
+++ b/Resources/Locale/en-US/_Goobstation/armor/armor-examine.ftl
@@ -1,13 +1,3 @@
-# SPDX-FileCopyrightText: 2024 Piras314 <p1r4s@proton.me>
-# SPDX-FileCopyrightText: 2024 username <113782077+whateverusername0@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 Aiden <aiden@djkraz.com>
-# SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
-#
-# SPDX-License-Identifier: AGPL-3.0-or-later
-
-armor-examine-stamina = - [color=cyan]Stamina[/color] damage reduced by [color=lightblue]{$num}%[/color].
-
 armor-examine-cancel-delayed-knockdown = - [color=green]Completely cancels[/color] stun baton delayed knockdown.
 
 armor-examine-modify-delayed-knockdown-delay =

--- a/Resources/Locale/en-US/_Trauma/armor/armor-examine.ftl
+++ b/Resources/Locale/en-US/_Trauma/armor/armor-examine.ftl
@@ -1,0 +1,8 @@
+-protection = damage { $protect ->
+    [true] reduced
+    *[false] [color=red]increased[/color]
+} by [color=lightblue]{TOSTRING($value, "F1")}%[/color].
+
+armor-coefficient-value-trauma = - [color=yellow]{$type}[/color] { -protection(protect: $protect, value: $value) }
+
+stamina-resistance-coefficient-value-trauma = - [color=lightyellow]Stamina[/color] { -protection(protect: $protect, value: $value) }

--- a/Resources/Locale/en-US/_lib.ftl
+++ b/Resources/Locale/en-US/_lib.ftl
@@ -1,14 +1,3 @@
-# SPDX-FileCopyrightText: 2021 20kdc <asdd2808@gmail.com>
-# SPDX-FileCopyrightText: 2021 mirrorcult <notzombiedude@gmail.com>
-# SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
-# SPDX-FileCopyrightText: 2023 Repo <47093363+Titian3@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
-# SPDX-FileCopyrightText: 2024 Stalen <33173619+stalengd@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 Aiden <aiden@djkraz.com>
-#
-# SPDX-License-Identifier: AGPL-3.0-or-later
-
 ### Special messages used by internal localizer stuff.
 
 # Used internally by the PRESSURE() function.

--- a/Resources/Locale/en-US/armor/armor-examine.ftl
+++ b/Resources/Locale/en-US/armor/armor-examine.ftl
@@ -1,12 +1,3 @@
-# SPDX-FileCopyrightText: 2022 CommieFlowers <rasmus.cedergren@hotmail.com>
-# SPDX-FileCopyrightText: 2022 rolfero <45628623+rolfero@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 Chronophylos <nikolai@chronophylos.com>
-# SPDX-FileCopyrightText: 2024 SlamBamActionman <83650252+SlamBamActionman@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 Aiden <aiden@djkraz.com>
-#
-# SPDX-License-Identifier: AGPL-3.0-or-later
-
 # Armor examines
 armor-examinable-verb-text = Armor
 armor-examinable-verb-message = Examine the armor values.

--- a/Resources/Locale/en-US/damage/stamina.ftl
+++ b/Resources/Locale/en-US/damage/stamina.ftl
@@ -1,11 +1,3 @@
-# SPDX-FileCopyrightText: 2023 Slava0135 <40753025+Slava0135@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 Aiden <aiden@djkraz.com>
-#
-# SPDX-License-Identifier: AGPL-3.0-or-later
-
 melee-stamina = Not enough stamina
 slow-on-damage-modifier-examine = Slowness from injuries is reduced by [color=yellow]{$mod}%[/color]
 stamina-resistance-coefficient-value = - [color=lightyellow]Stamina[/color] damage reduced by [color=lightblue]{$value}%[/color].


### PR DESCRIPTION
fixes #1837

## Media
<img width="316" height="128" alt="00:20:57" src="https://github.com/user-attachments/assets/6725560e-6895-4103-b9f4-f3f4897c6450" />
<img width="333" height="159" alt="00:21:24" src="https://github.com/user-attachments/assets/53aa9913-a7ad-48b4-b955-9c38e62437f9" />


:cl:
- tweak: Made armor examine better, no more negative "protection" or 20 decimal places.