### PR TITLE
make ipc reboot use vital damage

### DIFF
--- a/Content.Trauma.Server/Silicon/DeadStartupButton/DeadStartupButtonSystem.cs
+++ b/Content.Trauma.Server/Silicon/DeadStartupButton/DeadStartupButtonSystem.cs
@@ -34,12 +34,12 @@ public sealed class DeadStartupButtonSystem : SharedDeadStartupButtonSystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<DeadStartupButtonComponent, OnDoAfterButtonPressedEvent>(OnDoAfter);
+        SubscribeLocalEvent<DeadStartupButtonComponent, DeadStartupDoAfterEvent>(OnDoAfter);
         SubscribeLocalEvent<DeadStartupButtonComponent, ElectrocutedEvent>(OnElectrocuted);
         SubscribeLocalEvent<DeadStartupButtonComponent, MobStateChangedEvent>(OnMobStateChanged);
     }
 
-    private void OnDoAfter(EntityUid uid, DeadStartupButtonComponent comp, OnDoAfterButtonPressedEvent args)
+    private void OnDoAfter(EntityUid uid, DeadStartupButtonComponent comp, DeadStartupDoAfterEvent args)
     {
         if (args.Handled || args.Cancelled
             || !TryComp<MobStateComponent>(uid, out var mobStateComponent)
@@ -47,7 +47,7 @@ public sealed class DeadStartupButtonSystem : SharedDeadStartupButtonSystem
             || !TryComp<MobThresholdsComponent>(uid, out var mobThresholdsComponent))
             return;
 
-        var damage = _damageable.GetTotalDamage(uid);
+        var damage = _mobThreshold.CheckVitalDamage(uid);
         // Check if entity have critical state
         if (_mobThreshold.TryGetThresholdForState(uid, MobState.Critical, out var criticalThreshold, mobThresholdsComponent)
             && damage < criticalThreshold)

--- a/Content.Trauma.Server/Silicon/DeadStartupButton/DeadStartupButtonSystem.cs
+++ b/Content.Trauma.Server/Silicon/DeadStartupButton/DeadStartupButtonSystem.cs
@@ -5,7 +5,6 @@ using Content.Server.Lightning;
 using Content.Server.Lightning.Components;
 using Content.Server.Popups;
 using Content.Shared.Audio;
-using Content.Shared.Damage.Systems;
 using Content.Shared.Electrocution;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
@@ -19,7 +18,6 @@ namespace Content.Trauma.Server.Silicon.DeadStartupButton;
 
 public sealed class DeadStartupButtonSystem : SharedDeadStartupButtonSystem
 {
-    [Dependency] private readonly DamageableSystem _damageable = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly MobThresholdSystem _mobThreshold = default!;
@@ -48,7 +46,7 @@ public sealed class DeadStartupButtonSystem : SharedDeadStartupButtonSystem
             return;
 
         var damage = _mobThreshold.CheckVitalDamage(uid);
-        // Check if entity have critical state
+        // Check if entity has a critical state
         if (_mobThreshold.TryGetThresholdForState(uid, MobState.Critical, out var criticalThreshold, mobThresholdsComponent)
             && damage < criticalThreshold)
         {
@@ -56,7 +54,7 @@ public sealed class DeadStartupButtonSystem : SharedDeadStartupButtonSystem
             return;
         }
 
-        // Check if entity have dead state
+        // Check if entity has a dead state
         if (_mobThreshold.TryGetThresholdForState(uid, MobState.Dead, out var deadThreshold, mobThresholdsComponent)
             && damage < deadThreshold)
         {

--- a/Content.Trauma.Shared/Silicon/DeadStartupButton/SharedDeadStartupButtonSystem.cs
+++ b/Content.Trauma.Shared/Silicon/DeadStartupButton/SharedDeadStartupButtonSystem.cs
@@ -49,7 +49,7 @@ public abstract partial class SharedDeadStartupButtonSystem : EntitySystem
         if (!_net.IsServer)
             return;
         _audio.PlayPvs(comp.ButtonSound, target);
-        var args = new DoAfterArgs(EntityManager, user, comp.DoAfterInterval, new OnDoAfterButtonPressedEvent(), target, target:target)
+        var args = new DoAfterArgs(EntityManager, user, comp.DoAfterInterval, new DeadStartupDoAfterEvent(), target, target:target)
         {
             BreakOnDamage = true,
             BreakOnMove = true,
@@ -59,7 +59,7 @@ public abstract partial class SharedDeadStartupButtonSystem : EntitySystem
     }
 
     [Serializable, NetSerializable]
-    public sealed partial class OnDoAfterButtonPressedEvent : SimpleDoAfterEvent
+    public sealed partial class DeadStartupDoAfterEvent : SimpleDoAfterEvent
     {
     }
 


### PR DESCRIPTION
also changed horrible event name

:cl:
- fix: Rebooting IPCs now uses vital damage instead of total damage.