### PR TITLE
Heretic and nullrod changes

### DIFF
--- a/Content.Goobstation.Server/Religion/WeakToHolySystem.cs
+++ b/Content.Goobstation.Server/Religion/WeakToHolySystem.cs
@@ -43,8 +43,7 @@ public sealed class WeakToHolySystem : SharedWeakToHolySystem
         if (TerminatingOrDeleted(parent) || !HasComp<WeakToHolyComponent>(parent))
             return;
 
-        var ev = new UnholyStatusChangedEvent(parent, ent, false);
-        RaiseLocalEvent(parent, ref ev);
+        ChangeUnholyStatus(ent, parent, false);
     }
 
     private void OnStartup(Entity<UnholyItemComponent> ent, ref ComponentStartup args)
@@ -53,20 +52,17 @@ public sealed class WeakToHolySystem : SharedWeakToHolySystem
         if (TerminatingOrDeleted(parent) || !HasComp<WeakToHolyComponent>(parent))
             return;
 
-        var ev = new UnholyStatusChangedEvent(parent, ent, true);
-        RaiseLocalEvent(parent, ref ev);
+        ChangeUnholyStatus(ent, parent, true);
     }
 
     private void OnHandUnequip(Entity<UnholyItemComponent> ent, ref GotUnequippedHandEvent args)
     {
-        var ev = new UnholyStatusChangedEvent(args.User, ent, false);
-        RaiseLocalEvent(args.User, ref ev);
+        ChangeUnholyStatus(ent, args.User, false);
     }
 
     private void OnHandEquip(Entity<UnholyItemComponent> ent, ref GotEquippedHandEvent args)
     {
-        var ev = new UnholyStatusChangedEvent(args.User, ent, true);
-        RaiseLocalEvent(args.User, ref ev);
+        ChangeUnholyStatus(ent, args.User, true);
     }
 
     private void OnUnquip(Entity<UnholyItemComponent> ent, ref GotUnequippedEvent args)
@@ -74,8 +70,7 @@ public sealed class WeakToHolySystem : SharedWeakToHolySystem
         if (args.SlotFlags == SlotFlags.POCKET)
             return;
 
-        var ev = new UnholyStatusChangedEvent(args.Equipee, ent, false);
-        RaiseLocalEvent(args.Equipee, ref ev);
+        ChangeUnholyStatus(ent, args.Equipee, false);
     }
 
     private void OnEquip(Entity<UnholyItemComponent> ent, ref GotEquippedEvent args)
@@ -83,8 +78,13 @@ public sealed class WeakToHolySystem : SharedWeakToHolySystem
         if (args.SlotFlags == SlotFlags.POCKET)
             return;
 
-        var ev = new UnholyStatusChangedEvent(args.Equipee, ent, true);
-        RaiseLocalEvent(args.Equipee, ref ev);
+        ChangeUnholyStatus(ent, args.Equipee, true);
+    }
+
+    private void ChangeUnholyStatus(EntityUid source, EntityUid user, bool status)
+    {
+        var ev = new UnholyStatusChangedEvent(user, source, status);
+        RaiseLocalEvent(user, ref ev);
     }
 
     private void OnUnholyStatus(Entity<ShouldTakeHolyComponent> ent, ref UnholyStatusChangedEvent args)

--- a/Content.Goobstation.Server/Religion/WeakToHolySystem.cs
+++ b/Content.Goobstation.Server/Religion/WeakToHolySystem.cs
@@ -33,6 +33,28 @@ public sealed class WeakToHolySystem : SharedWeakToHolySystem
         SubscribeLocalEvent<UnholyItemComponent, GotUnequippedEvent>(OnUnquip);
         SubscribeLocalEvent<UnholyItemComponent, GotEquippedHandEvent>(OnHandEquip);
         SubscribeLocalEvent<UnholyItemComponent, GotUnequippedHandEvent>(OnHandUnequip);
+        SubscribeLocalEvent<UnholyItemComponent, ComponentStartup>(OnStartup);
+        SubscribeLocalEvent<UnholyItemComponent, ComponentShutdown>(OnShutdown);
+    }
+
+    private void OnShutdown(Entity<UnholyItemComponent> ent, ref ComponentShutdown args)
+    {
+        var parent = Transform(ent).ParentUid;
+        if (TerminatingOrDeleted(parent) || !HasComp<WeakToHolyComponent>(parent))
+            return;
+
+        var ev = new UnholyStatusChangedEvent(parent, ent, false);
+        RaiseLocalEvent(parent, ref ev);
+    }
+
+    private void OnStartup(Entity<UnholyItemComponent> ent, ref ComponentStartup args)
+    {
+        var parent = Transform(ent).ParentUid;
+        if (TerminatingOrDeleted(parent) || !HasComp<WeakToHolyComponent>(parent))
+            return;
+
+        var ev = new UnholyStatusChangedEvent(parent, ent, true);
+        RaiseLocalEvent(parent, ref ev);
     }
 
     private void OnHandUnequip(Entity<UnholyItemComponent> ent, ref GotUnequippedHandEvent args)

--- a/Content.Goobstation.Shared/Boomerang/BoomerangSystem.cs
+++ b/Content.Goobstation.Shared/Boomerang/BoomerangSystem.cs
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+using System.Numerics;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Throwing;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Systems;
 using Robust.Shared.Map;
 
 namespace Content.Goobstation.Shared.Boomerang;
