### PR TITLE
make error webhook use ringbuffer instead of queue

### DIFF
--- a/Content.Trauma.Common/CCVar/TraumaCVars.cs
+++ b/Content.Trauma.Common/CCVar/TraumaCVars.cs
@@ -126,6 +126,14 @@ public sealed partial class TraumaCVars
     public static readonly CVarDef<float> ErrorWebhookDelay =
         CVarDef.Create("trauma.error_webhook_delay", 0.3f, CVar.SERVER);
 
+    /// <summary>
+    /// How many messages can be queued at once.
+    /// If this limit is exceeded the oldest messages get dropped.
+    /// Changing this ingame drops all currently queued messages.
+    /// </summary>
+    public static readonly CVarDef<int> ErrorWebhookLimit =
+        CVarDef.Create("trauma.error_webhook_limit", 64, CVar.SERVER);
+
     #endregion
 
     #region EndCredits

--- a/Content.Trauma.Server/Decals/DecalDespawnSystem.cs
+++ b/Content.Trauma.Server/Decals/DecalDespawnSystem.cs
@@ -4,7 +4,7 @@ using Content.Server.Decals;
 using Content.Shared.GameTicking;
 using Content.Trauma.Common.CCVar;
 using Content.Trauma.Common.Decals;
-using Content.Trauma.Shared.Timing;
+using Content.Trauma.Shared.Utility;
 using Robust.Shared.Configuration;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Utility;

--- a/Content.Trauma.Server/Ghost/DelayedGhostRoleSystem.cs
+++ b/Content.Trauma.Server/Ghost/DelayedGhostRoleSystem.cs
@@ -4,7 +4,7 @@ using Content.Server.Ghost.Roles.Components;
 using Content.Shared.GameTicking;
 using Content.Trauma.Common.CCVar;
 using Content.Trauma.Shared.Ghost;
-using Content.Trauma.Shared.Timing;
+using Content.Trauma.Shared.Utility;
 using Robust.Shared.Configuration;
 using Robust.Shared.Timing;
 

--- a/Content.Trauma.Server/Logging/ErrorWebhookSystem.cs
+++ b/Content.Trauma.Server/Logging/ErrorWebhookSystem.cs
@@ -2,6 +2,7 @@
 
 using Content.Server.Discord;
 using Content.Trauma.Common.CCVar;
+using Content.Trauma.Shared.Utility;
 using Robust.Shared.Configuration;
 using Robust.Shared.Log;
 using Robust.Shared.Timing;
@@ -11,7 +12,7 @@ namespace Content.Trauma.Server.Logging;
 
 /// <summary>
 /// Sends errors to a discord webhook from the server config.
-/// Internally uses a queue to avoid hitting ratelimits as <see cref="DiscordWebhook"/> has no such mechanism.
+/// Internally uses a <see cref="TimedRingBuffer"/> to queue messages and avoid hitting ratelimits as <see cref="DiscordWebhook"/> has no such mechanisms.
 /// </summary>
 public sealed class ErrorWebhookSystem : EntitySystem
 {
@@ -20,20 +21,22 @@ public sealed class ErrorWebhookSystem : EntitySystem
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly ILogManager _log = default!;
 
-    private ErrorWebhookLogHandler _handler = default!;
+    private ErrorWebhookLogHandler _handler = new();
     private bool _enabled;
     private WebhookIdentifier? _identifier;
     private TimeSpan _nextSend;
     private TimeSpan _sendDelay;
+    private int _limit;
 
     public override void Initialize()
     {
         base.Initialize();
 
-        _handler = new ErrorWebhookLogHandler();
-
         Subs.CVar(_cfg, TraumaCVars.ErrorWebhookUrl, UpdateWebhookUrl, true);
         Subs.CVar(_cfg, TraumaCVars.ErrorWebhookDelay, x => _sendDelay = TimeSpan.FromSeconds(x), true);
+        Subs.CVar(_cfg, TraumaCVars.ErrorWebhookLimit, UpdateBufferLimit, true);
+
+        _handler.Buffer = new(_limit);
     }
 
     public override void Shutdown()
@@ -48,17 +51,16 @@ public sealed class ErrorWebhookSystem : EntitySystem
     {
         base.Update(frameTime);
 
-        if (_identifier is not {} identifier || _handler.Messages.Count == 0)
+        if (_identifier is not {} identifier || _handler.Buffer.IsEmpty)
             return; // not enabled or nothing to send
 
         var now = _timing.CurTime;
         if (now < _nextSend)
             return; // on cooldown
 
-        // wait before sending the next message to not get ratelimited
         _nextSend = now + _sendDelay;
 
-        var content = _handler.Messages.Dequeue();
+        _handler.Buffer.Pop(out var content);
         var payload = new WebhookPayload()
         {
             Content = content
@@ -87,6 +89,14 @@ public sealed class ErrorWebhookSystem : EntitySystem
         else
             root.RemoveHandler(_handler);
     }
+
+    private void UpdateBufferLimit(int limit)
+    {
+        _limit = limit;
+        // any queued messages will get dropped if it's changed midgame
+        if (_handler.Buffer != default)
+            _handler.Buffer.Reset(limit);
+    }
 }
 
 public sealed class ErrorWebhookLogHandler : ILogHandler
@@ -101,7 +111,7 @@ public sealed class ErrorWebhookLogHandler : ILogHandler
     /// </summary>
     public const string NetEntitySlop = "Can't resolve \"Robust.Shared.GameObjects.MetaDataComponent\" on entity";
 
-    public Queue<string> Messages = new();
+    public RingBuffer<string> Buffer = default!; // set in Initialize
 
     void ILogHandler.Log(string sawmillName, LogEvent message)
     {
@@ -125,6 +135,7 @@ public sealed class ErrorWebhookLogHandler : ILogHandler
 
         content = $"```\n{content}\n```";
 
-        Messages.Enqueue(content);
+        // if logs are being spammed too fast, oldest messages just get dropped
+        Buffer.Push(content, out _);
     }
 }

