### PR TITLE
full judo rework

### DIFF
--- a/Content.Trauma.Shared/EntityEffects/Armbar.cs
+++ b/Content.Trauma.Shared/EntityEffects/Armbar.cs
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Shared.EntityEffects;
+using Content.Trauma.Shared.MartialArts.Components;
+
+namespace Content.Trauma.Shared.EntityEffects;
+
+/// <summary>
+/// Adds <see cref="ArmbarredComponent" to the target entity if the effect has a user.
+/// </summary>
+public sealed partial class Armbar : EntityEffectBase<Armbar>
+{
+    public override string? EntityEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
+        => null;
+}
+
+public sealed class ArmbarEffectSystem : EntityEffectSystem<TransformComponent, Armbar>
+{
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+
+    protected override void Effect(Entity<TransformComponent> ent, ref EntityEffectEvent<Armbar> args)
+    {
+        if (args.User is not {} user)
+            return;
+
+        var comp = EnsureComp<ArmbarredComponent>(ent);
+        comp.User = user;
+        Dirty(ent, comp);
+    }
+
+    // nowhere better to put it
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var query = EntityQueryEnumerator<ArmbarredComponent>();
+        while (query.MoveNext(out var uid, out var comp))
+        {
+            if (TerminatingOrDeleted(comp.User) || !_transform.InRange(uid, comp.User, comp.Range))
+                RemCompDeferred(uid, comp);
+        }
+    }
+}

--- a/Content.Trauma.Shared/EntityEffects/GrabThrow.cs
+++ b/Content.Trauma.Shared/EntityEffects/GrabThrow.cs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Shared.Damage;
+using Content.Shared.EntityEffects;
+using Content.Trauma.Shared.Grab;
+
+namespace Content.Trauma.Shared.EntityEffects;
+
+/// <summary>
+/// Grab-throws the target mob away from the user, speed scales with effect scale.
+/// Does nothing if there is no user or it's at the same position as the target.
+/// </summary>
+public sealed partial class GrabThrow : EntityEffectBase<GrabThrow>
+{
+    [DataField]
+    public float Speed = 5f;
+
+    /// <summary>
+    /// Damage dealt after hitting a wall.
+    /// </summary>
+    [DataField]
+    public DamageSpecifier? Damage;
+
+    [DataField]
+    public bool DropItems = true;
+
+    public override string? EntityEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
+        => null; // not used by reagents idc
+}
+
+public sealed class GrabThrowEffectSystem : EntityEffectSystem<TransformComponent, GrabThrow>
+{
+    [Dependency] private readonly GrabThrownSystem _grabThrown = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+
+    protected override void Effect(Entity<TransformComponent> ent, ref EntityEffectEvent<GrabThrow> args)
+    {
+        if (args.User is not {} user)
+            return;
+
+        var pos = _transform.GetMapCoordinates(ent.Comp).Position;
+        var userPos = _transform.GetMapCoordinates(user).Position;
+        if (pos == userPos)
+            return;
+
+        var direction = (pos - userPos).Normalized();
+
+        var e = args.Effect;
+        _grabThrown.Throw(ent,
+            user,
+            direction,
+            e.Speed * args.Scale,
+            damage: e.Damage,
+            drop: e.DropItems);
+    }
+}

--- a/Content.Trauma.Shared/EntityEffects/SetGrabStage.cs
+++ b/Content.Trauma.Shared/EntityEffects/SetGrabStage.cs
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Shared.EntityEffects;
+using Content.Shared.Movement.Pulling.Components;
+using Content.Shared.Movement.Pulling.Systems;
+using Content.Trauma.Common.MartialArts;
+
+namespace Content.Trauma.Shared.EntityEffects;
+
+/// <summary>
+/// Sets the target's grab stage, does nothing if it isn't being pulled.
+/// </summary>
+public sealed partial class SetGrabStage : EntityEffectBase<SetGrabStage>
+{
+    /// <summary>
+    /// Grab stage to set to.
+    /// </summary>
+    [DataField(required: true)]
+    public GrabStage Stage;
+
+    public override string? EntityEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
+        => null;
+}
+
+public sealed class SetGrabStageEffectSystem : EntityEffectSystem<PullableComponent, SetGrabStage>
+{
+    [Dependency] private readonly PullingSystem _pulling = default!;
+
+    protected override void Effect(Entity<PullableComponent> ent, ref EntityEffectEvent<SetGrabStage> args)
+    {
+        if (ent.Comp.Puller is not {} puller || !TryComp<PullerComponent>(puller, out var pullerComp))
+            return;
+
+        _pulling.TrySetGrabStages((puller, pullerComp), ent, args.Effect.Stage);
+    }
+}

