### PR TITLE
[Port] Add in-game date to PDA

### DIFF
--- a/Content.Client/PDA/PdaMenu.xaml
+++ b/Content.Client/PDA/PdaMenu.xaml
@@ -69,6 +69,11 @@ SPDX-License-Identifier: AGPL-3.0-or-later
             <ContainerButton Name="StationTimeButton">
                 <RichTextLabel Name="StationTimeLabel" Access="Public"/>
             </ContainerButton>
+            <!-- Begin DeltaV changes -->
+            <ContainerButton Name="CurrentDateButton">
+                <RichTextLabel Name="CurrentDateLabel" Access="Public"/>
+            </ContainerButton>
+            <!-- End DeltaV changes -->
             <ContainerButton Name="StationAlertLevelInstructionsButton">
                 <RichTextLabel Name="StationAlertLevelInstructions" Access="Public"/>
             </ContainerButton>

--- a/Content.Client/PDA/PdaMenu.xaml.cs
+++ b/Content.Client/PDA/PdaMenu.xaml.cs
@@ -32,6 +32,7 @@ namespace Content.Client.PDA
         private string _stationName = Loc.GetString("comp-pda-ui-unknown");
         private string _alertLevel = Loc.GetString("comp-pda-ui-unknown");
         private string _instructions = Loc.GetString("comp-pda-ui-unknown");
+        private string _currentDate = Loc.GetString("comp-pda-ui-unknown"); // DeltaV - PDA date
 
 
         private int _currentView;
@@ -125,6 +126,12 @@ namespace Content.Client.PDA
                 _clipboard.SetText(_instructions);
             };
 
+            // Begin DeltaV additions
+            CurrentDateButton.OnPressed += _ =>
+            {
+                _clipboard.SetText(_currentDate);
+            };
+            // End DeltaV additions
 
 
 
@@ -187,6 +194,15 @@ namespace Content.Client.PDA
                 "comp-pda-ui-station-alert-level-instructions",
                 ("instructions", _instructions))
             );
+
+            // Begin DeltaV additions
+            if (state.PdaOwnerInfo.CurrentDate is { } curDate)
+                _currentDate = curDate.ToString("dd MMMM yyyy");
+                CurrentDateLabel.SetMarkup(Loc.GetString(
+                    "comp-pda-ui-current-date",
+                    ("date", _currentDate)
+                ));
+            // End DeltaV additions
 
             AddressLabel.Text = state.Address?.ToUpper() ?? " - ";
 

