### PR TITLE
Remove cosmic cult pending rework

### DIFF
--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -10,14 +10,14 @@
     Nukeops: 0.09
     Honkops: 0.01
     Revolutionary: 0.13
-    Xenomorphs: 0.04
-    Zombie: 0.04
+    Xenomorphs: 0.05
+    Zombie: 0.05
     Survival: 0.01
-    Blob: 0.04
+    Blob: 0.05
     Wizard: 0.05
-    Shadowlings: 0.04
+    Shadowlings: 0.05
     AllAtOnce: 0.01
-    CosmicCult: 0.04
+    #CosmicCult: 0.04 # Removed pending rework
     Abductors: 0.05
     Wraith: 0.05
     #Facism: 0.04


### PR DESCRIPTION
## About the PR
Yeah it's not in a very good state right now. I got all the data I needed from playtesting, and it seems like the majority still doesn't like it, so it will be out of rotation until I finish rework part 2 (or someone else decides to put it back for some reason). Can still be forced by admins, and is still in AllAtOnce.

**Changelog**
:cl:
- remove: Removed cosmic cult pending rework.