--- a/Content.Trauma.Shared/EntityEffects/StopPull.cs
+++ b/Content.Trauma.Shared/EntityEffects/StopPull.cs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Shared.EntityEffects;
+using Content.Shared.Movement.Pulling.Components;
+using Content.Shared.Movement.Pulling.Systems;
+
+namespace Content.Trauma.Shared.EntityEffects;
+
+/// <summary>
+/// Breaks the target entity's pull, if it's being pulled.
+/// </summary>
+public sealed partial class StopPull : EntityEffectBase<StopPull>
+{
+    /// <summary>
+    /// Whether to ignore grab stages.
+    /// </summary>
+    [DataField]
+    public bool IgnoreGrab = true;
+
+    public override string? EntityEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
+        => null;
+}
+
+public sealed class StopPullEffectSystem : EntityEffectSystem<PullableComponent, StopPull>
+{
+    [Dependency] private readonly PullingSystem _pulling = default!;
+
+    protected override void Effect(Entity<PullableComponent> ent, ref EntityEffectEvent<StopPull> args)
+    {
+        _pulling.TryStopPull(ent, ent.Comp, user: args.User, ignoreGrab: args.Effect.IgnoreGrab);
+    }
+}

--- a/Content.Trauma.Shared/MartialArts/Components/ArmbarredComponent.cs
+++ b/Content.Trauma.Shared/MartialArts/Components/ArmbarredComponent.cs
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Content.Trauma.Shared.MartialArts.Components;
+
+/// <summary>
+/// Added to the target after using armbar move.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+[AutoGenerateComponentState]
+public sealed partial class ArmbarredComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public EntityUid User;
+
+    /// <summary>
+    /// Armbar breaks if the distance to the user exceeds this distance.
+    /// </summary>
+    [DataField]
+    public float Range = 2f;
+}

--- a/Content.Trauma.Shared/MartialArts/Components/NoGunComponent.cs
+++ b/Content.Trauma.Shared/MartialArts/Components/NoGunComponent.cs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-
 namespace Content.Trauma.Shared.MartialArts.Components;
 
 /// <summary>

--- a/Content.Trauma.Shared/MartialArts/MartialArtsSystem.Combos.cs
+++ b/Content.Trauma.Shared/MartialArts/MartialArtsSystem.Combos.cs
@@ -61,7 +61,7 @@ public partial class MartialArtsSystem
         {
             var proto = _proto.Index(queued);
             var level = _knowledge.GetLevel(ent.Owner);
-            OverrideCombo(user, args.Target, proto, ent, level);
+            PerformCombo(user, args.Target, proto, ent, level);
             comboActions.QueuedPrototype = null;
             return;
         }
@@ -99,12 +99,12 @@ public partial class MartialArtsSystem
                 !_conditions.TryConditions(target, proto.Conditions))
                 continue;
 
-            OverrideCombo(performer, target, proto, ent, level);
+            PerformCombo(performer, target, proto, ent, level);
             break; // found the combo
         }
     }
 
