### PR TITLE
remove useless skill popups

### DIFF
--- a/Content.Trauma.Shared/Knowledge/Systems/SharedKnowledgeSystem.cs
+++ b/Content.Trauma.Shared/Knowledge/Systems/SharedKnowledgeSystem.cs
@@ -306,12 +306,12 @@ public abstract partial class SharedKnowledgeSystem : CommonKnowledgeSystem
     /// </summary>
     public bool RollForLevelUp(Entity<KnowledgeComponent> ent, EntityUid target)
     {
-        var getMastery = GetMastery(ent.Comp.NetLevel);
-        (int, bool) rollResult = (0, false);
-
         // If we don't have enough experience or level is max, return.
         if (ent.Comp.Experience < ent.Comp.ExperienceCost || ent.Comp.LearnedLevel >= 100)
             return false;
+
+        var oldMastery = GetMastery(ent.Comp.NetLevel);
+        (int, bool) rollResult = (0, false);
 
         // This should roll as many times as experience cached experience.
         int timesToRoll = ent.Comp.Experience / ent.Comp.ExperienceCost;
@@ -327,14 +327,8 @@ public abstract partial class SharedKnowledgeSystem : CommonKnowledgeSystem
         if (ent.Comp.LearnedLevel > 100) // Ensures Level doesn't go above 100.
             ent.Comp.LearnedLevel = 100;
 
-        // Controls client popup whatnot when you level up.
-        if (rollResult.Item2)
-            SkillPopup(Loc.GetString("knowledge-level-epiphany", ("knowledge", Name(ent))), target);
-
-        if (getMastery != GetMastery(ent.Comp.NetLevel) && !rollResult.Item2)
+        if (oldMastery != GetMastery(ent.Comp.NetLevel))
             SkillPopup(Loc.GetString("knowledge-level-up-popup", ("knowledge", Name(ent)), ("mastery", GetMasteryString(ent).ToLower())), target);
-        else if (!rollResult.Item2)
-            SkillPopup(Loc.GetString("knowledge-level-more", ("knowledge", Name(ent))), target);
 
         return true;
     }


### PR DESCRIPTION
now it only has popup when you change mastery

:cl:
- tweak: Removed popup spam about epiphany and shit from skills, nobody cares about getting 1 xp in tau ceti basic.