--- a/Content.Trauma.Server/Mobs/MobSpamSystem.cs
+++ b/Content.Trauma.Server/Mobs/MobSpamSystem.cs
@@ -4,7 +4,7 @@ using Content.Shared.GameTicking;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Systems;
 using Content.Trauma.Shared.Mobs;
-using Content.Trauma.Shared.Timing;
+using Content.Trauma.Shared.Utility;
 using Robust.Shared.Timing;
 
 namespace Content.Trauma.Shared.Mobs;

--- a/Content.Trauma.Shared/Utility/RingBuffer.cs
+++ b/Content.Trauma.Shared/Utility/RingBuffer.cs
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Content.Trauma.Shared.Utility;
+
+/// <summary>
+/// A ringbuffer that stores items in LIFO fashion, by pushing and popping items.
+/// Trying to add more items than the buffer supports will pop the oldest one.
+/// If used with entity-specific data it should be <c>Reset</c> when the round restarts to avoid problems.
+/// </summary>
+public sealed class RingBuffer<T>
+{
+    private T[] _items;
+
+    private int _offset;
+
+    /// <summary>
+    /// How many items are stored
+    /// </summary>
+    public int Count { get; private set; } = 0;
+
+    /// <summary>
+    /// How many items can be stored.
+    /// </summary>
+    public int Capacity => _items.Length;
+
+    /// <summary>
+    /// True if no items are stored.
+    /// </summary>
+    public bool IsEmpty => Count == 0;
+
+    /// <summary>
+    /// Create a ring buffer with a given capacity.
+    /// </summary>
+    public RingBuffer(int capacity)
+    {
+        _items = new T[capacity];
+    }
+
+    /// <summary>
+    /// Push a new item to the buffer which can be popped after all older items.
+    /// If it is full, it will return the oldest item which has been removed to fit this one.
+    /// The caller must handle the removal of the old item if it's not null.
+    /// </summary>
+    public bool Push(T item, out T old)
+    {
+        var popped = false;
+        old = default!;
+        if (Count == Capacity)
+            popped = Pop(out old);
+
+        _items[NewIndex] = item;
+        Count++;
+        return popped;
+    }
+
+    /// <summary>
+    /// Pops the oldest item, returning false if empty.
+    /// </summary>
+    public bool Pop(out T item)
+    {
+        item = default!;
+        if (Count == 0)
+            return false;
+
+        item = _items[OldIndex];
+        Count--;
+        _offset++;
+        _offset %= Capacity; // prevent it wrapping if it gets spammed
+        return true;
+    }
+
+    /// <summary>
+    /// Gets the oldest item without modifying anything, returning false if empty.
+    /// </summary>
+    public bool Peek(out T item)
+    {
+        item = default!;
+        if (Count == 0)
+            return false;
+
+        item = _items[OldIndex];
+        return true;
+    }
+
+    /// <summary>
+    /// Clear all items and allow changing the backing array to have a new capacity.
+    /// </summary>
+    public void Reset(int capacity)
+    {
+        Reset();
+        if (capacity != Capacity)
+            _items = new T[capacity];
+    }
+
+    /// <summary>
+    /// Clear all items without changing the backing array's capacity.
+    /// </summary>
+    public void Reset()
+    {
+        _offset = 0;
+        Count = 0;
+    }
+
+
+    /// <summary>
+    /// Call a delegate for every item
+    /// </summary>
+    public void VisitItems(Visitor visitor)
+    {
+        for (int i = 0; i < Count; i++)
+        {
+            visitor(ref _items[Index(i)]);
+        }
+    }
+
+    public delegate void Visitor(ref T item);
+
+    // index of the oldest item
+    private int OldIndex => Index(0);
+    // index of where to insert a new item
+    private int NewIndex => Index(Count);
+    // index to the array for a given item number
+    private int Index(int i)
+        => (_offset + i) % Capacity;
+}

