### PR TITLE
fix explosive cord not chain exploding

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/cables.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/cables.yml
@@ -260,7 +260,7 @@
     - trigger:
         !type:DamageTypeTrigger
         damageType: Structural #this is as close as we can get to only letting explosives set it off.
-        damage: 120
+        damage: 100 # Trauma - was 120, didn't chain explode due to nerfed damage
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]


### PR DESCRIPTION
fixes #1993

:cl:
- fix: Fixed explosive cord not chain exploding.