--- a/Content.Server/PDA/PdaSystem.cs
+++ b/Content.Server/PDA/PdaSystem.cs
@@ -32,6 +32,7 @@ namespace Content.Server.PDA
 {
     public sealed class PdaSystem : SharedPdaSystem
     {
+        [Dependency] private readonly IConfigurationManager _config = default!; // DeltaV
         [Dependency] private readonly CartridgeLoaderSystem _cartridgeLoader = default!;
         [Dependency] private readonly InstrumentSystem _instrument = default!;
         [Dependency] private readonly RingerSystem _ringer = default!;
@@ -42,9 +43,8 @@ namespace Content.Server.PDA
         [Dependency] private readonly UnpoweredFlashlightSystem _unpoweredFlashlight = default!;
         [Dependency] private readonly ContainerSystem _containerSystem = default!;
         [Dependency] private readonly IdCardSystem _idCard = default!;
-        [Dependency] private readonly IConfigurationManager _config = default!; // DeltaV
 
-        private static DateTime ServerDate; // DeltaV - PDA
+        private DateTime ServerDate; // DeltaV - PDA
 
         public override void Initialize()
         {
@@ -205,7 +205,7 @@ namespace Content.Server.PDA
             var hasInstrument = HasComp<InstrumentComponent>(uid);
             var showUplink = HasComp<UplinkComponent>(uid) && IsUnlocked(uid);
 
-            pda.CurrentDate = pda.DateOverride ?? ServerDate; // DeltaV - PDA date
+            pda.CurrentDate = ServerDate; // DeltaV - PDA date
             UpdateStationName(uid, pda);
             UpdateAlertLevel(uid, pda);
             // TODO: Update the level and name of the station with each call to UpdatePdaUi is only needed for latejoin players.

--- a/Content.Server/PDA/PdaSystem.cs
+++ b/Content.Server/PDA/PdaSystem.cs
@@ -1,3 +1,7 @@
+// <Trauma>
+using Content.Trauma.Common.CCVars;
+using Robust.Shared.Configuration;
+// </Trauma>
 using Content.Server.Access.Systems;
 using Content.Server.AlertLevel;
 using Content.Server.CartridgeLoader;
@@ -38,6 +42,9 @@ namespace Content.Server.PDA
         [Dependency] private readonly UnpoweredFlashlightSystem _unpoweredFlashlight = default!;
         [Dependency] private readonly ContainerSystem _containerSystem = default!;
         [Dependency] private readonly IdCardSystem _idCard = default!;
+        [Dependency] private readonly IConfigurationManager _config = default!; // DeltaV
+
+        private static DateTime ServerDate; // DeltaV - PDA
 
         public override void Initialize()
         {
@@ -61,6 +68,13 @@ namespace Content.Server.PDA
             SubscribeLocalEvent<AlertLevelChangedEvent>(OnAlertLevelChanged);
             SubscribeLocalEvent<PdaComponent, InventoryRelayedEvent<ChameleonControllerOutfitSelectedEvent>>(OnRelayedEventToIdCard);
             SubscribeLocalEvent<PdaComponent, InventoryRelayedEvent<VoiceMaskNameUpdatedEvent>>(OnRelayedEventToIdCard);
+
+            // Begin DeltaV additions
+            Subs.CVar(_config,
+                DCCVars.YearOffset,
+                value => ServerDate = DateTime.Today.AddYears(value),
+                true);
+            // End DeltaV additions
         }
 
         private void OnRelayedEventToIdCard<T>(Entity<PdaComponent> ent, ref InventoryRelayedEvent<T> args)
@@ -191,6 +205,7 @@ namespace Content.Server.PDA
             var hasInstrument = HasComp<InstrumentComponent>(uid);
             var showUplink = HasComp<UplinkComponent>(uid) && IsUnlocked(uid);
 
+            pda.CurrentDate = pda.DateOverride ?? ServerDate; // DeltaV - PDA date
             UpdateStationName(uid, pda);
             UpdateAlertLevel(uid, pda);
             // TODO: Update the level and name of the station with each call to UpdatePdaUi is only needed for latejoin players.
@@ -213,6 +228,7 @@ namespace Content.Server.PDA
                     ActualOwnerName = pda.OwnerName,
                     IdOwner = id?.FullName,
                     JobTitle = id?.LocalizedJobTitle,
+                    CurrentDate = pda.CurrentDate, // DeltaV - PDA date
                     StationAlertLevel = pda.StationAlertLevel,
                     StationAlertColor = pda.StationAlertColor
                 },

--- a/Content.Shared/PDA/PdaComponent.Trauma.cs
+++ b/Content.Shared/PDA/PdaComponent.Trauma.cs
@@ -1,7 +1,8 @@
 namespace Content.Shared.PDA
-
-public sealed partial class PdaComponent : Component
 {
-    [DataField]
-    public DateTime CurrentDate;
+    public sealed partial class PdaComponent : Component
+    {
+        [DataField]
+        public DateTime CurrentDate;
+    }
 }

--- a/Content.Shared/PDA/PdaComponent.Trauma.cs
+++ b/Content.Shared/PDA/PdaComponent.Trauma.cs
@@ -1,0 +1,7 @@
+namespace Content.Shared.PDA
+
+public sealed partial class PdaComponent : Component
+{
+    [DataField]
+    public DateTime CurrentDate;
+}

--- a/Content.Shared/PDA/PdaComponent.cs
+++ b/Content.Shared/PDA/PdaComponent.cs
@@ -37,5 +37,7 @@ namespace Content.Shared.PDA
         [ViewVariables] public string? StationName;
         [ViewVariables] public string? StationAlertLevel;
         [ViewVariables] public Color StationAlertColor = Color.White;
+        [DataField] public DateTime CurrentDate; // DeltaV - PDA date
+        [DataField] public DateTime? DateOverride; // DeltaV - PDA date
     }
 }

--- a/Content.Shared/PDA/PdaComponent.cs
+++ b/Content.Shared/PDA/PdaComponent.cs
@@ -37,7 +37,5 @@ namespace Content.Shared.PDA
         [ViewVariables] public string? StationName;
         [ViewVariables] public string? StationAlertLevel;
         [ViewVariables] public Color StationAlertColor = Color.White;
-        [DataField] public DateTime CurrentDate; // DeltaV - PDA date
-        [DataField] public DateTime? DateOverride; // DeltaV - PDA date
     }
 }

--- a/Content.Shared/PDA/PdaUpdateState.cs
+++ b/Content.Shared/PDA/PdaUpdateState.cs
@@ -49,5 +49,6 @@ namespace Content.Shared.PDA
         public string? JobTitle;
         public string? StationAlertLevel;
         public Color StationAlertColor;
+        public DateTime? CurrentDate; // DeltaV - PDA date
     }
 }

--- a/Content.Shared/PDA/PdaUpdateState.cs
+++ b/Content.Shared/PDA/PdaUpdateState.cs
@@ -49,6 +49,6 @@ namespace Content.Shared.PDA
         public string? JobTitle;
         public string? StationAlertLevel;
         public Color StationAlertColor;
