### PR TITLE
paint cloned items

### DIFF
--- a/Content.Trauma.Shared/Paint/PaintSystem.cs
+++ b/Content.Trauma.Shared/Paint/PaintSystem.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 using Content.Shared.Charges.Systems;
+using Content.Shared.Cloning;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Nutrition.EntitySystems;
@@ -27,6 +28,7 @@ public sealed class PaintSystem : EntitySystem
 
         SubscribeLocalEvent<PaintVisualsComponent, StackSplitEvent>(OnStackSplit);
         SubscribeLocalEvent<PaintVisualsComponent, PaintAttemptEvent>(OnRepaintAttempt);
+        SubscribeLocalEvent<PaintVisualsComponent, CloningItemEvent>(OnClonePaint);
         SubscribeLocalEvent<RandomSpriteComponent, PaintAttemptEvent>(OnRandomSpritePaintAttempt);
     }
 
@@ -52,14 +54,19 @@ public sealed class PaintSystem : EntitySystem
         if (ent.Comp.Color != args.Color)
             return;
 
-        _popup.PopupClient(Loc.GetString("spray-paint-same"), ent, args.User);
+        _popup.PopupClient("It's already painted that color.", ent, args.User);
         args.Cancelled = true;
+    }
+
+    private void OnClonePaint(Entity<PaintVisualsComponent> ent, ref CloningItemEvent args)
+    {
+        Paint(args.CloneUid, ent.Comp.Color);
     }
 
     private void OnRandomSpritePaintAttempt(Entity<RandomSpriteComponent> ent, ref PaintAttemptEvent args)
     {
         // no painting fish or whatever?
-        _popup.PopupClient(Loc.GetString("spray-paint-fish"), ent, args.User);
+        _popup.PopupClient("It's already colorful enough.", ent, args.User);
         args.Cancelled = true;
     }
 

--- a/Content.Trauma.Shared/Paint/PaintSystem.cs
+++ b/Content.Trauma.Shared/Paint/PaintSystem.cs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 using Content.Shared.Charges.Systems;
-using Content.Shared.Cloning;
+using Content.Shared.Cloning.Events;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Nutrition.EntitySystems;

--- a/Resources/Locale/en-US/_Trauma/paint/paint.ftl
+++ b/Resources/Locale/en-US/_Trauma/paint/paint.ftl
@@ -1,7 +1,5 @@
 spray-paint-closed = Open {THE($can)} first!
 spray-paint-empty = {THE($can)} is empty.
-spray-paint-same = It's already painted that color.
-spray-paint-fish = It's already colorful enough.
 spray-paint-failure = You can't paint {$target}!
 spray-paint-success-user = You give {$target} a new coat of paint.
 spray-paint-success-others = {CAPITALIZE($user)} gives {$target} a new coat of paint.


### PR DESCRIPTION
fixes #2105

:cl:
- fix: Fixed paradox clone items not having paint copied over.