### PR TITLE
Disable the station report announcement

### DIFF
--- a/Content.Trauma.Server/Station/StationReportSystem.cs
+++ b/Content.Trauma.Server/Station/StationReportSystem.cs
@@ -18,7 +18,6 @@ public sealed class StationReportSystem : EntitySystem
     [Dependency] private readonly IConfigurationManager _cfg = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly PaperSystem _paper = default!;
-    [Dependency] private readonly SharedChatSystem _chat = default!;
     [Dependency] private readonly StationTraitsSystem _traits = default!;
 
     private StringBuilder _sb = new();
@@ -52,11 +51,6 @@ public sealed class StationReportSystem : EntitySystem
             {
                 SpawnReport(uid, proto, text);
             }
-
-            // TODO: custom greenshift/threat level announcement
-            _chat.DispatchStationAnnouncement(station,
-                "A summary of the station's situation has been copied and printed to all communications consoles.",
-                "Station Report");
         }
     }
 


### PR DESCRIPTION
## About the PR
The station report no longer makes an announcement when it's sent to the station.

## Why / Balance
We don't need an announcement for something that always happens every round at the exact same time. This is just useless chat spam.

## Technical details
Removed 5 lines

## Media
No

## Requirements
No

## Breaking changes
No

**Changelog**
:cl:
- remove: Removed station report announcement