@@ -9,6 +12,8 @@ namespace Content.Goobstation.Shared.Boomerang;
 public sealed class BoomerangSystem : EntitySystem
 {
     [Dependency] private readonly ThrowingSystem _throwingSystem = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
     [Dependency] private readonly SharedHandsSystem _handsSystem = default!;
 
     private List<(EntityUid, EntityCoordinates, float, EntityUid?)> _toThrow = new();
@@ -18,6 +23,23 @@ public sealed class BoomerangSystem : EntitySystem
         base.Initialize();
         SubscribeLocalEvent<BoomerangComponent, LandEvent>(OnLanded);
         SubscribeLocalEvent<BoomerangComponent, ThrownEvent>(OnThrown);
+        SubscribeLocalEvent<BoomerangComponent, ThrowDoHitEvent>(OnHit);
+    }
+
+    private void OnHit(Entity<BoomerangComponent> ent, ref ThrowDoHitEvent args)
+    {
+        if (!TryComp(args.Thrown, out PhysicsComponent? body) || args.Component.Thrower is not { } thrower)
+            return;
+
+        var ourCoords = _transform.GetMapCoordinates(args.Thrown);
+        var throwerCoords = _transform.GetMapCoordinates(thrower);
+
+        if (ourCoords.MapId != throwerCoords.MapId)
+            return;
+
+        var vec = (throwerCoords.Position - ourCoords.Position).Normalized() * body.LinearVelocity.Length();
+
+        _physics.SetLinearVelocity(args.Thrown, vec, body: body);
     }
 
     public override void Update(float frameTime)
@@ -27,7 +49,10 @@ public sealed class BoomerangSystem : EntitySystem
         foreach (var (uid, coords, speed, thrower) in _toThrow)
         {
             if (!TerminatingOrDeleted(uid) && (thrower == null || !TerminatingOrDeleted(thrower)))
+            {
+                _physics.SetLinearVelocity(uid, Vector2.Zero);
                 _throwingSystem.TryThrow(uid, coords, speed, user: thrower, recoil: false, playSound: false);
+            }
         }
 
         _toThrow.Clear();

--- a/Content.Goobstation.Shared/Boomerang/BoomerangSystem.cs
+++ b/Content.Goobstation.Shared/Boomerang/BoomerangSystem.cs
@@ -48,11 +48,11 @@ public sealed class BoomerangSystem : EntitySystem
 
         foreach (var (uid, coords, speed, thrower) in _toThrow)
         {
-            if (!TerminatingOrDeleted(uid) && (thrower == null || !TerminatingOrDeleted(thrower)))
-            {
-                _physics.SetLinearVelocity(uid, Vector2.Zero);
-                _throwingSystem.TryThrow(uid, coords, speed, user: thrower, recoil: false, playSound: false);
-            }
+            if (TerminatingOrDeleted(uid) || thrower != null && TerminatingOrDeleted(thrower))
+                continue;
+
+            _physics.SetLinearVelocity(uid, Vector2.Zero);
+            _throwingSystem.TryThrow(uid, coords, speed, user: thrower, recoil: false, playSound: false);
         }
 
         _toThrow.Clear();

--- a/Content.Trauma.Client/Heretic/Systems/XRayVisionSystem.cs
+++ b/Content.Trauma.Client/Heretic/Systems/XRayVisionSystem.cs
@@ -2,16 +2,21 @@
 
 using Content.Trauma.Shared.Heretic.Crucible.Systems;
 using Robust.Client.Graphics;
+using Robust.Client.Player;
 
 namespace Content.Trauma.Client.Heretic.Systems;
 
 public sealed class XRayVisionSystem : SharedXRayVisionSystem
 {
     [Dependency] private readonly ILightManager _light = default!;
+    [Dependency] private readonly IPlayerManager _player = default!;
 
-    protected override void DrawLight(bool value)
+    protected override void DrawLight(EntityUid uid, bool value)
     {
-        base.DrawLight(value);
+        base.DrawLight(uid, value);
+
+        if (_player.LocalEntity != uid)
+            return;
 
         _light.DrawLighting = value;
     }

--- a/Content.Trauma.Server/Heretic/Abilities/HereticAbilitySystem.Side.cs
+++ b/Content.Trauma.Server/Heretic/Abilities/HereticAbilitySystem.Side.cs
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+using Content.Medical.Shared.Wounds;
 using Content.Server.Polymorph.Components;
 using Content.Shared.Actions;
 using Content.Shared.Atmos;
 using Content.Shared.Body.Components;
+using Content.Shared.Damage.Components;
 using Content.Shared.Ghost;
-using Content.Shared.Mobs.Components;
 using Content.Shared.Polymorph;
 using Content.Trauma.Shared.Heretic.Components;
 using Content.Trauma.Shared.Heretic.Components.Side;
@@ -17,8 +18,8 @@ public sealed partial class HereticAbilitySystem
 {
     [Dependency] private readonly EntityQuery<BloodstreamComponent> _bloodQuery = default!;
 
-    private HashSet<Entity<MobStateComponent>> _targets = new();
-    private HashSet<Entity<ReflectiveSurfaceComponent>> _mirrors = new();
+    private readonly List<EntityUid> _bloodStealTargets = new();
+    private readonly HashSet<Entity<ReflectiveSurfaceComponent>> _mirrors = new();
 
     protected override void SubscribeSide()
     {
@@ -116,25 +117,37 @@ public sealed partial class HereticAbilitySystem
 
         var hasTargets = false;
 
-        _targets.Clear();
-        Lookup.GetEntitiesInRange(args.Target, args.Range, _targets, LookupFlags.Dynamic);
-        foreach (var (target, _) in _targets)
+        TryComp(args.Performer, out DamageableComponent? damageable);
+
+        _bloodStealTargets.Clear();
+        foreach (var (target, _) in GetNearbyPeople(args.Performer, args.Range, null, args.Target))
         {
             if (target == args.Performer)
                 continue;
 
             hasTargets = true;
 
-            _dmg.TryChangeDamage(target, args.Damage, true, origin: args.Performer);
+            var dmg = _dmg.ChangeDamage(target, args.Damage, true, origin: args.Performer);
+            if (damageable != null)
+                _lifesteal.LifeSteal((args.Performer, damageable), dmg.GetTotal());
 
             if (!_bloodQuery.TryComp(target, out var blood))
-                continue;
+                return;
 
-            _blood.TryModifyBloodLevel((target, blood), args.BloodModifyAmount);
             _blood.TryModifyBleedAmount((target, blood), blood.MaxBleedAmount);
+            _bloodStealTargets.Add(target);
         }
 
-        if (hasTargets)
-            _aud.PlayPvs(args.Sound, args.Target);
+        _lifesteal.BloodSteal(args.Performer, _bloodStealTargets, args.BloodModifyAmount, null);
+
+        if (!hasTargets)
+            return;
+
+        foreach (var (_, woundable) in _body.GetOrgans<WoundableComponent>(args.Performer))
+        {
+            _container.EmptyContainer(woundable.Wounds);
+        }
+
+        _aud.PlayPvs(args.Sound, args.Target);
     }
 }

--- a/Content.Trauma.Server/Heretic/Abilities/HereticAbilitySystem.Side.cs
+++ b/Content.Trauma.Server/Heretic/Abilities/HereticAbilitySystem.Side.cs
@@ -132,7 +132,7 @@ public sealed partial class HereticAbilitySystem
                 _lifesteal.LifeSteal((args.Performer, damageable), dmg.GetTotal());
 
             if (!_bloodQuery.TryComp(target, out var blood))
-                return;
+                continue;
 
             _blood.TryModifyBleedAmount((target, blood), blood.MaxBleedAmount);
             _bloodStealTargets.Add(target);

--- a/Content.Trauma.Server/Heretic/Abilities/HereticAbilitySystem.cs
+++ b/Content.Trauma.Server/Heretic/Abilities/HereticAbilitySystem.cs
@@ -28,6 +28,8 @@ using Content.Shared.Weather;
 using Content.Trauma.Common.CollectiveMind;
 using Content.Trauma.Shared.Heretic.Events;
 using Content.Trauma.Shared.Heretic.Systems.Abilities;
+using Content.Trauma.Shared.Wizard.SanguineStrike;
+using Robust.Server.Containers;
 using Robust.Server.GameStates;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
@@ -64,6 +66,8 @@ public sealed partial class HereticAbilitySystem : SharedHereticAbilitySystem
     [Dependency] private readonly ActionContainerSystem _actionContainer = default!;
     [Dependency] private readonly InventorySystem _inventory = default!;
     [Dependency] private readonly ChatSystem _chat = default!;
+    [Dependency] private readonly SharedSanguineStrikeSystem _lifesteal = default!;
+    [Dependency] private readonly ContainerSystem _container = default!;
 
     #endregion
 

--- a/Content.Trauma.Server/Heretic/Systems/CarvingKnifeSystem.cs
+++ b/Content.Trauma.Server/Heretic/Systems/CarvingKnifeSystem.cs
@@ -274,7 +274,7 @@ public sealed class CarvingKnifeSystem : EntitySystem
         var flags = LookupFlags.Static | LookupFlags.Sundries | LookupFlags.Sensors;
         _carvings.Clear();
         _lookup.GetEntitiesInRange(coords, 0.5f, _carvings, flags);
-        return _carvings.Count == 0;
+        return _carvings.Count > 0;
     }
 
     private void OnCarvingSelected(Entity<CarvingKnifeComponent> ent, ref RuneCarvingSelectedMessage args)

