### PR TITLE
clean up gunpowder and bone materials

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Materials/materials.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/materials.yml
@@ -748,7 +748,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      Bone: 100
+      Bones: 100
   # </Trauma>
   - type: Stack
     stackType: Bones

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
@@ -238,6 +238,14 @@
   id: SpearBone
   description: A spear made of bones.
   components:
+  # <Trauma>
+  - type: PhysicalComposition
+    materialComposition:
+      Bones: 200
+  - type: Tag
+    tags:
+    - Trash
+  # </Trauma>
   - type: Sprite
     sprite: Objects/Weapons/Melee/bone_spear.rsi
   - type: Construction
@@ -266,14 +274,6 @@
             max: 2
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
-  # <Trauma>
-  - type: PhysicalComposition
-    materialComposition:
-      Bone: 200
-  - type: Tag
-    tags:
-    - Trash
-  # </Trauma>
 
 - type: entity
   name: sharkminnow tooth spear
@@ -281,6 +281,17 @@
   id: SpearSharkMinnow
   description: A spear with a sharkminnow tooth as a tip.
   components:
+  # <Trauma>
+  - type: PhysicalComposition
+    materialComposition:
+      Glass: 50
+      Steel: 50
+  - type: Tag
+    tags:
+    - Spear
+    - ScurretWearable
+    - Trash
+  # </Trauma>
   - type: Sprite
     sprite: Objects/Weapons/Melee/sharkminnow_spear.rsi
   - type: MeleeWeapon
@@ -294,14 +305,3 @@
         Piercing: 30 #goobedit - buff spear variant, nerf tooth.
   - type: Construction
     graph: SpearSharkMinnow
-  # <Trauma>
-  - type: PhysicalComposition
-    materialComposition:
-      Glass: 50
-      Steel: 50
-  - type: Tag
-    tags:
-    - Spear
-    - ScurretWearable
-    - Trash
-  # </Trauma>

--- a/Resources/Prototypes/Reagents/Materials/materials.yml
+++ b/Resources/Prototypes/Reagents/Materials/materials.yml
@@ -110,6 +110,7 @@
 
 - type: material
   id: Bones
+  stackEntity: MaterialBones1 # Trauma
   name: materials-bones
   unit: materials-unit-piece
   icon: { sprite: _Trauma/Objects/Materials/materials.rsi, state: bones } # Trauma
@@ -128,7 +129,7 @@
 - type: material
   id: Gunpowder
   stackEntity: MaterialGunpowder # Trauma
-  name: materials-bone
+  name: materials-gunpowder
   unit: materials-unit-piece
   icon: { sprite: Objects/Misc/reagent_fillings.rsi, state: powderpile }
   color: "#A9A9A9"

--- a/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/Melee/bones.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/Melee/bones.yml
@@ -57,7 +57,7 @@
     node: axe
   - type: PhysicalComposition
     materialComposition:
-      Bone: 300
+      Bones: 300
   - type: Tag
     tags:
     - Trash
@@ -94,4 +94,4 @@
     - Trash
   - type: PhysicalComposition
     materialComposition:
-      Bone: 100
+      Bones: 100

--- a/Resources/Prototypes/_Trauma/Reagents/Materials/materials.yml
+++ b/Resources/Prototypes/_Trauma/Reagents/Materials/materials.yml
@@ -33,12 +33,3 @@
   icon: { sprite: _Trauma/Objects/Tools/weaponreinforcement.rsi, state: icon }
   color: "#000000"
   price: 0
-
-- type: material
-  id: Bone
-  stackEntity: MaterialBones1
-  name: materials-gunpowder
-  unit: materials-unit-piece
-  icon: { sprite: _Trauma/Objects/Materials/materials.rsi, state: bones }
-  color: "#A9A9A9"
-  price: 0


### PR DESCRIPTION
made bone stuff use upstream Bones material and killed redundant Bone material
renamed gunpowder material from bone... why the fuck was it using bone...?

## Media


**Changelog**
:cl:
- fix: Fixed gunpowder being called bones in the secfab...