### PR TITLE
mutation refactor and scramble change

### DIFF
--- a/Content.Trauma.Shared/Genetics/Console/GeneticsConsoleSystem.cs
+++ b/Content.Trauma.Shared/Genetics/Console/GeneticsConsoleSystem.cs
@@ -112,7 +112,9 @@ public sealed partial class GeneticsConsoleSystem : EntitySystem
         ent.Comp.NextScramble = now + ent.Comp.ScrambleCooldown;
         DirtyField(ent.AsNullable(), nameof(GeneticsConsoleComponent.NextScramble));
 
-        _mutation.Scramble(mutatable, user: args.Actor, predicted: true);
+        // reset dormant but unactivated mutations and reroll them
+        _mutation.ClearUnusedDormant(mutatable);
+        _mutation.Scramble(mutatable);
         UpdateUI(ent.Owner);
     }
 

--- a/Content.Trauma.Shared/Genetics/Mutations/MutatableComponent.cs
+++ b/Content.Trauma.Shared/Genetics/Mutations/MutatableComponent.cs
@@ -8,7 +8,7 @@ namespace Content.Trauma.Shared.Genetics.Mutations;
 /// Allows an entity to have mutations.
 /// </summary>
 [RegisterComponent, NetworkedComponent, Access(typeof(MutationSystem))]