--- a/Content.Trauma.Shared/Heretic/Crucible/Components/XRayVisionStatusEffectComponent.cs
+++ b/Content.Trauma.Shared/Heretic/Crucible/Components/XRayVisionStatusEffectComponent.cs
@@ -4,8 +4,8 @@
 namespace Content.Trauma.Shared.Heretic.Crucible.Components;
 
 [RegisterComponent, NetworkedComponent]
-public sealed partial class XRayVisionComponent : Component
+public sealed partial class XRayVisionStatusEffectComponent : Component
 {
     [DataField]
-    public bool EyeHadFov;
+    public bool ShouldRemoveFov = true;
 }

--- a/Content.Trauma.Shared/Heretic/Crucible/Systems/SharedXRayVisionSystem.cs
+++ b/Content.Trauma.Shared/Heretic/Crucible/Systems/SharedXRayVisionSystem.cs
@@ -49,7 +49,7 @@ public abstract class SharedXRayVisionSystem : EntitySystem
             return;
 
         if (_status.TryEffectsWithComp<XRayVisionStatusEffectComponent>(args.Target, out var effects))
-            effects.Remove(ent.Owner);
+            effects.RemoveWhere(x => x.Owner == ent.Owner);
 
         if (_timing.IsFirstTimePredicted)
             ent.Comp.ShouldRemoveFov = eye.DrawFov && effects is not { Count: > 0 };

