### PR TITLE
Make suit storage not require a suit

### DIFF
--- a/Resources/Prototypes/InventoryTemplates/arachnid_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/arachnid_inventory_template.yml
@@ -188,7 +188,9 @@
       stripTime: 3
       uiWindowPos: 2,0
       strippingWindowPos: 2,5
-      dependsOn: outerClothing
-      dependsOnComponents:
-      - type: AllowSuitStorage
+      # <Trauma>
+      #dependsOn: outerClothing
+      #dependsOnComponents:
+      #- type: AllowSuitStorage
+      # </Trauma>
       displayName: Suit Storage

--- a/Resources/Prototypes/InventoryTemplates/corpse_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/corpse_inventory_template.yml
@@ -104,9 +104,11 @@
       stripTime: 3
       uiWindowPos: 2,0
       strippingWindowPos: 2,5
-      dependsOn: outerClothing
-      dependsOnComponents:
-      - type: AllowSuitStorage
+      # <Trauma>
+      #dependsOn: outerClothing
+      #dependsOnComponents:
+      #- type: AllowSuitStorage
+      # </Trauma>
       displayName: Suit Storage
     - name: belt
       slotTexture: belt

--- a/Resources/Prototypes/InventoryTemplates/digitigrade_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/digitigrade_inventory_template.yml
@@ -110,7 +110,9 @@
       stripTime: 3
       uiWindowPos: 2,0
       strippingWindowPos: 2,5
-      dependsOn: outerClothing
+      # <Trauma>
+      #dependsOn: outerClothing
+      # </Trauma>
       displayName: Suit Storage
     - name: id
       slotTexture: id

--- a/Resources/Prototypes/InventoryTemplates/diona_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/diona_inventory_template.yml
@@ -103,9 +103,11 @@
       stripTime: 3
       uiWindowPos: 2,0
       strippingWindowPos: 2,5
-      dependsOn: outerClothing
-      dependsOnComponents:
-      - type: AllowSuitStorage
+      # <Trauma>
+      #dependsOn: outerClothing
+      #dependsOnComponents:
+      #- type: AllowSuitStorage
+      # </Trauma>
       displayName: Suit Storage
     - name: id
       slotTexture: id

--- a/Resources/Prototypes/InventoryTemplates/human_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/human_inventory_template.yml
@@ -110,9 +110,11 @@
       stripTime: 3
       uiWindowPos: 2,0
       strippingWindowPos: 2,5
-      dependsOn: outerClothing
-      dependsOnComponents:
-      - type: AllowSuitStorage
+      # <Trauma>
+      #dependsOn: outerClothing
+      #dependsOnComponents:
+      #- type: AllowSuitStorage
+      # </Trauma>
       displayName: Suit Storage
     - name: id
       slotTexture: id

--- a/Resources/Prototypes/InventoryTemplates/mannequin_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/mannequin_inventory_template.yml
@@ -73,9 +73,11 @@
       stripTime: 3
       uiWindowPos: 2,0
       strippingWindowPos: 1,3
-      dependsOn: outerClothing
-      dependsOnComponents:
-      - type: AllowSuitStorage
+      # <Trauma>
+      #dependsOn: outerClothing
+      #dependsOnComponents:
+      #- type: AllowSuitStorage
+      # </Trauma>
       displayName: Suit Storage
     - name: back
       slotTexture: back

--- a/Resources/Prototypes/InventoryTemplates/monkey_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/monkey_inventory_template.yml
@@ -93,9 +93,11 @@
       stripTime: 3
       uiWindowPos: 2,0
       strippingWindowPos: 2,5
-      dependsOn: outerClothing
-      dependsOnComponents:
-      - type: AllowSuitStorage
+      # <Trauma>
+      #dependsOn: outerClothing
+      #dependsOnComponents:
+      #- type: AllowSuitStorage
+      # </Trauma>
       displayName: Suit Storage
     - name: id
       slotTexture: id

--- a/Resources/Prototypes/InventoryTemplates/scurret_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/scurret_inventory_template.yml
@@ -55,9 +55,11 @@
     stripTime: 3
     uiWindowPos: 2,0
     strippingWindowPos: 2,5
-    dependsOn: jumpsuit
-    dependsOnComponents:
-    - type: AllowSuitStorage
+    # <Trauma>
+    #dependsOn: jumpsuit
+    #dependsOnComponents:
+    #- type: AllowSuitStorage
+    # </Trauma>
     displayName: Suit Storage
   - name: back
     slotTexture: back

--- a/Resources/Prototypes/_EinsteinEngines/InventoryTemplates/plasmaman_inventory_template.yml
+++ b/Resources/Prototypes/_EinsteinEngines/InventoryTemplates/plasmaman_inventory_template.yml
@@ -98,9 +98,6 @@
       stripTime: 3
       uiWindowPos: 2,0
       strippingWindowPos: 2,5
-      dependsOn: jumpsuit # Goobstation - plasmamen can use the envirosuit as gasholder
-      dependsOnComponents:
-      - type: AllowSuitStorage
       displayName: Suit Storage
     - name: id
       slotTexture: id


### PR DESCRIPTION
## About the PR
You can now always use your suit storage slot, even if you don't have anything in your outer clothing slot at all.

## Why / Balance
This is barely at all a balance concern, and is more of a QoL change. If you have access to a gun, you would also have access to an armor vest, which enables suit storage. If you have access to a gas tank you also have access to a hardsuit/EVA suit. If realism is a concern, we could always say that all those items have a belt on them (most of them even have it on the sprite anyway). All this "feature" does is annoy players for no reason. Toggled your modsuit? Woops, your air tank fell off, and you now have to go back to pick it up, because there is little to no visual feedback.

Also reduces metagaming by 0.001%. Shadow cloak currently enables suit storage even while invisible, so you could instantly out yourself as a heretic by having an air tank with seemingly no outer clothing.

## Technical details
YAMLmaxxing

## Media
It's free real estate
<img width="215" height="525" alt="изображение" src="https://github.com/user-attachments/assets/b2a7d6e9-5e54-4e09-822f-cbfc1c36d8b7" />


**Changelog**
:cl:
- tweak: You can now always use the suit storage slot, even without having a hardsuit/armor/tank harness.