-    public void OverrideCombo(EntityUid performer, EntityUid target, ComboPrototype proto, Entity<CanPerformComboComponent> ent, int level)
+    public void PerformCombo(EntityUid performer, EntityUid target, ComboPrototype proto, Entity<CanPerformComboComponent> ent, int level)
     {
         ent.Comp.Momentum += 1;
 

--- a/Resources/Prototypes/_Trauma/MartialArts/judo.yml
+++ b/Resources/Prototypes/_Trauma/MartialArts/judo.yml
@@ -1,7 +1,6 @@
 - type: combo
   id: JudoDiscombobulate
   attacks:
-  - Grab
   - Disarm
   - Grab
   userEffects:
@@ -9,6 +8,12 @@
     messages:
     - judo-discombobulate
   opponentEffects:
+  - !type:PlaySoundEffect
+    sound: /Audio/Weapons/genhit3.ogg
+  - !type:ModifyStatusEffect
+    effectProto: JudoDiscombobulateStatusEffect # slowdown is roughly confusion
+    time: 5
+    type: Add # paradise parity...
   - !type:TakeStaminaDamage
     amount: 10
   levelRequired: 0
@@ -18,19 +23,27 @@
   attacks:
   - Disarm
   - Harm
-  - Harm
   userEffects:
   - !type:PopupMessage
     messages:
     - judo-eyepoke # isnt this more of a krav thing? judo is all grappling
   opponentEffects:
-  - !type:TakeStaminaDamage
-    amount: 25
+  - !type:PlaySoundEffect
+    sound: /Audio/Weapons/genhit3.ogg
+  - !type:GenericStatusEffect
+    key: TemporaryBlindness
+    component: TemporaryBlindness
+    time: 2
+  - !type:GenericStatusEffect
+    key: BlurryVision
+    component: BlurryVision
+    time: 5
   - !type:HealthChange
+    targetPart: Head
     damage:
       types:
-        Blunt: 5
-  levelRequired: 0
+        Blunt: 10
+  levelRequired: 20
 
 - type: combo
   id: JudoThrow
@@ -43,31 +56,45 @@
     messages:
     - judo-throw
   opponentEffects:
-  - !type:ModifyParalysis
-    time: 4
-  - !type:HealthChange
-    damage:
-      types:
-        Blunt: 5
+  - !type:PlaySoundEffect
+    sound: /Audio/Weapons/genhit3.ogg
+  - !type:ModifyKnockdown
+    time: 7
   - !type:TakeStaminaDamage
-    amount: 5
+    amount: 25
+  - !type:StopPull
+  userConditions:
+  - !type:StandingCondition
   levelRequired: 0
 
 - type: combo
   id: JudoArmbar
   attacks:
   - Disarm
-  - Harm
+  - Disarm
   - Grab
   userEffects:
   - !type:PopupMessage
     messages:
     - judo-armbar
   opponentEffects:
-  - !type:ModifyParalysis
+  - !type:PlaySoundEffect
+    sound: /Audio/Weapons/genhit3.ogg
+  - !type:ModifyKnockdown
     time: 5
   - !type:TakeStaminaDamage
-    amount: 10
+    amount: 45
+  - !type:SetGrabStage
+    stage: Suffocate # equivalent to a choke grab
+  - !type:Armbar # allows wheel throw and tracks it so it goes away when they separate
+  # TODO: disarm if the user is standing
+  conditions:
+  - !type:StandingCondition
+    inverted: true # has to be downed
+  - !type:WhitelistCondition
+    blacklist:
+      components:
+      - Armbarred # don't do it if already armbarred
   levelRequired: 0
 
 - type: combo
@@ -80,7 +107,29 @@
   - !type:PopupMessage
     messages:
     - judo-wheelthrow
+  - !type:RemoveComponents
+    components:
+    - type: KnockedDown
+  - !type:SetStanding
   opponentEffects:
+  - !type:PlaySoundEffect
+    sound: /Audio/Weapons/genhit3.ogg
   - !type:TakeStaminaDamage
     amount: 120
+  - !type:ModifyKnockdown
+    time: 15
+  - !type:ModifyStatusEffect
+    effectProto: JudoDiscombobulateStatusEffect # slowdown is roughly confusion
+    time: 10
+  - !type:StopPull
+  - !type:GrabThrow
+    speed: 5
+  - !type:RemoveComponents
+    components:
+    - type: Armbarred
+  conditions:
+  - !type:WhitelistCondition
+    whitelist:
+      components:
+      - Armbarred # needs to be armbarred
   levelRequired: 0

--- a/Resources/ServerInfo/_Goobstation/Guidebook/MartialArts/CorporateJudo.xml
+++ b/Resources/ServerInfo/_Goobstation/Guidebook/MartialArts/CorporateJudo.xml
@@ -24,7 +24,6 @@
   ### Discombobulate
 
   <Box>
-    <GuideEntityEmbed Entity="GuidebookGrab" Caption=""/>
     <GuideEntityEmbed Entity="GuidebookDisarm" Caption=""/>
     <GuideEntityEmbed Entity="GuidebookGrab" Caption=""/>
   </Box>
@@ -35,7 +34,6 @@
 
   <Box>
     <GuideEntityEmbed Entity="GuidebookDisarm" Caption=""/>
-    <GuideEntityEmbed Entity="GuidebookHarm" Caption=""/>
     <GuideEntityEmbed Entity="GuidebookHarm" Caption=""/>
   </Box>
 
@@ -56,7 +54,7 @@
 
   <Box>
     <GuideEntityEmbed Entity="GuidebookDisarm" Caption=""/>
-    <GuideEntityEmbed Entity="GuidebookHarm" Caption=""/>
+    <GuideEntityEmbed Entity="GuidebookDisarm" Caption=""/>
     <GuideEntityEmbed Entity="GuidebookGrab" Caption=""/>
   </Box>
 


### PR DESCRIPTION
resolves #1937
fixes #1102
fixes #1735

implemented almost everything for parity like standing checks, armbar requirement for wheel throw, etc

<img width="1382" height="314" alt="13:30:52" src="https://github.com/user-attachments/assets/564e1028-7029-47fb-8694-0a2723b95430" />

changed most things to paradise except judo throw, theres no swap hands move so it would conflict with wheel throw

only things missing are disarm if you are standing and moves needed for judo throw since theres no swap hands move

overall its much stronger but needs a little thought to use

:cl:
- tweak: Completely reworked judo to be much closer to how it is on Paradise station. 