--- a/Content.Trauma.Shared/Heretic/Crucible/Systems/SharedXRayVisionSystem.cs
+++ b/Content.Trauma.Shared/Heretic/Crucible/Systems/SharedXRayVisionSystem.cs
@@ -1,37 +1,62 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+using Content.Shared.StatusEffectNew;
+using Content.Trauma.Shared.Heretic.Crucible.Components;
+using Robust.Shared.Timing;
+
 namespace Content.Trauma.Shared.Heretic.Crucible.Systems;
 
 public abstract class SharedXRayVisionSystem : EntitySystem
 {
     [Dependency] private readonly SharedEyeSystem _eye = default!;
+    [Dependency] private readonly StatusEffectsSystem _status = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
 
     public override void Initialize()
     {
         base.Initialize();
 
-        SubscribeLocalEvent<Components.XRayVisionComponent, ComponentStartup>(OnStartup);
-        SubscribeLocalEvent<Components.XRayVisionComponent, ComponentShutdown>(OnShutdown);
+        SubscribeLocalEvent<XRayVisionStatusEffectComponent, StatusEffectAppliedEvent>(OnApply);
+        SubscribeLocalEvent<XRayVisionStatusEffectComponent, StatusEffectRemovedEvent>(OnRemove);
     }
 
-    private void OnShutdown(Entity<Components.XRayVisionComponent> ent, ref ComponentShutdown args)
+    private void OnRemove(Entity<XRayVisionStatusEffectComponent> ent, ref StatusEffectRemovedEvent args)
     {
-        if (TerminatingOrDeleted(ent) || !TryComp(ent, out EyeComponent? eye))
+        if (TerminatingOrDeleted(args.Target) || !TryComp(args.Target, out EyeComponent? eye))
             return;
 
-        _eye.SetDrawFov(ent, ent.Comp.EyeHadFov, eye);
-        DrawLight(true);
+        if (!_status.TryEffectsWithComp<XRayVisionStatusEffectComponent>(args.Target, out var effects) ||
+            effects.Count == 0)
+        {
+            _eye.SetDrawFov(args.Target, ent.Comp.ShouldRemoveFov, eye);
+            DrawLight(args.Target, ent.Comp.ShouldRemoveFov);
+        }
+        else
+        {
+            _eye.SetDrawFov(args.Target, false, eye);
+            if (!ent.Comp.ShouldRemoveFov)
+                return;
+            foreach (var (_, comp, _) in effects)
+            {
+                comp.ShouldRemoveFov = true;
+            }
+        }
     }
 
-    private void OnStartup(Entity<Components.XRayVisionComponent> ent, ref ComponentStartup args)
+    private void OnApply(Entity<XRayVisionStatusEffectComponent> ent, ref StatusEffectAppliedEvent args)
     {
-        if (!TryComp(ent, out EyeComponent? eye))
+        if (!TryComp(args.Target, out EyeComponent? eye))
             return;
 
-        ent.Comp.EyeHadFov = eye.DrawFov;
-        _eye.SetDrawFov(ent, false, eye);
-        DrawLight(false);
+        if (_status.TryEffectsWithComp<XRayVisionStatusEffectComponent>(args.Target, out var effects))
+            effects.Remove(ent);
+
+        if (_timing.IsFirstTimePredicted)
+            ent.Comp.ShouldRemoveFov = eye.DrawFov && effects is not { Count: > 0 };
+
+        _eye.SetDrawFov(args.Target, false, eye);
+        DrawLight(args.Target, false);
     }
 
-    protected virtual void DrawLight(bool value) { }
+    protected virtual void DrawLight(EntityUid uid, bool value) { }
 }

--- a/Content.Trauma.Shared/Heretic/Crucible/Systems/SharedXRayVisionSystem.cs
+++ b/Content.Trauma.Shared/Heretic/Crucible/Systems/SharedXRayVisionSystem.cs
@@ -49,7 +49,7 @@ public abstract class SharedXRayVisionSystem : EntitySystem
             return;
 
         if (_status.TryEffectsWithComp<XRayVisionStatusEffectComponent>(args.Target, out var effects))
-            effects.Remove(ent);
+            effects.Remove(ent.Owner);
 
         if (_timing.IsFirstTimePredicted)
             ent.Comp.ShouldRemoveFov = eye.DrawFov && effects is not { Count: > 0 };

--- a/Content.Trauma.Shared/Heretic/Events/HereticAbilities.cs
+++ b/Content.Trauma.Shared/Heretic/Events/HereticAbilities.cs
@@ -396,13 +396,15 @@ public sealed partial class EventHereticCleave : WorldTargetActionEvent
     {
         DamageDict =
         {
-            {"Heat", 20f},
-            {"Bloodloss", 10f},
+            {"Blunt", 4f},
+            {"Slash", 4f},
+            {"Piercing", 4f},
+            {"Bloodloss", 3f},
         },
     };
 
     [DataField]
-    public FixedPoint2 BloodModifyAmount = -50f;
+    public FixedPoint2 BloodModifyAmount = 50f;
 
     [DataField]
     public EntProtoId Effect = "EffectCleave";

--- a/Content.Trauma.Shared/Heretic/Systems/Side/SharedVoidCloakSystem.cs
+++ b/Content.Trauma.Shared/Heretic/Systems/Side/SharedVoidCloakSystem.cs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+using Content.Goobstation.Shared.Religion;
 using Content.Shared.Clothing.Components;
 using Content.Shared.Clothing.EntitySystems;
 using Content.Shared.Inventory;
@@ -82,6 +83,7 @@ public abstract class SharedVoidCloakSystem : EntitySystem
             return;
 
         EnsureComp<StripMenuInvisibleComponent>(cloak);
+        RemCompDeferred<UnholyItemComponent>(cloak);
         UpdatePressureProtection(cloak, false);
     }
 
@@ -95,6 +97,7 @@ public abstract class SharedVoidCloakSystem : EntitySystem
             return;
 
         RemCompDeferred<StripMenuInvisibleComponent>(cloak);
+        EnsureComp<UnholyItemComponent>(cloak);
         UpdatePressureProtection(cloak, true);
     }
 

--- a/Content.Trauma.Shared/Wizard/Traps/DamageTrapComponent.cs
+++ b/Content.Trauma.Shared/Wizard/Traps/DamageTrapComponent.cs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+using Content.Medical.Common.Damage;
+using Content.Medical.Common.Targeting;
 using Content.Shared.Damage;
 
 namespace Content.Trauma.Shared.Wizard.Traps;
@@ -12,4 +14,10 @@ public sealed partial class DamageTrapComponent : Component
 
     [DataField]
     public EntProtoId? SpawnedEntity;
+
+    [DataField]
+    public TargetBodyPart TargetPart = TargetBodyPart.Feet | TargetBodyPart.Legs;
+
+    [DataField]
+    public SplitDamageBehavior SplitDamageBehavior = SplitDamageBehavior.Split;
 }

--- a/Content.Trauma.Shared/Wizard/Traps/SharedWizardTrapsSystem.cs
+++ b/Content.Trauma.Shared/Wizard/Traps/SharedWizardTrapsSystem.cs
@@ -139,7 +139,11 @@ public abstract class SharedWizardTrapsSystem : EntitySystem
 
     private void OnDamageTriggered(Entity<DamageTrapComponent> ent, ref TrapTriggeredEvent args)
     {
-        _damageable.TryChangeDamage(args.Victim, ent.Comp.Damage, true, targetPart: TargetBodyPart.Feet);
+        _damageable.TryChangeDamage(args.Victim,
+            ent.Comp.Damage,
+            true,
+            targetPart: ent.Comp.TargetPart,
+            splitDamage: ent.Comp.SplitDamageBehavior);
         if (_net.IsServer && ent.Comp.SpawnedEntity is { } toSpawn)
             Spawn(toSpawn, _transform.GetMapCoordinates(ent));
     }

