### PR TITLE
only 1 xeno queen ever

### DIFF
--- a/Content.Trauma.Server/GameTicking/Rules/Components/XenomorphsRuleComponent.cs
+++ b/Content.Trauma.Server/GameTicking/Rules/Components/XenomorphsRuleComponent.cs
@@ -1,14 +1,22 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-using Robust.Shared.Audio; // Goobstation - Play music on announcement
+using Content.Trauma.Shared.Xenomorphs.Caste;
+using Robust.Shared.Audio;
 
 namespace Content.Trauma.Server.GameTicking.Rules.Components;
 
 [RegisterComponent]
 public sealed partial class XenomorphsRuleComponent : Component
 {
-    [ViewVariables]
-    public List<EntityUid> Xenomorphs = new ();
+    [DataField]
+    public List<EntityUid> Xenomorphs = new();
+
+    /// <summary>
+    /// Total number of each caste this rule has ever had.
+    /// Does not get decreased if they die or whatever.
+    /// <summary>
+    [DataField]
+    public Dictionary<ProtoId<XenomorphCastePrototype>, int> TotalCastes = new();
 
     #region Check
 
@@ -25,21 +33,21 @@ public sealed partial class XenomorphsRuleComponent : Component
     [DataField]
     public string? Announcement = "xenomorphs-announcement";
 
-    [DataField] // Goobstation - play music on announcement
+    [DataField]
     public SoundSpecifier XenomorphInfestationSound =
-            new SoundPathSpecifier("/Audio/_Goobstation/Music/Black_Swarm_Short.ogg")
-            {
-                Params = AudioParams.Default
-                    .WithVolume(-8f)
-            };
+        new SoundPathSpecifier("/Audio/_Goobstation/Music/Black_Swarm_Short.ogg")
+        {
+            Params = AudioParams.Default
+                .WithVolume(-8f)
+        };
 
-    [DataField] // Goobstation - play music on announcement
+    [DataField]
     public SoundSpecifier XenomorphTakeoverSound =
-            new SoundPathSpecifier("/Audio/_Goobstation/Music/Colonial_Marines_The_Final_Battle.ogg")
-            {
-                Params = AudioParams.Default
-                    .WithVolume(-8f)
-            };
+        new SoundPathSpecifier("/Audio/_Goobstation/Music/Colonial_Marines_The_Final_Battle.ogg")
+        {
+            Params = AudioParams.Default
+                .WithVolume(-8f)
+        };
 
     [DataField]
     public Color AnnouncementColor = Color.Red;

--- a/Content.Trauma.Server/GameTicking/Rules/XenomorphsRuleSystem.cs
+++ b/Content.Trauma.Server/GameTicking/Rules/XenomorphsRuleSystem.cs
@@ -84,23 +84,23 @@ public sealed class XenomorphsRuleSystem : GameRuleSystem<XenomorphsRuleComponen
     private void BeforeXenomorphEvolution(
         EntityUid uid,
         XenomorphComponent component,
-        BeforeXenomorphEvolutionEvent args
+        ref BeforeXenomorphEvolutionEvent args
     )
     {
         if (!_protoManager.TryIndex(args.Caste, out var cast) || cast.MaxCount == 0)
             return;
 
         var query = QueryActiveRules();
-        while (query.MoveNext(out _, out _, out var xenomorphsRule, out _))
+        while (query.MoveNext(out _, out _, out var rule, out _))
         {
-            if (!xenomorphsRule.Xenomorphs.Contains(uid))
+            if (!rule.Xenomorphs.Contains(uid))
                 continue;
 
-            if (GetXenomorphs(xenomorphsRule, args.Caste).Count >= cast.MaxCount
-                || cast.NeedCasteDeath != null && GetXenomorphs(xenomorphsRule, cast.NeedCasteDeath).Count > 0)
+            if (rule.TotalCastes.GetValueOrDefault(args.Caste) >= cast.MaxCount
+                || cast.NeedCasteDeath != null && GetXenomorphs(rule, cast.NeedCasteDeath).Count > 0)
             {
                 _popup.PopupEntity(Loc.GetString("xenomorphs-evolution-no-cast-slot", ("caste", Loc.GetString(cast.Name))), uid, uid);
-                args.Cancel();
+                args.Cancelled = true;
                 return;
             }
         }
@@ -109,14 +109,16 @@ public sealed class XenomorphsRuleSystem : GameRuleSystem<XenomorphsRuleComponen
     private void AfterXenomorphEvolution(
         EntityUid uid,
         XenomorphComponent component,
-        AfterXenomorphEvolutionEvent args
+        ref AfterXenomorphEvolutionEvent args
     )
     {
         var query = QueryActiveRules();
-        while (query.MoveNext(out _, out _, out var xenomorphsRule, out _))
+        while (query.MoveNext(out _, out _, out var rule, out _))
         {
-            if (xenomorphsRule.Xenomorphs.Remove(uid))
-                xenomorphsRule.Xenomorphs.Add(args.EvolvedInto);
+            if (!rule.Xenomorphs.Remove(uid))
+                continue;
+            rule.Xenomorphs.Add(args.EvolvedInto);
+            rule.TotalCastes[args.Caste] = rule.TotalCastes.GetValueOrDefault(args.Caste) + 1;
         }
     }
 

--- a/Content.Trauma.Server/Xenomorphs/Evolution/XenomorphEvolutionSystem.cs
+++ b/Content.Trauma.Server/Xenomorphs/Evolution/XenomorphEvolutionSystem.cs
@@ -105,7 +105,7 @@ public sealed class XenomorphEvolutionSystem : EntitySystem
             return;
 
         var ev = new BeforeXenomorphEvolutionEvent(args.Caste);
-        RaiseLocalEvent(uid, ev);
+        RaiseLocalEvent(uid, ref ev);
 
         if (ev.Cancelled)
             return;
@@ -120,7 +120,8 @@ public sealed class XenomorphEvolutionSystem : EntitySystem
 
         var dropHandItemsEvent = new DropHandItemsEvent();
         RaiseLocalEvent(uid, ref dropHandItemsEvent);
-        RaiseLocalEvent(uid, new AfterXenomorphEvolutionEvent(newXeno, mindUid, args.Caste));
+        var afterEv = new AfterXenomorphEvolutionEvent(newXeno, mindUid, args.Caste);
+        RaiseLocalEvent(uid, ref afterEv);
 
         _adminLog.Add(LogType.Mind, $"{ToPrettyString(uid)} evolved into {ToPrettyString(newXeno)}");
 
@@ -166,7 +167,7 @@ public sealed class XenomorphEvolutionSystem : EntitySystem
         }
 
         var ev = new BeforeXenomorphEvolutionEvent(xenomorph.Caste, checkNeedCasteDeath);
-        RaiseLocalEvent(uid, ev);
+        RaiseLocalEvent(uid, ref ev);
 
         if (ev.Cancelled)
             return false;

--- a/Content.Trauma.Shared/Actions/ActionRelaySystem.cs
+++ b/Content.Trauma.Shared/Actions/ActionRelaySystem.cs
@@ -15,18 +15,12 @@ public sealed class ActionRelaySystem : EntitySystem
         SubscribeLocalEvent<ActionsComponent, PlasmaAmountChangeEvent>(RelayEvent);
     }
 
