### PR TITLE
Expand the security funding booster's antag pool

### DIFF
--- a/Resources/Prototypes/_Trauma/GameRules/security.yml
+++ b/Resources/Prototypes/_Trauma/GameRules/security.yml
@@ -11,11 +11,18 @@
       - id: SleeperAgentsQuiet
         weight: 0.8
       - id: LoneAbductorSpawn
+        weight: 0.5 # Basically same as DuoAbductors anyway
       - id: DuoAbductorSpawn
+        weight: 0.5
       - id: MorphRule
+      - id: WraithMidround
+      - id: ColossusSpawn
+      - id: DragonSpawn
       - id: NinjaSpawn
         weight: 0.5 # even more antags!
       - id: LoneOpsSpawn
+        weight: 0.2
+      - id: BlobSpawn
         weight: 0.2
       - !type:AllSelector
         weight: 0.3


### PR DESCRIPTION
## About the PR
Security funding booster is great, but we can do better. Added wraith (midround version), space dragon, entropic colossus and blob (0.2 weight, like loneop) to the pool. Also gave both versions of abductor a weight of 0.5, as they're basically the same thing anyway, no reason to spawn them twice as often.

## Why / Balance
Variety good

## Technical details
YAMLmaxxing

## Media
No

**Changelog**
:cl:
- tweak: Security funding booster can now summon a wider variety of antags.
