### PR TITLE
change reinforcement beacons to delay adding instant ghost roles

### DIFF
--- a/Content.Trauma.Common/CCVar/TraumaCVars.Reinforcements.cs
+++ b/Content.Trauma.Common/CCVar/TraumaCVars.Reinforcements.cs
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Robust.Shared.Configuration;
+
+namespace Content.Trauma.Common.CCVar;
+
+public sealed partial class TraumaCVars
+{
+    /// <summary>
+    /// How many seconds regular reinforcement beacons take to open their ghost roles.
+    /// </summary>
+    public static readonly CVarDef<float> SlowReinforcementDelay =
+        CVarDef.Create("trauma.slow_reinforcement_delay", 180f, CVar.SERVER);
+
+    /// <summary>
+    /// How many seconds fast reinforcement beacons take to open their ghost roles.
+    /// </summary>
+    public static readonly CVarDef<float> FastReinforcementDelay =
+        CVarDef.Create("trauma.fast_reinforcement_delay", 30f, CVar.SERVER);
+}

--- a/Content.Trauma.Server/Decals/DecalDespawnSystem.cs
+++ b/Content.Trauma.Server/Decals/DecalDespawnSystem.cs
@@ -36,7 +36,7 @@ public sealed class DecalDespawnSystem : EntitySystem
         Subs.CVar(_cfg, TraumaCVars.DecalDespawnLimit, x => _limit = x, true);
         Subs.CVar(_cfg, TraumaCVars.DecalDespawnTime, UpdateDespawnTime, true);
 
-        _buffer = new(_limit!, _despawnTime, _timing);
+        _buffer = new(_limit, _despawnTime, _timing);
     }
 
     public override void Update(float frameTime)

--- a/Content.Trauma.Server/Ghost/DelayedGhostRoleSystem.cs
+++ b/Content.Trauma.Server/Ghost/DelayedGhostRoleSystem.cs
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Server.Ghost.Roles.Components;
+using Content.Shared.GameTicking;
+using Content.Trauma.Common.CCVar;
+using Content.Trauma.Shared.Ghost;
+using Content.Trauma.Shared.Timing;
+using Robust.Shared.Configuration;
+using Robust.Shared.Timing;
+
+namespace Content.Trauma.Server.Ghost;
+
+public sealed class DelayedGhostRoleSystem : EntitySystem
+{
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly EntityQuery<DelayedGhostRoleComponent> _query = default!;
+
+    // yeah this doesn't support persistence, tuff
+    // also 2 separate buffers so there's no need for arbitrary insert, just push at the end of the buffer
+    private TimedRingBuffer<EntityUid> _slow = default!;
+    private TimedRingBuffer<EntityUid> _fast = default!;
+
+    private TimeSpan _slowTime;
+    private TimeSpan _fastTime;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<DelayedGhostRoleComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundRestart);
+
+        Subs.CVar(_cfg, TraumaCVars.SlowReinforcementDelay, UpdateSlowTime, true);
+        Subs.CVar(_cfg, TraumaCVars.FastReinforcementDelay, UpdateFastTime, true);
+
+        // if you can buy that many reinforcements GG
+        _slow = new(64, _slowTime, _timing);
+        _fast = new(16, _fastTime, _timing);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        if (_slow.PopNext(out var uid) || _fast.PopNext(out uid))
+            CreateGhostRole(uid);
+    }
+
+    private void OnMapInit(Entity<DelayedGhostRoleComponent> ent, ref MapInitEvent args)
+    {
+        var buffer = ent.Comp.Fast ? _fast : _slow;
+        if (buffer.Push(ent.Owner, out var old))
+            CreateGhostRole(old); // GG
+    }
+
+    private void OnRoundRestart(RoundRestartCleanupEvent args)
+    {
+        _slow.Reset();
+        _fast.Reset();
+    }
+
+    private void UpdateSlowTime(float seconds)
+    {
+        _slowTime = TimeSpan.FromSeconds(seconds);
+        if (_slow != default)
+            _slow.PopDelay = _slowTime;
+    }
+
+    private void UpdateFastTime(float seconds)
+    {
+        _fastTime = TimeSpan.FromSeconds(seconds);
+        if (_fast != default)
+            _fast.PopDelay = _slowTime;
+    }
+
+    private void CreateGhostRole(EntityUid uid)
+    {
+        if (TerminatingOrDeleted(uid) || !_query.TryComp(uid, out var comp))
+            return;
+
+        var role = EnsureComp<GhostRoleComponent>(uid);
+        // resolving a system and updating every eui 3 times in a row award
+        role.RoleName = comp.Name;
+        role.RoleDescription = comp.Description;
+        role.RoleRules = comp.Rules;
+        role.MindRoles = comp.MindRoles;
+        role.JobProto = comp.Job;
+        RemComp(uid, comp);
+    }
+}