-[AutoGenerateComponentState]
+[AutoGenerateComponentState(fieldDeltas: true)]
 public sealed partial class MutatableComponent : Component
 {
     /// <summary>

--- a/Content.Trauma.Shared/Genetics/Mutations/MutationSystem.cs
+++ b/Content.Trauma.Shared/Genetics/Mutations/MutationSystem.cs
@@ -90,8 +90,7 @@ public sealed partial class MutationSystem : CommonMutationSystem
         if (_net.IsClient) // no rolling stuff
             return;
 
-        // clear is false, don't clear forced mutations in the yml or from previous polymorph body
-        Scramble(ent, clear: false, automatic: true);
+        AddRandomDormant(ent); // give random dormant mutations
 
         if (ent.Comp.Mutations.Count == 0)
         {
@@ -120,7 +119,7 @@ public sealed partial class MutationSystem : CommonMutationSystem
 
     private void OnDnaScrambled(Entity<MutatableComponent> ent, ref DnaScrambledEvent args)
     {
-        Scramble(ent, predicted: false); // currently it's only raised on server
+        Scramble(ent);
     }
 
     private void MutationAdded(Entity<MutatableComponent> ent, Entity<MutationComponent> mutation, EntityUid? user, bool automatic, bool predicted)
@@ -253,7 +252,7 @@ public sealed partial class MutationSystem : CommonMutationSystem
         {
             comp.Dormant.Add(dormant.ToString());
         }
-        Dirty(mob, comp);
+        DirtyField(mob, comp, nameof(MutatableComponent.Dormant));
         foreach (var id in data.Mutations)
         {
             AddMutation(ent, id.ToString(), automatic: true, predicted: false);
@@ -382,7 +381,7 @@ public sealed partial class MutationSystem : CommonMutationSystem
         var uid = mutEnt.Value;
         Log.Debug($"Added mutation {ToPrettyString(uid)} to {ToPrettyString(ent)}");
         ent.Comp.Mutations[id] = uid;
-        Dirty(ent);
+        DirtyField(ent, ent.Comp, nameof(MutatableComponent.Mutations));
         MutationAdded((ent, ent.Comp), (uid, _query.Comp(uid)), user, automatic, predicted);
         MutateDna(ent, mutation.Difficulty / 4);
         return true;
@@ -469,7 +468,7 @@ public sealed partial class MutationSystem : CommonMutationSystem
 
         // this is done before the events are raised so monkified is removed from the original body properly
         ent.Comp.Mutations.Remove(id);
-        Dirty(ent);
+        DirtyField(ent, ent.Comp, nameof(MutatableComponent.Mutations));
 
         Log.Debug($"Removed mutation {ToPrettyString(mutation)} from {ToPrettyString(ent)}");
         MutationRemoved((ent, ent.Comp), mutation, user, automatic, predicted);
@@ -513,24 +512,42 @@ public sealed partial class MutationSystem : CommonMutationSystem
             PredictedQueueDel(mutation);
         }
         ent.Comp.Mutations.Clear();
+        DirtyField(ent, ent.Comp, nameof(MutatableComponent.Mutations));
 
-        ent.Comp.Dormant.Clear();
-        Dirty(ent);
+        ClearDormant(ent);
     }
 
     /// <summary>
-    /// Add random dormant mutations.
-    /// Optionally removes all active and mutations and dormant mutations beforehand.
-    /// Predicted only applies to clearing, the RNG is not predicted here
-    /// as mispredicts from tick timing or something might be disastrous.
+    /// Removes all dormant mutations from a mob.
     /// </summary>
-    public void Scramble(Entity<MutatableComponent> ent, bool clear = true, EntityUid? user = null, bool automatic = false, bool predicted = false)
+    public void ClearDormant(Entity<MutatableComponent?> ent)
     {
-        if (clear)
-            ClearMutations(ent.AsNullable(), user, automatic, predicted);
+        if (!_mutatableQuery.Resolve(ent, ref ent.Comp) || ent.Comp.Dormant.Count == 0)
+            return;
 
-        // don't scramble existing mutations
-        if (ent.Comp.Mutations.Count > 0)
+        ent.Comp.Dormant.Clear();
+        DirtyField(ent, ent.Comp, nameof(MutatableComponent.Dormant));
+    }
+
+    /// <summary>
+    /// Removes all dormant mutations from a mob which are not activated.
+    /// </summary>
+    public void ClearUnusedDormant(Entity<MutatableComponent> ent)
+    {
+        if (ent.Comp.Dormant.Count == 0)
+            return;
+
+        ent.Comp.Dormant.RemoveAll(id => !ent.Comp.Mutations.ContainsKey(id));
+        DirtyField(ent, ent.Comp, nameof(MutatableComponent.Dormant));
+    }
+
+    /// <summary>
+    /// Add random dormant mutations until there are enough of them.
+    /// Not predicted as mispredicts might be disastrous.
+    /// </summary>
+    public void AddRandomDormant(Entity<MutatableComponent> ent)
+    {
+        if (_net.IsClient)
             return;
 
         // add enough random dormant mutations so there will be enough sequences.
@@ -543,8 +560,15 @@ public sealed partial class MutationSystem : CommonMutationSystem
 
         // don't have dormant mutation as first item
         _random.Shuffle(ent.Comp.Dormant);
-        Dirty(ent);
+        DirtyField(ent, ent.Comp, nameof(MutatableComponent.Dormant));
+    }
 
+    /// <summary>
+    /// DNA scrambling logic for scrambler implant and console scramble button.
+    /// </summary>
+    public void Scramble(Entity<MutatableComponent> ent)
+    {
+        AddRandomDormant(ent);
         MutateDna(ent, rolls: 16);
         RemComp<ScannedGenomeComponent>(ent); // have to rescan it now chud
     }
@@ -559,7 +583,8 @@ public sealed partial class MutationSystem : CommonMutationSystem
         {
             target.Comp.Dormant.Add(dormant);
         }
-        ent.Comp.Dormant.Clear();
+        DirtyField(target, target.Comp, nameof(MutatableComponent.Dormant));
+        ClearDormant(ent.AsNullable());
 
         // transfer the mutation entities
         Log.Debug($"Transferring {ent.Comp.Mutations.Count} mutations from {ToPrettyString(ent)} to {ToPrettyString(target)}");
@@ -573,8 +598,8 @@ public sealed partial class MutationSystem : CommonMutationSystem
         }
         ent.Comp.Mutations.Clear();
 
-        Dirty(ent);
-        Dirty(target);
+        DirtyField(ent, ent.Comp, nameof(MutatableComponent.Mutations));
+        DirtyField(target, target.Comp, nameof(MutatableComponent.Mutations));
     }
 
     /// <summary>
@@ -593,27 +618,26 @@ public sealed partial class MutationSystem : CommonMutationSystem
             builder[n] = _random.Pick(MutationData.ATGC);
         }
 