-    public void RelayEvent<T>(EntityUid uid, ActionsComponent component, T args) where T : EntityEventArgs
+    public void RelayEvent<T>(EntityUid uid, ActionsComponent component, ref T args) where T : notnull
     {
-        var ev = new ActionRelayedEvent<T>(args);
         var actions = _actions.GetActions(uid, component);
         foreach (var action in actions)
         {
-            RaiseLocalEvent(action.Owner, ev);
+            RaiseLocalEvent(action.Owner, ref args);
         }
     }
-}
-
-public sealed class ActionRelayedEvent<TEvent>(TEvent args) : EntityEventArgs
-{
-    public TEvent Args = args;
 }

--- a/Content.Trauma.Shared/Actions/PlasmaCostActionSystem.cs
+++ b/Content.Trauma.Shared/Actions/PlasmaCostActionSystem.cs
@@ -16,7 +16,7 @@ public sealed class PlasmaCostActionSystem : EntitySystem
 
     public override void Initialize()
     {
-        SubscribeLocalEvent<PlasmaCostActionComponent, ActionRelayedEvent<PlasmaAmountChangeEvent>>(OnPlasmaAmountChange);
+        SubscribeLocalEvent<PlasmaCostActionComponent, PlasmaAmountChangeEvent>(OnPlasmaAmountChange);
         SubscribeLocalEvent<PlasmaCostActionComponent, ActionAttemptEvent>(OnActionAttempt);
         SubscribeLocalEvent<PlasmaCostActionComponent, ActionPerformedEvent>(OnActionPerformed);
     }