--- a/Resources/Locale/en-US/_Goobstation/Heretic/store/heretic/heretic-catalog-side.ftl
+++ b/Resources/Locale/en-US/_Goobstation/Heretic/store/heretic/heretic-catalog-side.ftl
@@ -41,7 +41,6 @@ knowledge-path-side-s4-shark-desc =
     Allows you to transmute 3 pools of ash, a liver, and 3 sheets of plasma into 3 Fire Sharks.
     Fire Sharks are fast and strong in groups, but die quickly. They are also highly resistant against fire attacks.
     Fire Sharks ignite their victims and drop plasma sheet once they die.
-    You can only create 15 at a time.
 
 knowledge-path-side-s4-ether-name = Ether Of The Newborn
 knowledge-path-side-s4-ether-desc =
@@ -162,11 +161,11 @@ knowledge-path-side-s8-grasp-desc =
     The longer you channel it - the higher the range will be. Channeling can be stopped early by activating grasp again.
     Area of effect grasp suffers increased cooldown, scaled by range and the number of victims.
 
-knowledge-path-side-s8-cleave-name = Blood Cleave
+knowledge-path-side-s8-cleave-name = Crimson Cleave
 knowledge-path-side-s8-cleave-desc =
     At first I didn't understand these instruments of war, but the Priest told me to use them regardless. Soon, he said, I would know them well.
 
-    Grants you Cleave, an area-of-effect targeted spell that causes heavy bleeding and blood loss to anyone afflicted.
+    Grants you Crimson Cleave, a targeted spell which siphons health in a small AOE. Cleanses all wounds upon casting
 
 knowledge-path-side-s8-space-phase-name = Space Phase
 knowledge-path-side-s8-space-phase-desc =

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -579,7 +579,6 @@
       playerRatio: 10
       blacklist:
         components:
-        - BibleUser
         - ZombieImmune
         - AntagImmune
       briefing:

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -433,7 +433,6 @@
     - prefRoles: [ InitialInfected ]
       max: 4
       playerRatio: 15
-      jobBlacklist: [ Chaplain ] # Goobstation
       blacklist:
         components:
         - CommandStaff # Goobstation

--- a/Resources/Prototypes/GameRules/subgamemodes.yml
+++ b/Resources/Prototypes/GameRules/subgamemodes.yml
@@ -27,7 +27,6 @@
       allowNonHumans: true
       multiAntagSetting: NotExclusive
       startingGear: ThiefGear
-      jobBlacklist: [ Chaplain ] # Goob
       components:
       - type: Pacified
       - type: Thieving

--- a/Resources/Prototypes/_EinsteinEngines/Gamerules/shadowling.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Gamerules/shadowling.yml
@@ -19,7 +19,6 @@
     - prefRoles: [ Shadowling ]
       max: 1
       playerRatio: 30
-      jobBlacklist: [ Chaplain ] # GOOBSTATION
       blacklist:
         components:
         - CommandStaff

--- a/Resources/Prototypes/_Goobstation/Actions/Heretic/path_blade.yml
+++ b/Resources/Prototypes/_Goobstation/Actions/Heretic/path_blade.yml
@@ -17,7 +17,7 @@
   components:
   - type: Action
     checkCanInteract: false
-    useDelay: 50
+    useDelay: 30
     itemIconStyle: NoItem
     icon:
       sprite: _Goobstation/Heretic/abilities_heretic.rsi

--- a/Resources/Prototypes/_Goobstation/Actions/Heretic/path_side.yml
+++ b/Resources/Prototypes/_Goobstation/Actions/Heretic/path_side.yml
@@ -53,25 +53,25 @@
 - type: entity
   parent: BaseAction
   id: ActionHereticCleave
-  name: Cleave
-  description: Causes severe bleeding on a target and several targets around them.
+  name: Crimson Cleave
+  description: A targeted spell that heals you while damaging the enemies. It cleanses you of all wounds as well.
   components:
   - type: Action
-    useDelay: 45
+    useDelay: 30
     itemIconStyle: NoItem
     icon:
       sprite: _Goobstation/Heretic/abilities_heretic.rsi
-      state: cleave
+      state: blood_siphon
     checkCanInteract: false
   - type: TargetAction
     checkCanAccess: false
-    range: 4
+    range: 5
   - type: WorldTargetAction
     event: !type:EventHereticCleave
   - type: HereticAction
     requireMagicItem: true
   - type: SpeakOnAction
-    sentence: heretic-speech-cleave
+    sentence: heretic-speech-bloodsiphon
 
 - type: entity
   parent: BaseAction

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -485,7 +485,7 @@
     damage:
       types:
         Piercing: 3
-        Holy: 6
+        Holy: 4
 
 - type: entity
   name : stun bolt

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/nullrod.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/nullrod.yml
@@ -78,19 +78,11 @@
     attackRate: 0.8
     damage:
       types:
-        Slash: 10
-        Holy: 13
+        Slash: 12
+        Holy: 8 # Land a mark hit for higher holy damage
     soundHit:
       path: /Audio/Weapons/bladeslice.ogg
   - type: Wieldable
-  - type: LeechOnMarker
-    leech:
-      types:
-        Blunt: -6.66
-        Slash: -6.66
-        Piercing: -6.66
-        Asphyxiation: -5
-        Bloodloss: -5
   - type: Clothing
     sprite: _ShitChap/Objects/Weapons/Nullrod/holyclaymore.rsi
     slots:
@@ -154,9 +146,6 @@
       types:
         Blunt: 3
         Holy: 10
-  - type: HeldSpeedModifier # HOLY.. AURA!
-    walkModifier: 1.15
-    sprintModifier: 1.15
   - type: Item
     size: Small
     sprite: _ShitChap/Objects/Weapons/Nullrod/rosary.rsi
