### PR TITLE
Remove slop from ninja threats

### DIFF
--- a/Resources/Prototypes/_Trauma/GameRules/midround.yml
+++ b/Resources/Prototypes/_Trauma/GameRules/midround.yml
@@ -119,23 +119,6 @@
       - MindRoleShadowling
       pickPlayer: false
 
-## Minor antags ninja threat
-
-- type: entity
-  parent: BaseGameRule
-  id: MidroundMinorAntagsRule
-  components:
-  - type: NestedRule
-    rules: !type:GroupSelector
-      rolls: 2, 3 # mild spam of chuds
-      children:
-      - id: TunnelClownMidround
-      - id: SingulothKnightsMidround
-      - id: DarkLordMidround # spawns chosen one after it's picked by a player
-      - id: MimeAssassinMidround
-      - id: DarkPriestMidround
-      - id: VoxRaidersMidround
-
 ## Sleeper agents ninja threat, the ninja does the announcement
 
 - type: entity

--- a/Resources/Prototypes/_Trauma/threats.yml
+++ b/Resources/Prototypes/_Trauma/threats.yml
@@ -24,11 +24,6 @@
   rule: ShadowlingMidround
 
 - type: ninjaHackingThreat
-  id: MinorAntags
-  announcement: terror-minor-antags
-  rule: MidroundMinorAntagsRule
-
-- type: ninjaHackingThreat
   id: WailingHorse
   announcement: terror-shadows
   rule: WailingHorseQuiet

--- a/Resources/Prototypes/threats.yml
+++ b/Resources/Prototypes/threats.yml
@@ -14,7 +14,6 @@
     SleeperAgents: 1
     Bingle: 1
     Shadowling: 1
-    MinorAntags: 1
     WailingHorse: 0.25 # a true horror
     # </Trauma>
 


### PR DESCRIPTION
## About the PR
Removed minor "antags" from ninja threats.

## Why / Balance
Ninja calling in a threat is supposed to summon an actual threat, not "; hey anyone wanna duel? I'm at the bar"

## Technical details
One line ops

## Media
No

## Requirements
No

## Breaking changes
No

## Changelog
No

## Good PR description
No

## Schizophrenia
Yes