--- a/Content.Trauma.Server/Ghost/DelayedGhostRoleSystem.cs
+++ b/Content.Trauma.Server/Ghost/DelayedGhostRoleSystem.cs
@@ -80,6 +80,7 @@ public sealed class DelayedGhostRoleSystem : EntitySystem
             return;
 
         var role = EnsureComp<GhostRoleComponent>(uid);
+        EnsureComp<GhostTakeoverAvailableComponent>(uid);
         // resolving a system and updating every eui 3 times in a row award
         role.RoleName = comp.Name;
         role.RoleDescription = comp.Description;

--- a/Content.Trauma.Server/Mobs/MobSpamSystem.cs
+++ b/Content.Trauma.Server/Mobs/MobSpamSystem.cs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+using Content.Shared.GameTicking;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Systems;
 using Content.Trauma.Shared.Mobs;
@@ -27,6 +28,7 @@ public sealed class MobSpamSystem : EntitySystem
         _buffer = new(64, DespawnTime, _timing);
 
         SubscribeLocalEvent<MobSpamComponent, MobStateChangedEvent>(OnMobStateChanged);
+        SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundRestart);
     }
 
     public override void Update(float frameTime)
@@ -43,6 +45,11 @@ public sealed class MobSpamSystem : EntitySystem
             return;
 
         QueueDespawn(ent);
+    }
+
+    private void OnRoundRestart(RoundRestartCleanupEvent args)
+    {
+        _buffer.Reset();
     }
 
     private void QueueDespawn(EntityUid uid)

--- a/Content.Trauma.Shared/Ghost/DelayedGhostRoleComponent.cs
+++ b/Content.Trauma.Shared/Ghost/DelayedGhostRoleComponent.cs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Shared.Roles;
+
+namespace Content.Trauma.Shared.Ghost;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class DelayedGhostRoleComponent : Component
+{
+    /// <summary>
+    /// Whether to use FastReinforcementDelay instead of SlowReinforcementDelay.
+    /// </summary>
+    [DataField]
+    public bool Fast;
+
+    /// <summary>
+    /// The name shown on the Ghost Role list
+    /// </summary>
+    [DataField(required: true)]
+    public LocId Name;
+
+    /// <summary>
+    /// The description shown on the Ghost Role list
+    /// </summary>
+    [DataField(required: true)]
+    public LocId Description;
+
+    /// <summary>
+    /// The introductory message shown when trying to take the ghost role/join the raffle
+    /// </summary>
+    [DataField(required: true)]
+    public LocId Rules;
+
+    /// <summary>
+    /// A list of mind roles that will be added to the entity's mind
+    /// </summary>
+    [DataField]
+    public List<EntProtoId> MindRoles = new() { "MindRoleGhostRoleNeutral" };
+
+    /// <summary>
+    /// The prototype ID of the job that will be given to the controlling mind
+    /// </summary>
+    [DataField]
+    public ProtoId<JobPrototype>? Job;
+}

--- a/Content.Trauma.Shared/Timing/TimedRingBuffer.cs
+++ b/Content.Trauma.Shared/Timing/TimedRingBuffer.cs
@@ -7,6 +7,7 @@ namespace Content.Trauma.Shared.Timing;
 /// <summary>
 /// A ringbuffer that stores items in order of a popping timespan.
 /// Trying to add more items than the buffer supports will pop the oldest one.
