### PR TITLE
fix durability welding

### DIFF
--- a/Content.Trauma.Shared/Durability/DurabilitySystem.cs
+++ b/Content.Trauma.Shared/Durability/DurabilitySystem.cs
@@ -340,7 +340,7 @@ public sealed class DurabilitySystem : EntitySystem
         {
             if (_tool.HasQuality(args.Used, ent.Comp.RepairTool, tool))
             {
-                _tool.UseTool(ent.Owner,
+                _tool.UseTool(args.Used,
                     args.User,
                     args.Target,
                     ent.Comp.RepairDoAfter,


### PR DESCRIPTION
passed wrong entity for the tool award
fixes #1845

:cl:
- fix: Fixed not being able to repair weapons durability with a welder.