### PR TITLE
Metal rods now fit in Construction Bags and Borg Grippers

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -726,18 +726,21 @@
         emptyLabel: borg-slot-construction-empty
         whitelist:
           tags:
+          - RodMetal # Trauma - borgs should be able to hold rods
           - ConstructionMaterial
     - hand:
         emptyRepresentative: BorgModuleConstructionMaterialPlaceholder
         emptyLabel: borg-slot-construction-empty
         whitelist:
           tags:
+          - RodMetal # Trauma
           - ConstructionMaterial
     - hand:
         emptyRepresentative: BorgModuleConstructionMaterialPlaceholder
         emptyLabel: borg-slot-construction-empty
         whitelist:
           tags:
+          - RodMetal # Trauma
           - ConstructionMaterial
     - hand:
         emptyRepresentative: DoorElectronics

--- a/Resources/Prototypes/Stacks/other.yml
+++ b/Resources/Prototypes/Stacks/other.yml
@@ -6,12 +6,6 @@
   name: stack-rods
   icon: { sprite: /Textures/Objects/Materials/parts.rsi, state: rods }
   spawn: PartRodMetal1
-  # <Trauma> Fixes rods not fitting in sheet related spaces. (They should >:( )
-  components:
-    - type: Tag
-      tags:
-      - Sheet
-  # </Trauma>
 
 - type: stack
   parent: BaseMediumStack # Trauma

--- a/Resources/Prototypes/Stacks/other.yml
+++ b/Resources/Prototypes/Stacks/other.yml
@@ -6,6 +6,12 @@
   name: stack-rods
   icon: { sprite: /Textures/Objects/Materials/parts.rsi, state: rods }
   spawn: PartRodMetal1
+  # <Trauma> Fixes rods not fitting in sheet related spaces. (They should >:( )
+  components:
+    - type: Tag
+      tags:
+      - Sheet
+  # </Trauma>
 
 - type: stack
   parent: BaseMediumStack # Trauma

--- a/Resources/Prototypes/_NF/Entities/Specific/Engineering/construction_bags.yml
+++ b/Resources/Prototypes/_NF/Entities/Specific/Engineering/construction_bags.yml
@@ -52,7 +52,7 @@
       - CableCoil
       - RawMaterial
       - PartBase
-      - MetalRod # Trauma - Borgs should be able to carry rods.
+      - RodMetal # Trauma - Constructionbags should be able to carry rods.
   - type: Dumpable
   - type: ItemToggle
     soundActivate:

--- a/Resources/Prototypes/_NF/Entities/Specific/Engineering/construction_bags.yml
+++ b/Resources/Prototypes/_NF/Entities/Specific/Engineering/construction_bags.yml
@@ -52,6 +52,7 @@
       - CableCoil
       - RawMaterial
       - PartBase
+      - MetalRod # Trauma - Borgs should be able to carry rods.
   - type: Dumpable
   - type: ItemToggle
     soundActivate:

--- a/Resources/Prototypes/_NF/Entities/Specific/Engineering/construction_bags.yml
+++ b/Resources/Prototypes/_NF/Entities/Specific/Engineering/construction_bags.yml
@@ -52,7 +52,7 @@
       - CableCoil
       - RawMaterial
       - PartBase
-      - RodMetal # Trauma - Constructionbags should be able to carry rods.
+      - RodMetal
   - type: Dumpable
   - type: ItemToggle
     soundActivate:


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
Added the `- RodMetal` tag to the ConstructionBag whitelist and Borg hand module thing

## Why / Balance
It makes it so they fit in construction bags.
Borgs really need this change.

## Technical details
It's 4 lines of yml it's not that hard.
Please correct me if that fucks other stuff up though

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Vanadiom
- fix: Metal rods now finally fit in construction bags and construction borg hands!