@@ -181,7 +170,7 @@
         Shock: -7.5
     damage:
       types:
-        Holy: 20
+        Holy: 7 # Aoe free damage :drools:
   - type: Tag
     tags:
     - Rosary
@@ -208,8 +197,6 @@
         Holy: 14
     soundHit:
       path: /Audio/Weapons/Guns/Hits/energy_meat1.ogg
-  - type: IgniteOnMeleeHit # emphasis on FLAMING GIFT!!
-    fireStacks: 0.25
   - type: HolyIgniteOnMeleeHit
     fireStacks: 3.0
   - type: Cautery
@@ -261,7 +248,7 @@
     damage:
       types:
         Slash: 7
-        Holy: 12
+        Holy: 8
     soundHit:
       path: /Audio/Weapons/bladeslice.ogg
   - type: ItemRandomizeMovementspeed
@@ -300,7 +287,7 @@
     attackRate: 3
     damage:
       types:
-        Holy: 7
+        Holy: 4
         Blunt: 1
     soundHit:
       collection: BoxingHit
@@ -341,14 +328,14 @@
   - type: DamageOtherOnHit
     damage:
       types:
-        Slash: 10
-        Holy: 14
+        Slash: 8
+        Holy: 8
   - type: MeleeWeapon
     attackRate: 1.5
     damage:
       types:
         Slash: 5
-        Holy: 10
+        Holy: 7
     soundHit:
       path: /Audio/Weapons/bladeslice.ogg
   - type: Item
@@ -471,7 +458,7 @@
     attackRate: 0.8
     damage:
       types:
-        Holy: 12
+        Holy: 10
         Blunt: 10
     soundHit:
       collection: RubberHammer
@@ -562,7 +549,7 @@
     attackRate: 0.9
     damage:
       types:
-        Holy: 14
+        Holy: 10
         Blunt: 9
     soundHit:
       path: /Audio/Weapons/smash.ogg
@@ -617,7 +604,7 @@
         Blunt: 2
         Slash: 3
         Structural: 20
-        Holy: 6
+        Holy: 3
     soundHit:
       path: /Audio/Weapons/chainsaw.ogg
       params:
@@ -717,7 +704,7 @@
 
 - type: entity
   name: blessing of the reaper
-  parent: [Nullrod, ArmBlade, BaseMajorContraband]
+  parent: [Nullrod, ArmBladeChangeling, BaseMajorContraband]
   id: BlessingOfTheReaper
   description: A special undroppable armblade nullrod, it's blessed by the dark gods.
   components:
@@ -729,13 +716,13 @@
     sprite: _Goobstation/Objects/Weapons/Melee/blessing_reaper.rsi
   - type: Unremoveable
   - type: MeleeWeapon
-    wideAnimationRotation: 90
-    attackRate: 0.75
     damage:
       types:
-        Slash: 25
-        Piercing: 15
-        Holy: 10
+        Slash: 15
+        Structural: 10
+        Holy: 5
+      woundSeverityMultipliers:
+        Slash: 1
 
 - type: entity
   parent: BaseNullrod
@@ -772,7 +759,7 @@
     damage:
       types:
         Piercing: 10
-        Holy: 18
+        Holy: 15
     angle: 0
     animation: WeaponArcThrust
     soundHit:
@@ -784,7 +771,7 @@
     damage:
       types:
         Piercing: 15
-        Holy: 25
+        Holy: 20
   - type: EmbeddableProjectile
     offset: -0.15,0.0
   - type: ThrowingAngle

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/nullrod.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/nullrod.yml
@@ -170,7 +170,7 @@
         Shock: -7.5
     damage:
       types:
-        Holy: 7 # Aoe free damage :drools:
+        Holy: 7
   - type: Tag
     tags:
     - Rosary

--- a/Resources/Prototypes/_Goobstation/GameRules/midround.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/midround.yml
@@ -72,7 +72,6 @@
         components:
         - CommandStaff
         - AntagImmune
-        - BibleUser
       lateJoinAdditional: true
       mindRoles:
       - MindRoleChangelingmidround
@@ -105,10 +104,8 @@
         components:
         - CommandStaff
         - AntagImmune
-        - BibleUser
       startingGear: Heretictmidround
       lateJoinAdditional: true
-      jobBlacklist: [ Chaplain ] # GOOBSTATION
       mindRoles:
       - MindRoleHeretic
 

--- a/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
@@ -66,7 +66,6 @@
     - prefRoles: [ Changeling ]
       max: 4
       playerRatio: 12
-      jobBlacklist: [ Chaplain ] # GOOBSTATION
       blacklist:
         components:
         - CommandStaff
@@ -261,7 +260,6 @@
     definitions:
     - prefRoles: [ Blob ]
       allowNonHumans: true
-      jobBlacklist: [ Chaplain ] # Goobstation
       blacklist:
         components:
         - CommandStaff

--- a/Resources/Prototypes/_Goobstation/Heretic/Catalog/Heretic/path_side.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Catalog/Heretic/path_side.yml
@@ -344,7 +344,7 @@
   id: HereticSidePath8Cleave
   name: knowledge-path-side-s8-cleave-name
   description: knowledge-path-side-s8-cleave-desc
-  icon: { sprite: _Goobstation/Heretic/abilities_heretic.rsi, state: cleave }
+  icon: { sprite: _Goobstation/Heretic/abilities_heretic.rsi, state: blood_siphon }
   raiseProductEventOnMind: true
   productEvent: !type:EventHereticAddKnowledge
     knowledge:

--- a/Resources/Prototypes/_Goobstation/Heretic/Entities/Clothing/Head/hoods.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Entities/Clothing/Head/hoods.yml
@@ -41,7 +41,6 @@
         Piercing: 0.5
         Heat: 0.5
         Caustic: 0.5
-        # Holy: 1.25
     traumaDeductions:
       Dismemberment: 0.5
       OrganDamage: 0.5
@@ -137,7 +136,6 @@
         Piercing: 0.7
         Heat: 0.7
         Caustic: 0.7
