### PR TITLE
make full fat oil require stirring

### DIFF
--- a/Resources/Prototypes/Recipes/Reactions/cleaning.yml
+++ b/Resources/Prototypes/Recipes/Reactions/cleaning.yml
@@ -1,16 +1,3 @@
-# SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
-# SPDX-FileCopyrightText: 2021 Vera Aguilera Puerto <6766154+Zumorica@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2021 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
-# SPDX-FileCopyrightText: 2023 Boaz1111 <149967078+Boaz1111@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 Psychpsyo <60073468+Psychpsyo@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 TemporalOroboros <TemporalOroboros@gmail.com>
-# SPDX-FileCopyrightText: 2024 dffdff2423 <dffdff2423@gmail.com>
-# SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
-#
-# SPDX-License-Identifier: AGPL-3.0-or-later
-
 - type: reaction
   id: Bleach
   reactants:

--- a/Resources/Prototypes/_Trauma/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Reactions/chemicals.yml
@@ -116,6 +116,7 @@
       amount: 1
   products:
     FullFatOils: 2
+  requiredMixerCategories: [ Stir ] # to not conflict with soap making
 
 - type: reaction
   id: CocainePowderReaction


### PR DESCRIPTION
fixes #2104

:cl:
- fix: Full-fat oil now requires stirring to make, so you can now make bluespace soap again.