### PR TITLE
make cargo not aids

### DIFF
--- a/Resources/Prototypes/Catalog/cargo_accounts.yml
+++ b/Resources/Prototypes/Catalog/cargo_accounts.yml
@@ -5,7 +5,7 @@
   color: "#b48b57"
   radioChannel: Supply
   acquisitionSlip: PaperAcquisitionSlipCargo
-  approveAccess: Quartermaster # Trauma
+  approveAccess: Cargo # Trauma
 
 - type: cargoAccount
   id: Engineering


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
cargo techs can now approve orders again

## Why / Balance
<img width="888" height="72" alt="image" src="https://github.com/user-attachments/assets/36913e9d-cbb6-4836-8e03-88003aea8a32" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

**Changelog**
:cl:
- tweak: Cargo Techs can now approve orders again