-        # Holy: 1.25
     traumaDeductions:
       Dismemberment: 0.3
       OrganDamage: 0.3

--- a/Resources/Prototypes/_Goobstation/Heretic/Entities/Clothing/Mask/masks.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Entities/Clothing/Mask/masks.yml
@@ -19,12 +19,6 @@
     sprite: _Goobstation/Heretic/mad_mask.rsi
   - type: BreathMask
   - type: IdentityBlocker
-  - type: Armor
-    coverage:
-    - Head
-    modifiers:
-      coefficients:
-        Holy: 1.25
   - type: Tag
     tags:
     - Mask

--- a/Resources/Prototypes/_Goobstation/Heretic/Entities/Clothing/Neck/specific.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Entities/Clothing/Neck/specific.yml
@@ -21,10 +21,6 @@
     state: icon
   - type: Clothing
     sprite: _Goobstation/Heretic/amber_focus.rsi
-  - type: Armor
-    modifiers:
-      coefficients:
-        Holy: 1.25
 
 - type: entity
   parent: ClothingNeckAmberFocus

--- a/Resources/Prototypes/_Goobstation/Heretic/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Entities/Clothing/OuterClothing/armor.yml
@@ -45,7 +45,6 @@
         Piercing: 0.5
         Heat: 0.5
         Caustic: 0.5
-        Holy: 1.25
     traumaDeductions:
       Dismemberment: 0.5
       OrganDamage: 0.5
@@ -161,8 +160,7 @@
   name: void cloak
   description: Black like tar, reflecting no light. Runic symbols line the outside. With each flash you lose comprehension of what you are seeing.
   components:
-  # - type: UnholyItem # This should only be active when cloak is visible. Can't simply ensure/remove this component on
-  # cloak toggle due to goobmod. Should be done when heretic is moved to goobmod probably.
+  - type: UnholyItem
   - type: Sprite
     sprite: _Goobstation/Heretic/Clothing/OuterClothing/void_cloak.rsi
     layers:
@@ -185,7 +183,6 @@
         Piercing: 0.7
         Heat: 0.7
         Caustic: 0.7
-        # Holy: 1.25
     traumaDeductions:
       Dismemberment: 0.3
       OrganDamage: 0.3

--- a/Resources/Prototypes/_Goobstation/Heretic/Entities/Clothing/Shoes/shoes.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Entities/Clothing/Shoes/shoes.yml
@@ -32,7 +32,6 @@
         Piercing: 0.5
         Heat: 0.5
         Caustic: 0.5
-        Holy: 1.25
     traumaDeductions:
       Dismemberment: 0.5
       OrganDamage: 0.5

--- a/Resources/Prototypes/_Goobstation/Heretic/Entities/Objects/Weapons/Melee/heretic_blades.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Entities/Objects/Weapons/Melee/heretic_blades.yml
@@ -19,7 +19,7 @@
     wideAnimationRotation: -125
     damage:
       types:
-        Slash: 17 # moving to 17 to encourage more spell use, can be sharpened to hit 20 again
+        Slash: 20
       armorPenetration: 0.3
       woundSeverityMultipliers:
         Slash: 1.5

--- a/Resources/Prototypes/_Goobstation/Heretic/Entities/Objects/Weapons/Melee/heretic_blades.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Entities/Objects/Weapons/Melee/heretic_blades.yml
@@ -19,7 +19,7 @@
     wideAnimationRotation: -125
     damage:
       types:
-        Slash: 20
+        Slash: 17
       armorPenetration: 0.3
       woundSeverityMultipliers:
         Slash: 1.5
@@ -28,6 +28,10 @@
   - type: Item
     size: Normal
     sprite: _Goobstation/Heretic/Blades/eldritch_blade-inhands.rsi
+    shape:
+    - 0,0,1,0
+    - 0,1,0,1
+    storedRotation: 180
   - type: Scalpel
     speed: 1.5
   - type: BoneSaw

--- a/Resources/Prototypes/_Goobstation/Heretic/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Entities/Objects/Weapons/Melee/sword.yml
@@ -15,7 +15,7 @@
   - type: MeleeWeapon # Same dps, more wounding and range compared to blade, but no AP
     damage:
       types:
-        Slash: 20
+        Slash: 17
       woundSeverityMultipliers:
         Slash: 2
     angle: 90

--- a/Resources/Prototypes/_Goobstation/Heretic/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Entities/Objects/Weapons/Melee/sword.yml
@@ -15,7 +15,7 @@
   - type: MeleeWeapon # Same dps, more wounding and range compared to blade, but no AP
     damage:
       types:
-        Slash: 17
+        Slash: 20
       woundSeverityMultipliers:
         Slash: 2
     angle: 90

--- a/Resources/Prototypes/_Goobstation/Heretic/Entities/Structures/Specific/Heretic/carvings.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Entities/Structures/Specific/Heretic/carvings.yml
@@ -69,6 +69,9 @@
     damage:
       types:
         Blunt: 20
+      woundSeverityMultipliers:
+        Blunt: 2
+      partDamageVariation: 2
 
 - type: entity
   parent: BaseCarving

--- a/Resources/Prototypes/_Goobstation/Heretic/Entities/Structures/Specific/Heretic/eldritch_influence.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Entities/Structures/Specific/Heretic/eldritch_influence.yml
@@ -72,6 +72,36 @@
   - type: Clickable
   - type: Visibility
     layer: 64 # keep in sync with VisibilityFlags.EldritchInfluence for upstream merges
+  - type: StepTrigger
+    requiredTriggeredSpeed: 0
+    intersectRatio: 0.1
+  - type: Physics
+    bodyType: Static
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeCircle
+          radius: 5
+        layer:
+          - WallLayer
+        mask:
+          - Impassable
+          - HighImpassable
+          - MidImpassable
+          - LowImpassable
+        hard: false
+  - type: TileEntityEffect
+    effects:
+    - !type:ModifyStatusEffect
+      effectProto: StatusEffectInfluenceXray
+      time: 10
+      conditions:
+      - !type:WhitelistCondition
+        checkMind: true
+        whitelist:
+          components:
+          - Heretic
 
 - type: entity
   id: EldritchInfluenceIntermediate
