### PR TITLE
make headrev fallback on traitor

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -338,6 +338,7 @@
     selectionTime: IntraPlayerSpawn # Goobstation
     definitions:
     - prefRoles: [ HeadRev ]
+      fallbackRoles: [ Traitor ] # Trauma - make headrev-less rev rounds much rarer
       max: 3
       playerRatio: 15
       blacklist:


### PR DESCRIPTION
fixes #1996

:cl:
- fix: Fixed rev rounds having no headrevs if nobody opted into headrev, it will also look for traitor now as a fallback.