### PR TITLE
phone supremacy featuring intercomms

### DIFF
--- a/Resources/Prototypes/radio_channels.yml
+++ b/Resources/Prototypes/radio_channels.yml
@@ -56,9 +56,11 @@
   keycode: ";"
   frequency: 1459
   color: "#2cdb2c"
+  # <Trauma>
   sendWhitelist:
     components:
     - Intercom
+  # </Trauma>
 
 - type: radioChannel
   id: CentCom

--- a/Resources/Prototypes/radio_channels.yml
+++ b/Resources/Prototypes/radio_channels.yml
@@ -56,6 +56,9 @@
   keycode: ";"
   frequency: 1459
   color: "#2cdb2c"
+  sendWhitelist:
+    components:
+    - Intercom
 
 - type: radioChannel
   id: CentCom


### PR DESCRIPTION
## About the PR
https://github.com/Goob-Station/Goob-Station/pull/3637

## Why / Balance
phones are a gimmick, i would rather them have purpose, also makes maints more scary to jobless bums with no departmental radio

## Technical details
3 line yml

## Media
[see bombaster's PR](https://github.com/Goob-Station/Goob-Station/pull/3637)

## Requirements
- [X] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X] I have added media to this PR or it does not require an in-game showcase.

**Changelog**
:cl: Western Electric, ITT, AT&T
- tweak: Headsets are now receive only for the common channel, to send messages use an intercom.
