### PR TITLE
Nerf nuclear elite hardsuit

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -728,7 +728,7 @@
         Blunt: 0.6 # Trauma, was .55
         Slash: 0.6 # Trauma, was .55
         Piercing: 0.6 # Trauma, was .55
-        Heat: 0.2
+        Heat: 0.35 # Trauma, was .2
         Radiation: 0.01
   - type: Item
     size: Huge


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->
Nerfed elite hardsuit heat damage resistance to be 65% instead of 80%.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Its very hard to fight a nuclear operative that's wearing an elite hardsuit, because most security weaponry deals heat based damage.

## Technical details
<!-- Summary of code changes for easier review. -->
I just changed the resistance number. I don't know if there's anything else that needs to be changed, I was told it's as easy as changing one number.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Breaking changes
<!--
List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
You only need to consider this if there are other PRs open or in the works that would be massively broken by this.
-->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
- tweak: Syndicate elite hardsuit heat resistance is now 65% instead of 80%.
