### PR TITLE
kill plague mouse event + mail

### DIFF
--- a/Resources/Prototypes/_Trauma/Entities/Objects/Deliveries/letters.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Objects/Deliveries/letters.yml
@@ -99,8 +99,6 @@
       - id: MobMouse
       - id: MobMouse1
       - id: MobMouse2
-      - id: MobMousePlague
-        weight: 0.05
       - id: MobMouseCancer
         weight: 0.01
 

--- a/Resources/Prototypes/_Trauma/GameRules/events.yml
+++ b/Resources/Prototypes/_Trauma/GameRules/events.yml
@@ -8,7 +8,6 @@
     - id: MalignRiftSpawn
     - id: FloorGoblinMidRound
     - id: ClownGoblinMigration
-    - id: PlagueMiceSpawn
 
 - type: entityTable
   id: BasicAntagEventsTrauma
@@ -33,22 +32,6 @@
     - id: XenomorphsInfestation
     #- id: SlasherSpawn # TODO: when slasher is ready
     - id: ColossusSpawn
-
-- type: entity
-  parent: BaseStationEventShortDelay
-  id: PlagueMiceSpawn
-  components:
-  - type: StationEvent
-    startAnnouncement: station-event-vent-creatures-start-announcement
-    earliestStart: 20
-    minimumPlayers: 15
-    weight: 4 # annoying
-    reoccurrenceDelay: 60 # no spamming them
-    duration: 5
-  - type: VentHordeRule
-    table:
-      id: MobMousePlague
-      amount: 1, 3
 
 - type: entity
   id: RatmaSpawn


### PR DESCRIPTION
fixes #1872

doesnt do anything anymore so no point having it

:cl:
- remove: Removed plague mouse event since plague mice had their diseases removed a while ago.