### PR TITLE
limit grab throw damage based on mass

### DIFF
--- a/Content.Trauma.Shared/Grab/GrabThrownSystem.cs
+++ b/Content.Trauma.Shared/Grab/GrabThrownSystem.cs
@@ -23,6 +23,8 @@ public sealed class GrabThrownSystem : CommonGrabThrownSystem
     [Dependency] private readonly INetManager _netMan = default!;
     [Dependency] private readonly SharedStunSystem _stun = default!;
 
+    public const float MinMass = 30f;
+
     public override void Initialize()
     {
         base.Initialize();
@@ -60,6 +62,9 @@ public sealed class GrabThrownSystem : CommonGrabThrownSystem
 
         var velocitySquared = args.OurBody.LinearVelocity.LengthSquared();
         var mass = physicsComponent.Mass;
+        if (mass < MinMass)
+            return; // don't care about mice and stuff
+
         var kineticEnergy = 0.5f * mass * velocitySquared;
         var kineticEnergyDamage = new DamageSpecifier();
         kineticEnergyDamage.DamageDict.Add("Blunt", 1);


### PR DESCRIPTION
resolves #1913
anything below 30kg no longer knocks you down etc when thrown
monkeys people goliaths etc should all still do damage due to their density

:cl:
- tweak: Grab-throwing mice and other light mobs no longer knocks down anyone they hit.