### PR TITLE
Un-kill free money but not really

### DIFF
--- a/Content.Trauma.Common/CCVar/TraumaCVars.cs
+++ b/Content.Trauma.Common/CCVar/TraumaCVars.cs
@@ -180,7 +180,7 @@ public sealed partial class TraumaCVars
     /// Minimum number of players for antag summoner to work, to prevent farming money when nobody is even going to take the ghost roles.
     /// </summary>
     public static readonly CVarDef<int> AntagSummonerMinPlayers =
-        CVarDef.Create("trauma.antag_summoner_min_players", 30, CVar.SERVER);
+        CVarDef.Create("trauma.antag_summoner_min_players", 10, CVar.SERVER);
 
     #endregion
 }


### PR DESCRIPTION
## About the PR
Security funding booster now requires only 10 players, down from 30.

## Why / Balance
Deltanedas casually forcing every lowpop round to be a chudshift, and not even making a cl entry. There are, in fact, ghosts at playercounts below 30 (if mostly because of the button's existiance). If HoS wants to risk calling a dragon/colossus/blob on a station with 2 security members, that's completely on them.

At 10 players you're pretty much forced into extended anyway, which is a good thing, because even minor antags can fuck over a station with 10 players. Thus, 10 player limit will remain.

## Technical details
Changed one number

**Changelog**
:cl:
- tweak: Security funding booster can be used on lowpop rounds again, unless there are less than 10 players.
