### PR TITLE
nerf map vote

### DIFF
--- a/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
+++ b/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
@@ -278,7 +278,7 @@ namespace Content.Server.Voting.Managers
                 options.InitiatorTimeout = TimeSpan.FromSeconds(10);
             // <Trauma> - only allow calling map vote when it matters
             var roundEnd = _entityManager.System<RoundEndSystem>();
-            if (_gameTicker.RunLevel == GameRunLevel.InRound && !roundEnd.IsRoundEndRequested())
+            if (_gameTicker?.RunLevel == GameRunLevel.InRound && !roundEnd.IsRoundEndRequested())
             {
                 if (initiator is { } session)
                 {


### PR DESCRIPTION
you can now only call mapvote in the lobby or if evac is called/round ended

its genius

:cl:
- remove: No more map vote spamming while in the middle of a round :)