--- a/Content.Trauma.Shared/Utility/TimedRingBuffer.cs
+++ b/Content.Trauma.Shared/Utility/TimedRingBuffer.cs
@@ -2,30 +2,32 @@
 
 using Robust.Shared.Timing;
 
-namespace Content.Trauma.Shared.Timing;
+namespace Content.Trauma.Shared.Utility;
 
 /// <summary>
 /// A ringbuffer that stores items in order of a popping timespan.
 /// Trying to add more items than the buffer supports will pop the oldest one.
-/// If used in an entity system it should be <c>Reset</c> when the round restarts to avoid problems.
+/// If used with entity-specific data it should be <c>Reset</c> when the round restarts to avoid problems.
 /// </summary>
 public sealed class TimedRingBuffer<T>
 {
     private IGameTiming _timing;
-
-    private (TimeSpan, T)[] _items;
-
-    private int _offset;
+    private RingBuffer<(TimeSpan, T)> _buffer; // not using inheritance since some semantics change
 
     /// <summary>
     /// How many items are stored
     /// </summary>
-    public int Count { get; private set; } = 0;
+    public int Count => _buffer.Count;
 
     /// <summary>
     /// How many items can be stored.
     /// </summary>
-    public int Capacity => _items.Length;
+    public int Capacity => _buffer.Capacity;
+
+    /// <summary>
+    /// True if no items are stored.
+    /// </summary>
+    public bool IsEmpty => _buffer.IsEmpty;
 
     private TimeSpan _popDelay;
     /// <summary>
@@ -41,19 +43,17 @@ public sealed class TimedRingBuffer<T>
 
             var diff = value - _popDelay;
             _popDelay = value;
-            for (int i = 0; i < Count; i++)
-            {
-                _items[Index(i)].Item1 += diff;
-            }
+            // update old times so they're as if they were using this delay all along. preserves order when pushing new items
+            _buffer.VisitItems((ref pair) => pair.Item1 += diff);
         }
     }
 
     /// <summary>
-    /// Create a ring buffer with a given capacity.
+    /// Create a timed ring buffer with a given capacity and pop delay.
     /// </summary>
     public TimedRingBuffer(int capacity, TimeSpan popDelay, IGameTiming timing)
     {
-        _items = new (TimeSpan, T)[capacity];
+        _buffer = new(capacity);
         _popDelay = popDelay;
         _timing = timing;
     }
@@ -66,14 +66,12 @@ public sealed class TimedRingBuffer<T>
     public bool Push(T item, out T old)
     {
         var popTime = _timing.CurTime + _popDelay;
-        var popped = false;
         old = default!;
-        if (Count == Capacity)
-            popped = PopImmediate(out old);
+        if (!_buffer.Push((popTime, item), out var oldPair))
+            return false;
 
-        _items[NewIndex] = (popTime, item);
-        Count++;
-        return popped;
+        old = oldPair.Item2;
+        return true;
     }
 
     /// <summary>
@@ -82,13 +80,10 @@ public sealed class TimedRingBuffer<T>
     public bool PopImmediate(out T item)
     {
         item = default!;
-        if (Count == 0)
+        if (!_buffer.Pop(out var pair))
             return false;
 
-        item = _items[OldIndex].Item2;
-        Count--;
-        _offset++;
-        _offset %= Capacity; // prevent it wrapping if it gets spammed
+        item = pair.Item2;
         return true;
     }
 
@@ -113,13 +108,9 @@ public sealed class TimedRingBuffer<T>
     /// </summary>
     public bool Peek(out TimeSpan popTime, out T item)
     {
-        popTime = TimeSpan.Zero;
-        item = default!;
-        if (Count == 0)
-            return false;
-
-        (popTime, item) = _items[OldIndex];
-        return true;
+        var valid = _buffer.Peek(out var pair);
+        (popTime, item) = pair;
+        return valid;
     }
 
     /// <summary>
@@ -127,9 +118,7 @@ public sealed class TimedRingBuffer<T>
     /// </summary>
     public void Reset(int capacity)
     {
-        Reset();
-        if (capacity != Capacity)
-            _items = new (TimeSpan, T)[capacity];
+        _buffer.Reset(capacity);
     }
 
     /// <summary>
@@ -137,15 +126,6 @@ public sealed class TimedRingBuffer<T>
     /// </summary>
     public void Reset()
     {
-        _offset = 0;
-        Count = 0;
+        _buffer.Reset();
     }
-
-    // index of the oldest item
-    private int OldIndex => Index(0);
-    // index of where to insert a new item
-    private int NewIndex => Index(Count);
-    // index to the array for a given item number
-    private int Index(int i)
-        => (_offset + i) % Capacity;
 }


### PR DESCRIPTION
queue is slop (despite probably being a ringbuffer internally anyway)
limited errors queue to 64 messages
also added generic RingBuffer for stuff that isnt pop delay like this