### PR TITLE
remove weather pending rework

### DIFF
--- a/Resources/Prototypes/_Lavaland/Procedural/lavaland_planets.yml
+++ b/Resources/Prototypes/_Lavaland/Procedural/lavaland_planets.yml
@@ -35,6 +35,4 @@
       whitelist: # TODO fix shuttles FTLing on planets and remove this whitelist
         components:
         - MiningShuttle
-  - !type:ModifyStatusEffect
-    effectProto: WeatherSchedulerAshStorm # Regular ash storms
-    time: null # permanent
+  # FIXME: engine is fucked

--- a/Resources/Prototypes/_Trauma/Entities/Stations/Traits/negative.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Stations/Traits/negative.yml
@@ -179,7 +179,7 @@
 - type: stationTrait
   id: RadiationStormfront
   group: Negative
-  chance: 0.4
+  chance: 0 # FIXME: engine is fucked
   name: "Radiation Stormfront"
   report: "A radioactive stormfront is passing through your station's system. Expect an increased likelihood of radiation storms passing over your station."
   effects:


### PR DESCRIPTION
nobody is ever going to fix engine so we cant have nice things

fixes #1960

:cl:
- remove: Removed ash storms because they were causing game resets.