### PR TITLE
Fixed honkops not having a minimum player count

### DIFF
--- a/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
@@ -263,6 +263,8 @@
   parent: BaseNukeopsRule
   id: Honkops
   components:
+  - type: GameRule
+    minPlayers: 20
   - type: RandomMetadata # this generates the random operation name cuz it's cool.
     nameSegments:
     - OperationPrefixHonkops


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->
Made it so that honkops has a 20 player minimum count like nukeops.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
People were asking "why does honkops always happen at low population?" Then I remembered that sometimes I see honkops try to run on my localhost.
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="609" height="610" alt="honkops has no min players" src="https://github.com/user-attachments/assets/b1a16a0b-cefb-4a83-baaa-a734b82a861a" />

Checking that honkops runs on 1 player but nukeops doesn't. 


<img width="591" height="83" alt="image" src="https://github.com/user-attachments/assets/2124aadd-9ae8-4ced-9d44-bfaa3770de4d" />
yep, it worked


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Breaking changes
<!--
List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
You only need to consider this if there are other PRs open or in the works that would be massively broken by this.
-->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: RatherUncreativeName
- fix: Fixed honklear operatives spawning with no minimum playercount.