-        public DateTime? CurrentDate; // DeltaV - PDA date
+        public DateTime CurrentDate; // DeltaV - PDA date
     }
 }

--- a/Content.Trauma.Common/CCVars/DCCVars.cs
+++ b/Content.Trauma.Common/CCVars/DCCVars.cs
@@ -61,7 +61,7 @@ public sealed class DCCVars
     /// The delay between the monument getting upgraded to tier 3 and the finale starting.
     /// </summary>
     public static readonly CVarDef<int> CosmicCultFinaleDelaySeconds =
-        CVarDef.Create("cosmiccult.extra_entropy_for_finale", 150, CVar.SERVER);    
+        CVarDef.Create("cosmiccult.extra_entropy_for_finale", 150, CVar.SERVER);
 
     /// <summary>
     /// What year it is in the game. Actual value shown in game is server date + this value.

--- a/Content.Trauma.Common/CCVars/DCCVars.cs
+++ b/Content.Trauma.Common/CCVars/DCCVars.cs
@@ -64,7 +64,7 @@ public sealed class DCCVars
         CVarDef.Create("cosmiccult.extra_entropy_for_finale", 150, CVar.SERVER);    
 
     /// <summary>
-    /// What year it is in the game. Actual value shown in game is server date + this value.
+    /// The offset for in-game date (the date will be server date + this amount of years).
     /// </summary>
     public static readonly CVarDef<int> YearOffset =
         CVarDef.Create("game.current_year_offset", 739, CVar.SERVERONLY);

--- a/Content.Trauma.Common/CCVars/DCCVars.cs
+++ b/Content.Trauma.Common/CCVars/DCCVars.cs
@@ -61,10 +61,11 @@ public sealed class DCCVars
     /// The delay between the monument getting upgraded to tier 3 and the finale starting.
     /// </summary>
     public static readonly CVarDef<int> CosmicCultFinaleDelaySeconds =
-        CVarDef.Create("cosmiccult.extra_entropy_for_finale", 150, CVar.SERVER);    /// <summary>
+        CVarDef.Create("cosmiccult.extra_entropy_for_finale", 150, CVar.SERVER);    
 
+    /// <summary>
     /// What year it is in the game. Actual value shown in game is server date + this value.
     /// </summary>
     public static readonly CVarDef<int> YearOffset =
-        CVarDef.Create("game.current_year_offset", 550, CVar.SERVERONLY);
+        CVarDef.Create("game.current_year_offset", 739, CVar.SERVERONLY);
 }

--- a/Content.Trauma.Common/CCVars/DCCVars.cs
+++ b/Content.Trauma.Common/CCVars/DCCVars.cs
@@ -61,5 +61,10 @@ public sealed class DCCVars
     /// The delay between the monument getting upgraded to tier 3 and the finale starting.
     /// </summary>
     public static readonly CVarDef<int> CosmicCultFinaleDelaySeconds =
-        CVarDef.Create("cosmiccult.extra_entropy_for_finale", 150, CVar.SERVER);
+        CVarDef.Create("cosmiccult.extra_entropy_for_finale", 150, CVar.SERVER);    /// <summary>
+
+    /// What year it is in the game. Actual value shown in game is server date + this value.
+    /// </summary>
+    public static readonly CVarDef<int> YearOffset =
+        CVarDef.Create("game.current_year_offset", 550, CVar.SERVERONLY);
 }

--- a/Resources/Locale/en-US/_DV/pda/pda-component.ftl
+++ b/Resources/Locale/en-US/_DV/pda/pda-component.ftl
@@ -1,0 +1,1 @@
+comp-pda-ui-current-date = Current date: [color=white]{ $date }[/color]


### PR DESCRIPTION
Port of https://github.com/DeltaV-Station/Delta-v/pull/4277
## About the PR
PDA now displays the current in-universe date. The specific date can be easily changed if needed via a CVar. Currently set to today +739 years, (this would be midly convenient for one of my char's lore, and I'm the one making the port :trollface:)

## Why / Balance
Roleplay 📈📈📈 
Lore 📈📈📈 
Paperwork 📈📈📈 
And yes, you can copy the value by clicking on the date in the PDA. You can do this with pretty much every field in the PDA info tab, by the way.

## Technical details
See original PR

## Media
Ignore the wrong date I fumbled the creenshit a little
<img width="569" height="448" alt="изображение" src="https://github.com/user-attachments/assets/5a573d55-1426-4a3c-b1fe-a49b4377fe44" />


## Requirements
Yes

## Breaking changes
No

**Changelog**
:cl:
- add: PDAs now display the current in-game date