+/// If used in an entity system it should be <c>Reset</c> when the round restarts to avoid problems.
 /// </summary>
 public sealed class TimedRingBuffer<T>
 {
@@ -126,10 +127,18 @@ public sealed class TimedRingBuffer<T>
     /// </summary>
     public void Reset(int capacity)
     {
-        _offset = 0;
-        Count = 0;
+        Reset();
         if (capacity != Capacity)
             _items = new (TimeSpan, T)[capacity];
+    }
+
+    /// <summary>
+    /// Clear all items without changing the backing array's capacity.
+    /// </summary>
+    public void Reset()
+    {
+        _offset = 0;
+        Count = 0;
     }
 
     // index of the oldest item

--- a/Resources/Locale/en-US/_Trauma/ghost/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/_Trauma/ghost/ghost-role-component.ftl
@@ -14,7 +14,7 @@ ghost-role-information-reinforcement-chemist-name = Station Reinforcement (Chemi
 ghost-role-information-reinforcement-cargo-name = Station Reinforcement (Cargo)
 ghost-role-information-reinforcement-salv-name = Station Reinforcement (Salvage)
 
-ghost-role-information-reinforcement-description = You're a reinforcement sent to the nanotrasen station, transit to the station takes three minutes.
+ghost-role-information-reinforcement-description = You're a reinforcement sent to a nanotrasen station.
 ghost-role-information-DClass-description = The science team wants to use you for its experiments, comply or risk death.
 
 ghost-role-information-facehugger-name = facehugger

--- a/Resources/Prototypes/_Trauma/Entities/Objects/Devices/Reinforcements/reinforcement_beacons.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Objects/Devices/Reinforcements/reinforcement_beacons.yml
@@ -40,13 +40,11 @@
       - !type:PlaySoundBehavior
         sound:
           collection: MetalBreak
-  - type: GhostRole
+  - type: DelayedGhostRole
     description: ghost-role-information-reinforcement-description
     rules: ghost-role-information-nonantagonist-rules
     mindRoles:
     - MindRoleGhostRoleNeutral
-    raffle:
-      settings: reinforcement # TODO: make raffle normal but delay the ghost role opening by a few minutes
   - type: GhostCharacterSpawner
     components:
     - type: IdBind
@@ -62,7 +60,7 @@
   id: ReinforcementBeaconSecurityOfficer
   suffix: Security
   components:
-  - type: GhostRole
+  - type: DelayedGhostRole
     job: SecurityOfficer
     name: ghost-role-information-reinforcement-sec-name
   - type: GhostCharacterSpawner
@@ -80,17 +78,16 @@
   id: ReinforcementBeaconSecurityOfficerFast
   suffix: Security, Fast
   components:
-  - type: GhostRole
+  - type: DelayedGhostRole
+    fast: true
     name: ghost-role-information-reinforcement-fast-sec-name
-    raffle:
-      settings: short
 
 - type: entity
   parent: ReinforcementBeaconSecurityOfficer
   id: ReinforcementBeaconSpecialistOfficerLaser
   suffix: Security, Laser
   components:
-  - type: GhostRole
+  - type: DelayedGhostRole
     name: ghost-role-information-reinforcement-specialist-sec-name
   - type: GhostCharacterSpawner
     components:
@@ -104,7 +101,7 @@
   id: ReinforcementBeaconBartender
   suffix: Bartender
   components:
-  - type: GhostRole
+  - type: DelayedGhostRole
     job: Bartender
     name: ghost-role-information-reinforcement-bartender-name
   - type: GhostCharacterSpawner
@@ -117,7 +114,7 @@
   id: ReinforcementBeaconChef
   suffix: Chef
   components:
-  - type: GhostRole
+  - type: DelayedGhostRole
     job: Chef
     name: ghost-role-information-reinforcement-chef-name
   - type: GhostCharacterSpawner
@@ -130,7 +127,7 @@
   id: ReinforcementBeaconBotanist
   suffix: Botanist
   components:
-  - type: GhostRole
+  - type: DelayedGhostRole
     job: Botanist
     name: ghost-role-information-reinforcement-botanist-name
   - type: GhostCharacterSpawner
@@ -145,7 +142,7 @@
   id: ReinforcementBeaconEngi
   suffix: Engineer
   components:
-  - type: GhostRole
+  - type: DelayedGhostRole
     job: StationEngineer
     name: ghost-role-information-reinforcement-engi-name
   - type: GhostCharacterSpawner
@@ -159,7 +156,7 @@
   id: ReinforcementBeaconAtmos
   suffix: Atmos
   components:
-  - type: GhostRole
+  - type: DelayedGhostRole
     job: AtmosphericTechnician
     name: ghost-role-information-reinforcement-atmos-name
   - type: GhostCharacterSpawner
@@ -174,7 +171,7 @@
   id: ReinforcementBeaconSci
   suffix: Scientist
   components:
-  - type: GhostRole
+  - type: DelayedGhostRole
     job: Scientist
     name: ghost-role-information-reinforcement-sci-name
   - type: GhostCharacterSpawner
@@ -189,7 +186,7 @@
   id: ReinforcementBeaconAssistant
   suffix: Assistant
   components:
-  - type: GhostRole
+  - type: DelayedGhostRole
     job: Passenger
     name: ghost-role-information-reinforcement-assistant-name
   - type: GhostCharacterSpawner
@@ -202,7 +199,7 @@
   id: ReinforcementBeaconDClass
   suffix: D-Class
   components:
-  - type: GhostRole
+  - type: DelayedGhostRole
     name: ghost-role-information-reinforcement-DClass-name
     description: ghost-role-information-DClass-description
     rules: ghost-role-information-freeagent-rules
@@ -220,7 +217,7 @@
   id: ReinforcementBeaconDoctor
   suffix: Medical Doctor
   components:
-  - type: GhostRole
+  - type: DelayedGhostRole
     job: MedicalDoctor
     name: ghost-role-information-reinforcement-doctor-name
   - type: GhostCharacterSpawner
@@ -234,7 +231,7 @@
   id: ReinforcementBeaconChemist
   suffix: Chemist
   components:
-  - type: GhostRole
+  - type: DelayedGhostRole
     job: Chemist
     name: ghost-role-information-reinforcement-chemist-name
   - type: GhostCharacterSpawner
@@ -249,7 +246,7 @@
   id: ReinforcementBeaconCargo
   suffix: Cargo Tech
   components:
-  - type: GhostRole
+  - type: DelayedGhostRole
     job: CargoTechnician
     name: ghost-role-information-reinforcement-cargo-name
   - type: GhostCharacterSpawner
@@ -262,7 +259,7 @@
   id: ReinforcementBeaconSalv
   suffix: Salvage
   components:
-  - type: GhostRole
+  - type: DelayedGhostRole
     job: SalvageSpecialist
     name: ghost-role-information-reinforcement-salv-name
   - type: GhostCharacterSpawner

--- a/Resources/Prototypes/_Trauma/GhostRoleRaffles/settings.yml
+++ b/Resources/Prototypes/_Trauma/GhostRoleRaffles/settings.yml
@@ -1,6 +1,0 @@
-- type: ghostRoleRaffleSettings
-  id: reinforcement
-  settings:
-    initialDuration: 180 #3 minutes
-    joinExtendsDurationBy: 0
-    maxDuration: 180


### PR DESCRIPTION
fuck 3 minute long raffle
resolves #2032

now if you see a ghost role you can just take it

## Media
no ghost role when they spawn
<img width="532" height="233" alt="21:39:17" src="https://github.com/user-attachments/assets/e3f56673-d000-4875-be95-6c09949383c6" />

after the delay (30s / 180s)
<img width="487" height="348" alt="21:39:43" src="https://github.com/user-attachments/assets/9a72dad2-af26-4425-96f0-c787da48b9b0" />


**Changelog**
:cl:
- tweak: Changed crew reinforcement beacons to only open the ghost role after a timer, and have no raffle.