### PR TITLE
no sleeper agent code blue for ninja/summoner

### DIFF
--- a/Resources/Prototypes/_Trauma/GameRules/midround.yml
+++ b/Resources/Prototypes/_Trauma/GameRules/midround.yml
@@ -139,12 +139,29 @@
 ## Sleeper agents ninja threat, the ninja does the announcement
 
 - type: entity
-  parent: SleeperAgents
+  parent: BaseTraitorRule
   id: SleeperAgentsQuiet # cipher's assassin...
   components:
   - type: StationEvent
-    startAnnouncement: null
-    startAudio: null
+    earliestStart: 30
+    weight: 8
+    minimumPlayers: 15
+    maxOccurrences: 1 # can only happen once per round
+    duration: null # the rule has to last the whole round not 1 second
+    occursDuringRoundEnd: false
+  - type: AntagSelection
+    definitions:
+    - prefRoles: [ TraitorSleeper ]
+      fallbackRoles: [ Traitor ]
+      min: 1
+      max: 2
+      playerRatio: 10
+      blacklist:
+        components:
+        - AntagImmune
+        - CommandStaff
+      mindRoles:
+      - MindRoleTraitorSleeper
 
 ## Quiet version of wailing horse
 


### PR DESCRIPTION
fixes #1961

copy paste ops instead of inheriting so theres no alert level rule component

:cl:
- fix: Fixed sleeper agents from ninja and funding booster setting the station to blue alert.