@@ -43,9 +43,9 @@ public sealed class PlasmaCostActionSystem : EntitySystem
             _plasma.ChangePlasmaAmount(performer, -cost);
     }
 
-    private void OnPlasmaAmountChange(EntityUid uid, PlasmaCostActionComponent component, ActionRelayedEvent<PlasmaAmountChangeEvent> args)
+    private void OnPlasmaAmountChange(EntityUid uid, PlasmaCostActionComponent component, ref PlasmaAmountChangeEvent args)
     {
-        _actions.SetEnabled(uid, component.PlasmaCost <= args.Args.Amount);
+        _actions.SetEnabled(uid, component.PlasmaCost <= args.Amount);
     }
 
     private void OnActionAttempt(Entity<PlasmaCostActionComponent> ent, ref ActionAttemptEvent args)

--- a/Content.Trauma.Shared/Xenomorphs/Event.cs
+++ b/Content.Trauma.Shared/Xenomorphs/Event.cs
@@ -59,20 +59,11 @@ public sealed partial class TailLashActionEvent : WorldTargetActionEvent;
 
 public sealed partial class AcidActionEvent : EntityTargetActionEvent;
 
-public sealed class AfterXenomorphEvolutionEvent(EntityUid evolvedInto, EntityUid mindUid, ProtoId<XenomorphCastePrototype> caste) : EntityEventArgs
-{
-    public EntityUid EvolvedInto = evolvedInto;
-    public EntityUid MindUid = mindUid;
-    public ProtoId<XenomorphCastePrototype> Caste = caste;
-}
+[ByRefEvent]
+public record struct AfterXenomorphEvolutionEvent(EntityUid EvolvedInto, EntityUid MindUid, ProtoId<XenomorphCastePrototype> Caste);
 
-public sealed class BeforeXenomorphEvolutionEvent(ProtoId<XenomorphCastePrototype> caste, bool checkNeedCasteDeath = true) : CancellableEntityEventArgs
-{
-    public ProtoId<XenomorphCastePrototype> Caste = caste;
-    public bool CheckNeedCasteDeath = checkNeedCasteDeath;
-}
+[ByRefEvent]
+public record struct BeforeXenomorphEvolutionEvent(ProtoId<XenomorphCastePrototype> Caste, bool CheckNeedCasteDeath = true, bool Cancelled = false);
 
-public sealed class PlasmaAmountChangeEvent(FixedPoint2 amount) : EntityEventArgs
-{
-    public FixedPoint2 Amount = amount;
-}
+[ByRefEvent]
+public record struct PlasmaAmountChangeEvent(FixedPoint2 Amount);

--- a/Content.Trauma.Shared/Xenomorphs/Plasma/SharedPlasmaSystem.cs
+++ b/Content.Trauma.Shared/Xenomorphs/Plasma/SharedPlasmaSystem.cs
@@ -39,7 +39,8 @@ public abstract class SharedPlasmaSystem : EntitySystem
         component.Plasma = FixedPoint2.Min(component.Plasma + amount, component.MaxPlasma);
         Dirty(uid, component);
 
-        RaiseLocalEvent(uid, new PlasmaAmountChangeEvent(component.Plasma));
+        var ev = new PlasmaAmountChangeEvent(component.Plasma);
+        RaiseLocalEvent(uid, ref ev);
 
         _alerts.ShowAlert(uid, component.PlasmaAlert);
 


### PR DESCRIPTION
limited queen evolution so once a queen evolves, there cant be another queen ever
same applies for praetorian so dont die...

also cleanup shit

:cl:
- tweak: Changed xeno evolution so a queen/praetorian can only ever be evolved to once, even if an old one died.