@@ -133,3 +163,5 @@
     layer: 1
   - type: EldritchInfluence
     spent: true
+  - type: TileEntityEffect
+    effects: []

--- a/Resources/Prototypes/_Goobstation/Heretic/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/GameRules/roundstart.yml
@@ -37,7 +37,6 @@
       max: 3
       playerRatio: 15
       lateJoinAdditional: true
-      jobBlacklist: [ Chaplain, ] # GOOBSTATION
       blacklist:
         components:
         - CommandStaff
@@ -68,7 +67,6 @@
       max: 2
       playerRatio: 20
       lateJoinAdditional: true
-      jobBlacklist: [ Chaplain ] # GOOBSTATION
       blacklist:
         components:
         - CommandStaff

--- a/Resources/Prototypes/_Goobstation/Heretic/Heretic/heretic_rituals.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Heretic/heretic_rituals.yml
@@ -1617,7 +1617,6 @@
     sprite: _Goobstation/Heretic/eldritch_mobs.rsi
     state: fire_shark_icon
   - type: HereticRitual
-    limit: 15
     effects:
     - !type:LookupRitualEffect
       applyOn: Platform

--- a/Resources/Prototypes/_Goobstation/Heretic/StatusEffects/effects.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/StatusEffects/effects.yml
@@ -116,9 +116,7 @@
   components:
   - type: StatusEffectAlert
     alert: DuskAndDawn
-  - type: GrantComponentsStatusEffect
-    components:
-    - type: XRayVision
+  - type: XRayVisionStatusEffect
 
 - type: entity
   parent: MobStatusEffectBase
@@ -302,3 +300,10 @@
     interval: 7.5
     maxBlades: 5
     refreshBlades: true
+
+- type: entity
+  parent: MobStatusEffectBase
+  id: StatusEffectInfluenceXray
+  name: influence xray
+  components:
+  - type: XRayVisionStatusEffect

--- a/Resources/Prototypes/_Goobstation/Roles/mind_roles.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/mind_roles.yml
@@ -36,7 +36,7 @@
   - type: MindRole
     antagPrototype: Ghoul
     exclusiveAntag: false
-    roleType: Familiar
+    roleType: TeamAntagonist
     subtype: role-subtype-ghoul
   - type: GhoulRole
 

--- a/Resources/Prototypes/_Goobstation/Wizard/traps.yml
+++ b/Resources/Prototypes/_Goobstation/Wizard/traps.yml
@@ -87,6 +87,9 @@
     damage:
       types:
         Blunt: 50
+      woundSeverityMultipliers:
+        Blunt: 2
+      partDamageVariation: 2
 
 - type: entity
   parent: BaseTrap

--- a/Resources/Prototypes/_Trauma/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Trauma/GameRules/roundstart.yml
@@ -161,7 +161,6 @@
       max: 6
       playerRatio: 10
       lateJoinAdditional: true
-      jobBlacklist: [ Chaplain ]
       blacklist:
         components:
         - CommandStaff
@@ -179,7 +178,6 @@
     - prefRoles: [ Shadowling ]
       max: 3
       playerRatio: 25
-      jobBlacklist: [ Chaplain ]
       blacklist:
         components:
         - CommandStaff

--- a/Resources/Prototypes/_Trauma/GameRules/subgamemodes.yml
+++ b/Resources/Prototypes/_Trauma/GameRules/subgamemodes.yml
@@ -28,7 +28,6 @@
     - prefRoles: [ Heretic ]
       min: 1
       max: 1
-      jobBlacklist: [ Chaplain ]
       blacklist:
         components:
         - CommandStaff


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->

Fixes #1970 
Fixed carving knife not working.
Grasping carving targets legs too as well as feet and has more wounding.
Removed extra holy damage vulnerability from heretic gear. Now you won't take more than default amount.
Nerfed some null rods (some slightly, some more, some untouched) cause the values/abilities were kinda insane.
Reworked boomerang component to behave more like boomerang, also it shouldn't damage one target multiple times (hopefully).
Heretic gets x-ray vision near unspent influences. Parity + allows to spot them easier.
Replaced cleave with crimson cleave (less cd, less damage, lifesteal + bloodsteal, removes users wounds on cast). Should be worth 2 points now.
Void cloak now makes you take holy damage when visible.
Removed fire shark ritual limit (Armok's request).
Sacraments of power cd reduced 50 -> 30
~Heretic blade now deals 20 damage again. It's parity + simple math (takes 5 seconds to crit unarmored, and grasp knockdown lasts 5 too) + riot armor exists literally and before it took like 13 hits to crit a person in riot armor, heretic don't get shooting skill so you can't effectively gun them down and combat spells aren't lethal enough/some path don't even get them to help you in combat. And no, I'm not doing better than wolves gameplay loop to get whetstones as heretic to sharpen the blade.~ Same damage but less size in inventory.
Chaplain can roll heretic/changeling/shadowling/zombie/thief.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Heretic struggles a bit too much currently cause of weaker blades, gigabuffed chaplain. It's supposed to be hard, but not supposed to be impossible.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Breaking changes
<!--
List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
You only need to consider this if there are other PRs open or in the works that would be massively broken by this.
-->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Aviu
- fix: Fix carving knife not working.
- tweak: Nerfed some nullrods to me not so insane.
- tweak: Boomerangs behave like boomerangs more and shouldn't damage one target multiple times hopefully.
- fix; Void cloak gives holy vulnerability when visible.
- tweak: Heretic blades have less size in inventory.
- add: Heretics get temporary xray vision near unspent influences.
- add: Cleave spell replaced with Crimson Cleave (a better version).
- tweak: Sacraments of power cooldown 50 -> 30.
- remove: Scorching shark ritual limit.
- add: Chaplain can roll changeling, shadowling, zombie, thief and heretic.