-        comp.DNA = builder.ToString();
-        Dirty(uid, comp);
-
-        var ev = new GenerateDnaEvent()
-        {
-            Owner = uid,
-            DNA = comp.DNA
-        };
-        RaiseLocalEvent(uid, ref ev);
+        SetDna((uid, comp), builder.ToString());
     }
 
     public string? GetDna(EntityUid uid)
         => _dnaQuery.CompOrNull(uid)?.DNA;
 
-    public void SetDna(EntityUid uid, string dna)
+    public void SetDna(Entity<DnaComponent?> ent, string dna)
     {
-        if (!_dnaQuery.TryComp(uid, out var comp))
+        if (!_dnaQuery.Resolve(ent, ref ent.Comp, false) || ent.Comp.DNA == dna)
             return;
 
-        comp.DNA = dna;
-        Dirty(uid, comp);
+        ent.Comp.DNA = dna;
+        Dirty(ent, ent.Comp);
+
+        var ev = new GenerateDnaEvent()
+        {
+            Owner = ent.Owner,
+            DNA = ent.Comp.DNA
+        };
+        RaiseLocalEvent(ent, ref ev);
     }
 
     /// <summary>
@@ -654,15 +678,17 @@ public sealed partial class MutationSystem : CommonMutationSystem
             }
         }
 
+        if (_removing.Count == 0)
+            return false;
+
         foreach (var id in _removing)
         {
             PredictedQueueDel(ent.Comp.Mutations[id]);
             ent.Comp.Mutations.Remove(id);
         }
 
-        if (_removing.Count > 0)
-            Dirty(ent);
-        return _removing.Count > 0;
+        DirtyField(ent, ent.Comp, nameof(MutatableComponent.Mutations));
+        return true;
     }
 
     /// <summary>
@@ -675,7 +701,7 @@ public sealed partial class MutationSystem : CommonMutationSystem
             return;
 
         ent.Comp.TotalInstability += instability;
-        Dirty(ent);
+        DirtyField(ent, ent.Comp, nameof(MutatableComponent.TotalInstability));
 
         if (!automatic && InstabilityPopup(ent.Comp.TotalInstability) is {} key)
         {

--- a/Content.Trauma.Shared/Genetics/Mutations/MutationSystem.cs
+++ b/Content.Trauma.Shared/Genetics/Mutations/MutationSystem.cs
@@ -119,6 +119,7 @@ public sealed partial class MutationSystem : CommonMutationSystem
 
     private void OnDnaScrambled(Entity<MutatableComponent> ent, ref DnaScrambledEvent args)
     {
+        ClearMutations(ent.Owner, automatic: true, predicted: false); // currently it's only raised on server
         Scramble(ent);
     }
 

--- a/Resources/ServerInfo/_Trauma/Guidebook/Genetics.xml
+++ b/Resources/ServerInfo/_Trauma/Guidebook/Genetics.xml
@@ -44,6 +44,11 @@ Think carefully if you need to give every lowly assistant hulk, you won't have a
 
 To remove mutations instead of using mutadone, you print a cleanser from the storage tab using a disk with the mutation you want to remove. Inject it and the mutation is gone!
 
+# Scrambling DNA
+
+If monkeys are in extra short supply and you are having bad luck, you can use the [bold]Scramble DNA[/bold] button to reroll any dormant mutations the subject has.
+It will receive a lot of damage though, so get some meds.
+
 # Combining
 
 Combining mutations is done with a "catalyst" mutation stored on the current disk, and any mutation the subject already has.


### PR DESCRIPTION
- scramble dna no longer removes active mutations, only unused dormant ones. scrambling a monkey no longer makes it a human 4 free
  dna scrambler implant not changed, still removes all active + dormant mutations
- use field deltas for mutatable state

parity soyface

<img width="979" height="65" alt="18:26:04" src="https://github.com/user-attachments/assets/007eb6fe-7ea6-45f9-ab54-f815929db440" />

:cl:
- fix: Fixed genetics console scramble DNA button removing active mutations like turning monkeys into humans (which also didnt actually scramble the new human's DNA).