### PR TITLE
remove theory mastery requirements for almost every recipe

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/clothing.yml
+++ b/Resources/Prototypes/Recipes/Construction/clothing.yml
@@ -97,7 +97,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    BananiumKnowledge: 2
+    BananiumKnowledge: 0
   practical:
     TailoringKnowledge: 1
   # </Trauma>
@@ -111,7 +111,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    BananiumKnowledge: 2
+    BananiumKnowledge: 0
   practical:
     TailoringKnowledge: 1
   # </Trauma>
@@ -125,7 +125,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    BananiumKnowledge: 2
+    BananiumKnowledge: 0
   practical:
     TailoringKnowledge: 1
   # </Trauma>
@@ -139,8 +139,8 @@
   objectType: Item
   # <Trauma>
   theory:
-    FabricationKnowledge: 1
-    ElectronicsKnowledge: 2
+    FabricationKnowledge: 0
+    ElectronicsKnowledge: 1
   # </Trauma>
 
 - type: construction
@@ -178,8 +178,8 @@
   objectType: Item
   # <Trauma>
   theory:
-    FabricationKnowledge: 1
-    ElectronicsKnowledge: 2
+    FabricationKnowledge: 0
+    ElectronicsKnowledge: 1
   # </Trauma>
 
 - type: construction

--- a/Resources/Prototypes/Recipes/Construction/fun.yml
+++ b/Resources/Prototypes/Recipes/Construction/fun.yml
@@ -7,5 +7,5 @@
   objectType: Item
   # <Trauma>
   theory:
-    BananiumKnowledge: 1
+    BananiumKnowledge: 0
   # </Trauma>

--- a/Resources/Prototypes/Recipes/Construction/furniture.yml
+++ b/Resources/Prototypes/Recipes/Construction/furniture.yml
@@ -30,7 +30,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     MetalworkingKnowledge: 1
   # </Trauma>
@@ -48,7 +48,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     MetalworkingKnowledge: 1
   # </Trauma>
@@ -66,7 +66,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     MetalworkingKnowledge: 1
   # </Trauma>
@@ -84,7 +84,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     MetalworkingKnowledge: 1
   # </Trauma>
@@ -102,7 +102,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     MetalworkingKnowledge: 1
   # </Trauma>
@@ -120,7 +120,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     MetalworkingKnowledge: 1
   # </Trauma>
@@ -138,7 +138,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     MetalworkingKnowledge: 1
   # </Trauma>
@@ -192,7 +192,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     CarvingKnowledge: 1
   # </Trauma>
@@ -210,7 +210,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     MechanicsKnowledge: 1
   # </Trauma>
@@ -228,7 +228,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     MetalworkingKnowledge: 1
   # </Trauma>
@@ -246,7 +246,7 @@
   - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   # </Trauma>
 
 - type: construction
@@ -262,7 +262,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     CarvingKnowledge: 1
   # </Trauma>
@@ -281,7 +281,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     TailoringKnowledge: 1
   # </Trauma>
@@ -300,7 +300,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     TailoringKnowledge: 1
   # </Trauma>
@@ -319,7 +319,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     MetalworkingKnowledge: 1
   # </Trauma>
@@ -337,7 +337,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     MetalworkingKnowledge: 1
   # </Trauma>
@@ -355,7 +355,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     MetalworkingKnowledge: 1
   # </Trauma>
@@ -373,7 +373,7 @@
   - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     MetalworkingKnowledge: 1
   # </Trauma>
@@ -391,7 +391,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     MetalworkingKnowledge: 1
   # </Trauma>
@@ -409,7 +409,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     MetalworkingKnowledge: 1
   # </Trauma>
@@ -427,7 +427,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     MetalworkingKnowledge: 1
   # </Trauma>
@@ -463,7 +463,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     TailoringKnowledge: 2
   # </Trauma>
@@ -482,7 +482,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     TailoringKnowledge: 2
   # </Trauma>
@@ -501,7 +501,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     TailoringKnowledge: 2
   # </Trauma>
@@ -520,7 +520,7 @@
   - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     TailoringKnowledge: 2
   # </Trauma>
@@ -539,7 +539,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     TailoringKnowledge: 2
   # </Trauma>
@@ -558,7 +558,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     TailoringKnowledge: 2
   # </Trauma>
@@ -577,7 +577,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     TailoringKnowledge: 2
   # </Trauma>
@@ -596,7 +596,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     FurnitureKnowledge: 2
   # </Trauma>
@@ -615,7 +615,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     FurnitureKnowledge: 2
   # </Trauma>
@@ -634,7 +634,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     FurnitureKnowledge: 2
   # </Trauma>
@@ -653,7 +653,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     FurnitureKnowledge: 2
   # </Trauma>
@@ -671,7 +671,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1 # bend metal thats it
+    FurnitureKnowledge: 0
   practical:
     MetalworkingKnowledge: 1
   # </Trauma>
@@ -689,7 +689,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     CarvingKnowledge: 1
   # </Trauma>
@@ -708,7 +708,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
     InfrastructureKnowledge: 0
   practical:
     MechanicsKnowledge: 1
@@ -728,7 +728,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     TailoringKnowledge: 1
   # </Trauma>
@@ -746,7 +746,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
     FirstAidKnowledge: 0 # :)
   practical:
     TailoringKnowledge: 1
@@ -765,7 +765,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     TailoringKnowledge: 1
     CarvingKnowledge: 1
@@ -784,7 +784,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     CarvingKnowledge: 1
   # </Trauma>
@@ -803,7 +803,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     MetalworkingKnowledge: 1
   # </Trauma>
@@ -822,9 +822,9 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    CookingKnowledge: 1
-    FabricationKnowledge: 1
-    FurnitureKnowledge: 1
+    CookingKnowledge: 0
+    FabricationKnowledge: 0
+    FurnitureKnowledge: 0
   # </Trauma>
 
 - type: construction
@@ -856,7 +856,7 @@
   canBuildInImpassable: true
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     TailoringKnowledge: 1
   # </Trauma>
@@ -873,7 +873,7 @@
   canBuildInImpassable: true
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     TailoringKnowledge: 1
   # </Trauma>
@@ -890,7 +890,7 @@
   canBuildInImpassable: true
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     TailoringKnowledge: 1
   # </Trauma>
@@ -907,7 +907,7 @@
   canBuildInImpassable: true
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     TailoringKnowledge: 1
   # </Trauma>
@@ -924,7 +924,7 @@
   canBuildInImpassable: true
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     TailoringKnowledge: 1
   # </Trauma>
@@ -941,7 +941,7 @@
   canBuildInImpassable: true
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     TailoringKnowledge: 1
   # </Trauma>
@@ -958,7 +958,7 @@
   canBuildInImpassable: true
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     TailoringKnowledge: 1
   # </Trauma>
@@ -975,7 +975,7 @@
   canBuildInImpassable: true
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     TailoringKnowledge: 1
   # </Trauma>
@@ -992,7 +992,7 @@
   canBuildInImpassable: true
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     TailoringKnowledge: 1
   # </Trauma>
@@ -1009,7 +1009,7 @@
   canBuildInImpassable: true
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     TailoringKnowledge: 1
   # </Trauma>
@@ -1027,7 +1027,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     CarvingKnowledge: 1
   # </Trauma>
@@ -1046,7 +1046,7 @@
     - !type:WallmountCondition
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     CarvingKnowledge: 1
   # </Trauma>
@@ -1065,7 +1065,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     CarvingKnowledge: 2
   # </Trauma>

--- a/Resources/Prototypes/Recipes/Construction/lighting.yml
+++ b/Resources/Prototypes/Recipes/Construction/lighting.yml
@@ -7,7 +7,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    FabricationKnowledge: 1
+    FabricationKnowledge: 0
   practical:
     ElectronicsKnowledge: 1
   # </Trauma>
@@ -21,7 +21,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    FabricationKnowledge: 1
+    FabricationKnowledge: 0
   practical:
     ElectronicsKnowledge: 1
   # </Trauma>
@@ -35,7 +35,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    FabricationKnowledge: 1
+    FabricationKnowledge: 0
   practical:
     ElectronicsKnowledge: 1
   # </Trauma>
@@ -49,7 +49,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    FabricationKnowledge: 1
+    FabricationKnowledge: 0
   practical:
     ElectronicsKnowledge: 1
   # </Trauma>
@@ -63,7 +63,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    FabricationKnowledge: 1
+    FabricationKnowledge: 0
   practical:
     ElectronicsKnowledge: 1
   # </Trauma>
@@ -77,7 +77,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    FabricationKnowledge: 1
+    FabricationKnowledge: 0
   practical:
     ElectronicsKnowledge: 1
   # </Trauma>
@@ -91,7 +91,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    FabricationKnowledge: 1
+    FabricationKnowledge: 0
   practical:
     ElectronicsKnowledge: 1
   # </Trauma>
@@ -105,7 +105,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    FabricationKnowledge: 1
+    FabricationKnowledge: 0
   practical:
     ElectronicsKnowledge: 1
   # </Trauma>
@@ -119,7 +119,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    FabricationKnowledge: 1
+    FabricationKnowledge: 0
   practical:
     ElectronicsKnowledge: 1
   # </Trauma>
@@ -133,7 +133,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    FabricationKnowledge: 1
+    FabricationKnowledge: 0
   practical:
     ElectronicsKnowledge: 1
   # </Trauma>
@@ -147,7 +147,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    FabricationKnowledge: 1
+    FabricationKnowledge: 0
   practical:
     ElectronicsKnowledge: 1
   # </Trauma>
@@ -161,7 +161,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    FabricationKnowledge: 1
+    FabricationKnowledge: 0
   practical:
     ElectronicsKnowledge: 1
   # </Trauma>
@@ -175,7 +175,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    FabricationKnowledge: 1
+    FabricationKnowledge: 0
   practical:
     ElectronicsKnowledge: 1
   # </Trauma>
@@ -189,7 +189,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    FabricationKnowledge: 1
+    FabricationKnowledge: 0
   practical:
     ElectronicsKnowledge: 1
   # </Trauma>
@@ -203,7 +203,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    FabricationKnowledge: 1
+    FabricationKnowledge: 0
   practical:
     ElectronicsKnowledge: 1
   # </Trauma>
@@ -217,7 +217,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    FabricationKnowledge: 1
+    FabricationKnowledge: 0
   practical:
     ElectronicsKnowledge: 1
   # </Trauma>

--- a/Resources/Prototypes/Recipes/Construction/machines.yml
+++ b/Resources/Prototypes/Recipes/Construction/machines.yml
@@ -41,9 +41,8 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    ElectronicsKnowledge: 1
-  practical:
-    ElectronicsKnowledge: 2
+    ElectronicsKnowledge: 0
+  useQuality: false
   # </Trauma>
 
 - type: construction
@@ -61,9 +60,8 @@
   hide: true #TODO: Fix the lightswitch, issue #34659. Until then, keep hidden so people don't build it and get confused.
   # <Trauma>
   theory:
-    ElectronicsKnowledge: 1
-  practical:
-    ElectronicsKnowledge: 2
+    ElectronicsKnowledge: 0
+  useQuality: false
   # </Trauma>
 
 - type: construction
@@ -80,9 +78,8 @@
     - !type:WallmountCondition
   # <Trauma>
   theory:
-    ElectronicsKnowledge: 1
-  practical:
-    ElectronicsKnowledge: 2
+    ElectronicsKnowledge: 0
+  useQuality: false
   # </Trauma>
 
 - type: construction
@@ -100,8 +97,7 @@
   # <Trauma>
   theory:
     ElectronicsKnowledge: 0 # most basic signal source
-  practical:
-    ElectronicsKnowledge: 2
+  useQuality: false
   # </Trauma>
 
 - type: construction
@@ -121,8 +117,7 @@
   # <Trauma>
   theory:
     ElectronicsKnowledge: 1
-  practical:
-    ElectronicsKnowledge: 2
+  useQuality: false
   # </Trauma>
 
 - type: construction
@@ -141,8 +136,7 @@
   # <Trauma>
   theory:
     ElectronicsKnowledge: 1
-  practical:
-    ElectronicsKnowledge: 2
+  useQuality: false
   # </Trauma>
 
 - type: construction
@@ -161,6 +155,5 @@
   # <Trauma>
   theory:
     ElectronicsKnowledge: 0
-  practical:
-    ElectronicsKnowledge: 2
+  useQuality: false
   # </Trauma>

--- a/Resources/Prototypes/Recipes/Construction/materials.yml
+++ b/Resources/Prototypes/Recipes/Construction/materials.yml
@@ -9,8 +9,6 @@
   theory: # TODO should reqire tools to make
     MaterialsKnowledge: 0
   useQuality: false
-  practical:
-    MetalworkingKnowledge: 1
   # </Trauma>
 
 - type: construction
@@ -22,7 +20,7 @@
   objectType: Item
   # <Trauma>
   theory: # TODO should reqire tools to make
-    MaterialsKnowledge: 1
+    MaterialsKnowledge: 0
   useQuality: false
   # </Trauma>
 
@@ -35,10 +33,8 @@
   objectType: Item
   # <Trauma>
   theory: # TODO should reqire tools to make
-    MaterialsKnowledge: 1
+    MaterialsKnowledge: 0
   useQuality: false
-  practical:
-    MetalworkingKnowledge: 1
   # </Trauma>
 
 - type: construction
@@ -50,7 +46,7 @@
   objectType: Item
   # <Trauma>
   theory: # TODO should reqire tools to make
-    MaterialsKnowledge: 1
+    MaterialsKnowledge: 0
   useQuality: false
   # </Trauma>
 
@@ -63,10 +59,8 @@
   objectType: Item
   # <Trauma>
   theory: # TODO should reqire tools to make
-    MaterialsKnowledge: 1
+    MaterialsKnowledge: 0
   useQuality: false
-  practical:
-    MetalworkingKnowledge: 1
   # </Trauma>
 
 - type: construction
@@ -78,10 +72,8 @@
   objectType: Item
   # <Trauma>
   theory: # TODO should reqire tools to make
-    MaterialsKnowledge: 1
+    MaterialsKnowledge: 0
   useQuality: false
-  practical:
-    MetalworkingKnowledge: 1
   # </Trauma>
 
 - type: construction
@@ -93,10 +85,8 @@
   objectType: Item
   # <Trauma>
   theory: # TODO should reqire tools to make
-    MaterialsKnowledge: 1
+    MaterialsKnowledge: 0
   useQuality: false
-  practical:
-    MetalworkingKnowledge: 1
   # </Trauma>
 
 # <Trauma> remove durathread handcraft
@@ -107,11 +97,6 @@
 #  targetNode: MaterialDurathread
 #  category: construction-category-materials
 #  objectType: Item
-#  # <Trauma>
-#  theory: # TODO should reqire tools to make
-#    MaterialsKnowledge: 2
-#  useQuality: false
-#  # </Trauma>
 # </Trauma>
 
 - type: construction
@@ -123,7 +108,7 @@
   objectType: Item
   # <Trauma>
   theory: # TODO should reqire tools to make
-    MaterialsKnowledge: 1
+    MaterialsKnowledge: 0
   useQuality: false
   # </Trauma>
 
@@ -136,10 +121,8 @@
   objectType: Item
   # <Trauma>
   theory: # TODO should reqire tools to make
-    MaterialsKnowledge: 1
+    MaterialsKnowledge: 0
   useQuality: false
-  practical:
-    MetalworkingKnowledge: 1
   # </Trauma>
 
 - type: construction
@@ -151,10 +134,8 @@
   objectType: Item
   # <Trauma>
   theory: # TODO should reqire tools to make
-    MaterialsKnowledge: 1
+    MaterialsKnowledge: 0
   useQuality: false
-  practical:
-    MetalworkingKnowledge: 1
   # </Trauma>
 
 - type: construction
@@ -166,8 +147,6 @@
   objectType: Item
   # <Trauma>
   theory: # TODO should reqire tools to make
-    MaterialsKnowledge: 1
+    MaterialsKnowledge: 0
   useQuality: false
-  practical:
-    MetalworkingKnowledge: 1
   # </Trauma>

--- a/Resources/Prototypes/Recipes/Construction/storage.yml
+++ b/Resources/Prototypes/Recipes/Construction/storage.yml
@@ -30,7 +30,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     MetalworkingKnowledge: 2
   # </Trauma>
@@ -67,7 +67,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     CarvingKnowledge: 1
   # </Trauma>
@@ -119,7 +119,7 @@
     - !type:WallmountCondition
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     MetalworkingKnowledge: 1
   # </Trauma>
@@ -137,7 +137,7 @@
     - !type:WallmountCondition
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     CarvingKnowledge: 1
   # </Trauma>
@@ -154,7 +154,7 @@
     - !type:WallmountCondition
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     MetalworkingKnowledge: 1
   # </Trauma>
@@ -171,7 +171,7 @@
     - !type:WallmountCondition
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     MetalworkingKnowledge: 1
   # </Trauma>
@@ -189,7 +189,7 @@
     - !type:WallmountCondition
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     CarvingKnowledge: 1
   # </Trauma>
@@ -206,7 +206,7 @@
     - !type:WallmountCondition
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     MetalworkingKnowledge: 1
   # </Trauma>
@@ -223,7 +223,7 @@
     - !type:WallmountCondition
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     MetalworkingKnowledge: 1
   # </Trauma>

--- a/Resources/Prototypes/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/Recipes/Construction/structures.yml
@@ -52,7 +52,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    WallsKnowledge: 1
+    WallsKnowledge: 0
     FabricationKnowledge: 0
   practical:
     MetalworkingKnowledge: 2
@@ -93,7 +93,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    WallsKnowledge: 1
+    WallsKnowledge: 0
     FabricationKnowledge: 0
   practical:
     MetalworkingKnowledge: 2
@@ -113,7 +113,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    WallsKnowledge: 1
+    WallsKnowledge: 0
     FabricationKnowledge: 0
   practical:
     MetalworkingKnowledge: 2
@@ -133,7 +133,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    WallsKnowledge: 1
+    WallsKnowledge: 0
     FabricationKnowledge: 1
   practical:
     WallsKnowledge: 1 # it's just hammering wood together
@@ -153,7 +153,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    WallsKnowledge: 1
+    WallsKnowledge: 0
     FabricationKnowledge: 0
   practical:
     MetalworkingKnowledge: 2
@@ -173,7 +173,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    WallsKnowledge: 1
+    WallsKnowledge: 0
     FabricationKnowledge: 0
   practical:
     MetalworkingKnowledge: 2
@@ -193,7 +193,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    WallsKnowledge: 1
+    WallsKnowledge: 0
   # </Trauma>
 
 - type: construction
@@ -210,7 +210,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    WallsKnowledge: 1
+    WallsKnowledge: 0
     FabricationKnowledge: 0
   practical:
     MetalworkingKnowledge: 2
@@ -250,8 +250,8 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    WallsKnowledge: 2
-    FabricationKnowledge: 2
+    WallsKnowledge: 0
+    FabricationKnowledge: 0
   practical:
     MetalworkingKnowledge: 2
   # </Trauma>
@@ -271,8 +271,8 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    WallsKnowledge: 2
-    FabricationKnowledge: 2
+    WallsKnowledge: 0
+    FabricationKnowledge: 0
   practical:
     MetalworkingKnowledge: 2
   # </Trauma>
@@ -291,8 +291,8 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    WallsKnowledge: 1
-    BananiumKnowledge: 2
+    WallsKnowledge: 0
+    BananiumKnowledge: 0
   # </Trauma>
 
 - type: construction
@@ -309,7 +309,7 @@
   - !type:TileNotBlocked
   # <Trauma>
   theory:
-    WallsKnowledge: 1
+    WallsKnowledge: 0
   # </Trauma>
 
 - type: construction
@@ -326,7 +326,7 @@
   canRotate: false
   # <Trauma>
   theory:
-    WallsKnowledge: 1
+    WallsKnowledge: 0
   # </Trauma>
 
 - type: construction
@@ -380,7 +380,7 @@
   placementMode: SnapgridCenter
   # <Trauma>
   theory:
-    WallsKnowledge: 1 # diagonal is harder to make
+    WallsKnowledge: 0
   practical:
     MetalworkingKnowledge: 1
   # </Trauma>
@@ -398,7 +398,7 @@
   placementMode: SnapgridCenter
   # <Trauma>
   theory:
-    WallsKnowledge: 1 # diagonal is harder to make
+    WallsKnowledge: 0
   practical:
     MetalworkingKnowledge: 1
   # </Trauma>
@@ -418,7 +418,7 @@
   canRotate: false
   # <Trauma>
   theory:
-    WindowsKnowledge: 1
+    WindowsKnowledge: 0
   practical:
     FabricationKnowledge: 1
   # </Trauma>
@@ -458,7 +458,7 @@
   canRotate: false
   # <Trauma>
   theory:
-    WindowsKnowledge: 1
+    WindowsKnowledge: 0
   practical:
     FabricationKnowledge: 1
   # </Trauma>
@@ -478,7 +478,7 @@
   placementMode: SnapgridCenter
   # <Trauma>
   theory:
-    WindowsKnowledge: 1
+    WindowsKnowledge: 0
   practical:
     FabricationKnowledge: 1
   # </Trauma>
@@ -498,7 +498,7 @@
   canRotate: false
   # <Trauma>
   theory:
-    WindowsKnowledge: 1
+    WindowsKnowledge: 0
   practical:
     FabricationKnowledge: 1
   # </Trauma>
@@ -518,7 +518,7 @@
   canRotate: false
   # <Trauma>
   theory:
-    WindowsKnowledge: 1
+    WindowsKnowledge: 0
   practical:
     FabricationKnowledge: 1
   # </Trauma>
@@ -538,7 +538,7 @@
   placementMode: SnapgridCenter
   # <Trauma>
   theory:
-    WindowsKnowledge: 1
+    WindowsKnowledge: 0
   practical:
     FabricationKnowledge: 1
   # </Trauma>
@@ -558,7 +558,7 @@
   canRotate: false
   # <Trauma>
   theory:
-    WindowsKnowledge: 1
+    WindowsKnowledge: 0
   practical:
     FabricationKnowledge: 1
   # </Trauma>
@@ -578,7 +578,7 @@
   canRotate: false
   # <Trauma>
   theory:
-    WindowsKnowledge: 1
+    WindowsKnowledge: 0
   practical:
     FabricationKnowledge: 2
   # </Trauma>
@@ -598,7 +598,7 @@
   canRotate: false
   # <Trauma>
   theory:
-    WindowsKnowledge: 2
+    WindowsKnowledge: 0
   practical:
     FabricationKnowledge: 2
   # </Trauma>
@@ -618,7 +618,7 @@
   placementMode: SnapgridCenter
   # <Trauma>
   theory:
-    WindowsKnowledge: 1
+    WindowsKnowledge: 0
   practical:
     FabricationKnowledge: 2
   # </Trauma>
@@ -638,7 +638,7 @@
   placementMode: SnapgridCenter
   # <Trauma>
   theory:
-    WindowsKnowledge: 1
+    WindowsKnowledge: 0
   practical:
     FabricationKnowledge: 2
   # </Trauma>
@@ -753,7 +753,7 @@
   canRotate: false
   # <Trauma>
   theory:
-    WindowsKnowledge: 1
+    WindowsKnowledge: 0
   practical:
     FabricationKnowledge: 1
   # </Trauma>
@@ -773,7 +773,7 @@
   canRotate: false
   # <Trauma>
   theory:
-    WindowsKnowledge: 1
+    WindowsKnowledge: 0
   practical:
     FabricationKnowledge: 2
   # </Trauma>
@@ -793,7 +793,7 @@
   placementMode: SnapgridCenter
   # <Trauma>
   theory:
-    WindowsKnowledge: 1
+    WindowsKnowledge: 0
   practical:
     FabricationKnowledge: 1
   # </Trauma>
@@ -813,7 +813,7 @@
   placementMode: SnapgridCenter
   # <Trauma>
   theory:
-    WindowsKnowledge: 1
+    WindowsKnowledge: 0
   practical:
     FabricationKnowledge: 2
   # </Trauma>
@@ -832,7 +832,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    AirlocksKnowledge: 1
+    AirlocksKnowledge: 0
   practical:
     MetalworkingKnowledge: 2
   # </Trauma>
@@ -851,7 +851,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    AirlocksKnowledge: 1
+    AirlocksKnowledge: 0
   practical:
     MetalworkingKnowledge: 2
   # </Trauma>
@@ -870,7 +870,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    AirlocksKnowledge: 1
+    AirlocksKnowledge: 0
   practical:
     MetalworkingKnowledge: 2
   # </Trauma>
@@ -888,7 +888,7 @@
   - !type:TileNotBlocked
   # <Trauma>
   theory:
-    AirlocksKnowledge: 1
+    AirlocksKnowledge: 0
   practical:
     MetalworkingKnowledge: 3
   # </Trauma>
@@ -904,7 +904,7 @@
   canBuildInImpassable: true
   # <Trauma>
   theory:
-    AirlocksKnowledge: 1
+    AirlocksKnowledge: 0
   practical:
     MetalworkingKnowledge: 2
   # </Trauma>
@@ -920,7 +920,7 @@
   canBuildInImpassable: true
   # <Trauma>
   theory:
-    AirlocksKnowledge: 1
+    AirlocksKnowledge: 0
   practical:
     MetalworkingKnowledge: 2
   # </Trauma>
@@ -936,7 +936,7 @@
   canBuildInImpassable: true
   # <Trauma>
   theory:
-    AirlocksKnowledge: 1
+    AirlocksKnowledge: 0
   practical:
     MetalworkingKnowledge: 2
   # </Trauma>
@@ -952,7 +952,7 @@
   canBuildInImpassable: true
   # <Trauma>
   theory:
-    AirlocksKnowledge: 2
+    AirlocksKnowledge: 0
   practical:
     MetalworkingKnowledge: 3
   # </Trauma>
@@ -975,7 +975,7 @@
   canBuildInImpassable: false
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   useQuality: false
   # </Trauma>
 
@@ -996,7 +996,7 @@
   canBuildInImpassable: false
   # <Trauma>
   theory:
-    BananiumKnowledge: 2
+    BananiumKnowledge: 0
   useQuality: false
   # </Trauma>
 
@@ -1032,7 +1032,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     CarvingKnowledge: 2
   # </Trauma>
@@ -1126,7 +1126,7 @@
   - !type:TileNotBlocked
   # <Trauma>
   theory:
-    WallsKnowledge: 1
+    WallsKnowledge: 0
   practical:
     MetalworkingKnowledge: 1
   # </Trauma>
@@ -1145,7 +1145,7 @@
   - !type:TileNotBlocked
   # <Trauma>
   theory:
-    WallsKnowledge: 1
+    WallsKnowledge: 0
   practical:
     MetalworkingKnowledge: 1
   # </Trauma>
@@ -1164,7 +1164,7 @@
   - !type:TileNotBlocked
   # <Trauma>
   theory:
-    WallsKnowledge: 1
+    WallsKnowledge: 0
   practical:
     MetalworkingKnowledge: 1
   # </Trauma>
@@ -1182,7 +1182,7 @@
   - !type:TileNotBlocked
   # <Trauma>
   theory:
-    WallsKnowledge: 1
+    WallsKnowledge: 0
   practical:
     MetalworkingKnowledge: 1
   # </Trauma>
@@ -1201,7 +1201,7 @@
   - !type:TileNotBlocked
   # <Trauma>
   theory:
-    WallsKnowledge: 1
+    WallsKnowledge: 0
   practical:
     CarvingKnowledge: 1
   # </Trauma>
@@ -1220,7 +1220,7 @@
   - !type:TileNotBlocked
   # <Trauma>
   theory:
-    WallsKnowledge: 1
+    WallsKnowledge: 0
   practical:
     CarvingKnowledge: 1
   # </Trauma>
@@ -1239,7 +1239,7 @@
   - !type:TileNotBlocked
   # <Trauma>
   theory:
-    WallsKnowledge: 1
+    WallsKnowledge: 0
   practical:
     CarvingKnowledge: 1
   # </Trauma>
@@ -1258,7 +1258,7 @@
   - !type:TileNotBlocked
   # <Trauma>
   theory:
-    WallsKnowledge: 1
+    WallsKnowledge: 0
   practical:
     CarvingKnowledge: 1
   # </Trauma>
@@ -1276,7 +1276,7 @@
   - !type:TileNotBlocked
   # <Trauma>
   theory:
-    WallsKnowledge: 1
+    WallsKnowledge: 0
   practical:
     CarvingKnowledge: 1
   # </Trauma>
@@ -1295,7 +1295,7 @@
   - !type:TileNotBlocked
   # <Trauma>
   theory:
-    WallsKnowledge: 1
+    WallsKnowledge: 0
   practical:
     CarvingKnowledge: 1
   # </Trauma>
@@ -1314,7 +1314,7 @@
   - !type:TileNotBlocked
   # <Trauma>
   theory:
-    WallsKnowledge: 1
+    WallsKnowledge: 0
   practical:
     CarvingKnowledge: 1
   # </Trauma>
@@ -1333,7 +1333,7 @@
   - !type:TileNotBlocked
   # <Trauma>
   theory:
-    WallsKnowledge: 1
+    WallsKnowledge: 0
   practical:
     CarvingKnowledge: 1
   # </Trauma>
@@ -1352,7 +1352,7 @@
   - !type:TileNotBlocked
   # <Trauma>
   theory:
-    WallsKnowledge: 1
+    WallsKnowledge: 0
   practical:
     CarvingKnowledge: 1
   # </Trauma>
@@ -1371,7 +1371,7 @@
   - !type:TileNotBlocked
   # <Trauma>
   theory:
-    WallsKnowledge: 1
+    WallsKnowledge: 0
   practical:
     CarvingKnowledge: 1
   # </Trauma>
@@ -1390,7 +1390,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    AirlocksKnowledge: 1
+    AirlocksKnowledge: 0
   practical:
     MechanicsKnowledge: 2
   # </Trauma>
@@ -1408,7 +1408,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    AirlocksKnowledge: 1
+    AirlocksKnowledge: 0
   practical:
     MechanicsKnowledge: 2
   # </Trauma>
@@ -1427,7 +1427,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    AirlocksKnowledge: 1
+    AirlocksKnowledge: 0
   practical:
     MechanicsKnowledge: 2
   # </Trauma>
@@ -1446,7 +1446,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    AirlocksKnowledge: 1
+    AirlocksKnowledge: 0
   practical:
     MechanicsKnowledge: 2
   # </Trauma>
@@ -1465,7 +1465,7 @@
   - !type:TileNotBlocked
   # <Trauma>
   theory:
-    AirlocksKnowledge: 1
+    AirlocksKnowledge: 0
   practical:
     MechanicsKnowledge: 2
   # </Trauma>
@@ -1485,7 +1485,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    AirlocksKnowledge: 1
+    AirlocksKnowledge: 0
   practical:
     MechanicsKnowledge: 2
   # </Trauma>
@@ -1503,8 +1503,8 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    WindowsKnowledge: 1
-    AirlocksKnowledge: 1
+    WindowsKnowledge: 0
+    AirlocksKnowledge: 0
   practical:
     MechanicsKnowledge: 2
   # </Trauma>
@@ -1522,8 +1522,8 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    WindowsKnowledge: 1
-    AirlocksKnowledge: 1
+    WindowsKnowledge: 0
+    AirlocksKnowledge: 0
   practical:
     MechanicsKnowledge: 2
   # </Trauma>
@@ -1541,8 +1541,8 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    WindowsKnowledge: 1
-    AirlocksKnowledge: 1
+    WindowsKnowledge: 0
+    AirlocksKnowledge: 0
   practical:
     MechanicsKnowledge: 2
   # </Trauma>
@@ -1564,7 +1564,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    ElectronicsKnowledge: 1
+    ElectronicsKnowledge: 0
   useQuality: false
   # </Trauma>
 
@@ -1583,7 +1583,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    ElectronicsKnowledge: 1
+    ElectronicsKnowledge: 0
   useQuality: false
   # </Trauma>
 
@@ -1601,7 +1601,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    ElectronicsKnowledge: 1
+    ElectronicsKnowledge: 0
   useQuality: false
   # </Trauma>
 
@@ -1619,7 +1619,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    ElectronicsKnowledge: 1
+    ElectronicsKnowledge: 0
   useQuality: false
   # </Trauma>
 
@@ -1637,7 +1637,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    ElectronicsKnowledge: 1
+    ElectronicsKnowledge: 0
   useQuality: false
   # </Trauma>
 
@@ -1655,7 +1655,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    ElectronicsKnowledge: 0 # This lets it train elcetronics
+    ElectronicsKnowledge: 0 # This lets it train electronics
   useQuality: false
   # </Trauma>
 
@@ -1672,7 +1672,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    DoorsKnowledge: 1
+    DoorsKnowledge: 0
   practical:
     MetalworkingKnowledge: 2
   # </Trauma>
@@ -1708,7 +1708,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    DoorsKnowledge: 1
+    DoorsKnowledge: 0
   practical:
     MetalworkingKnowledge: 2
   # </Trauma>
@@ -1726,7 +1726,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    DoorsKnowledge: 1
+    DoorsKnowledge: 0
   practical:
     MetalworkingKnowledge: 2
   # </Trauma>
@@ -1744,7 +1744,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    DoorsKnowledge: 1
+    DoorsKnowledge: 0
   practical:
     MetalworkingKnowledge: 2
   # </Trauma>
@@ -1760,7 +1760,7 @@
   canBuildInImpassable: false
   # <Trauma>
   theory:
-    DoorsKnowledge: 1
+    DoorsKnowledge: 0
   # </Trauma>
 
 - type: construction
@@ -1774,7 +1774,7 @@
   canBuildInImpassable: false
   # <Trauma>
   theory:
-    DoorsKnowledge: 1
+    DoorsKnowledge: 0
   # </Trauma>
 
 - type: construction
@@ -1791,7 +1791,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FabricationKnowledge: 3
+    FabricationKnowledge: 0
   # </Trauma>
 
 - type: construction
@@ -1808,7 +1808,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FabricationKnowledge: 2
+    FabricationKnowledge: 0
   # </Trauma>
 
 - type: construction
@@ -1824,7 +1824,7 @@
   - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FabricationKnowledge: 2
+    FabricationKnowledge: 0
   practical:
     CarvingKnowledge: 4
   # </Trauma>
@@ -1842,7 +1842,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    BananiumKnowledge: 2
+    BananiumKnowledge: 0
   practical:
     CarvingKnowledge: 4
   # </Trauma>
@@ -1860,8 +1860,8 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    BananiumKnowledge: 2
-    DoorsKnowledge: 1
+    BananiumKnowledge: 0
+    DoorsKnowledge: 0
   # </Trauma>
 
 ##- type: construction
@@ -1896,9 +1896,9 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    WallsKnowledge: 1
-    DoorsKnowledge: 1
-    ElectronicsKnowledge: 1
+    WallsKnowledge: 0
+    DoorsKnowledge: 0
+    ElectronicsKnowledge: 0
   useQuality: false
   # </Trauma>
 
@@ -1916,9 +1916,9 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    WallsKnowledge: 1
-    DoorsKnowledge: 1
-    ElectronicsKnowledge: 1
+    WallsKnowledge: 0
+    DoorsKnowledge: 0
+    ElectronicsKnowledge: 0
   useQuality: false
   # </Trauma>
 
@@ -1935,7 +1935,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FabricationKnowledge: 1
+    FabricationKnowledge: 0
   useQuality: false
   # </Trauma>
 
@@ -1972,7 +1972,7 @@
   - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   # </Trauma>
 
 - type: construction
@@ -1989,7 +1989,7 @@
   - !type:TileNotBlocked
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     CarvingKnowledge: 2
   # </Trauma>

--- a/Resources/Prototypes/Recipes/Construction/tools.yml
+++ b/Resources/Prototypes/Recipes/Construction/tools.yml
@@ -9,8 +9,6 @@
   theory:
     FabricationKnowledge: 0
   useQuality: false
-  practical:
-    CarvingKnowledge: 1
   # </Trauma>
 
 - type: construction
@@ -22,56 +20,46 @@
   objectType: Item
   # <Trauma>
   theory:
-    ElectronicsKnowledge: 1
+    ElectronicsKnowledge: 0
+  practical:
+    ElectronicsKnowledge: 2
   # </Trauma>
 
 - type: construction
+  parent: LogicGate # Trauma
   id: EdgeDetector
   graph: LogicGate
   startNode: start
   targetNode: edge_detector
   category: construction-category-tools
   objectType: Item
-  # <Trauma>
-  theory:
-    ElectronicsKnowledge: 1
-  # </Trauma>
 
 - type: construction
+  parent: LogicGate # Trauma
   id: PowerSensor
   graph: LogicGate
   startNode: start
   targetNode: power_sensor
   category: construction-category-tools
   objectType: Item
-  # <Trauma>
-  theory:
-    ElectronicsKnowledge: 1
-  # </Trauma>
 
 - type: construction
+  parent: LogicGate # Trauma
   id: MemoryCell
   graph: LogicGate
   startNode: start
   targetNode: memory_cell
   category: construction-category-tools
   objectType: Item
-  # <Trauma>
-  theory:
-    ElectronicsKnowledge: 1
-  # </Trauma>
 
 - type: construction
+  parent: LogicGate # Trauma
   id: RandomGate
   graph: LogicGate
   startNode: start
   targetNode: random_gate
   category: construction-category-tools
   objectType: Item
-  # <Trauma>
-  theory:
-    ElectronicsKnowledge: 1
-  # </Trauma>
 
 - type: construction
   id: MakeshiftMortarAndPestle
@@ -96,7 +84,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    FabricationKnowledge: 2
+    FabricationKnowledge: 0
   practical:
     CarvingKnowledge: 2
   # </Trauma>
@@ -110,7 +98,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    FabricationKnowledge: 2
-    ElectronicsKnowledge: 1
+    FabricationKnowledge: 0
+    ElectronicsKnowledge: 0
     # TODO: some kind of knowledge that you know about separating liquids by centrifugal forces
   # </Trauma>

--- a/Resources/Prototypes/Recipes/Construction/utilities.yml
+++ b/Resources/Prototypes/Recipes/Construction/utilities.yml
@@ -9,7 +9,7 @@
   placementMode: SnapgridCenter
   # <Trauma>
   theory:
-    ElectronicsKnowledge: 1
+    ElectronicsKnowledge: 0
   practical:
     ElectronicsKnowledge: 2
   # </Trauma>
@@ -25,7 +25,7 @@
   canBuildInImpassable: true
   # <Trauma>
   theory:
-    ElectronicsKnowledge: 1
+    ElectronicsKnowledge: 0
   # </Trauma>
 
 - type: construction
@@ -42,7 +42,7 @@
   - !type:WallmountCondition {}
   # <Trauma>
   theory:
-    ElectronicsKnowledge: 1
+    ElectronicsKnowledge: 0
   practical:
     ElectronicsKnowledge: 1
   # </Trauma>
@@ -89,7 +89,7 @@
   canBuildInImpassable: true
   # <Trauma>
   theory:
-    ElectronicsKnowledge: 1
+    ElectronicsKnowledge: 0
   # </Trauma>
 
 - type: construction
@@ -103,7 +103,7 @@
   canBuildInImpassable: true
   # <Trauma>
   theory:
-    ElectronicsKnowledge: 1
+    ElectronicsKnowledge: 0
   # </Trauma>
 
 - type: construction
@@ -117,7 +117,7 @@
   canBuildInImpassable: true
   # <Trauma>
   theory:
-    ElectronicsKnowledge: 1
+    ElectronicsKnowledge: 0
   practical:
     ElectronicsKnowledge: 3 # 6 kW!!
   # </Trauma>
@@ -134,7 +134,7 @@
   # <Trauma>
   theory:
     ElectronicsKnowledge: 0
-    InfrastructureKnowledge: 1
+    InfrastructureKnowledge: 0
   practical:
     ElectronicsKnowledge: 1
   # </Trauma>
@@ -150,7 +150,7 @@
   # <Trauma>
   theory:
     ElectronicsKnowledge: 0
-    InfrastructureKnowledge: 1
+    InfrastructureKnowledge: 0
   practical:
     ElectronicsKnowledge: 1
   # </Trauma>
@@ -180,8 +180,8 @@
   canBuildInImpassable: false
   # <Trauma>
   theory:
-    ElectronicsKnowledge: 1
-    InfrastructureKnowledge: 1
+    ElectronicsKnowledge: 0
+    InfrastructureKnowledge: 0
   practical:
     MetalworkingKnowledge: 1
   # </Trauma>
@@ -196,8 +196,8 @@
   canBuildInImpassable: false
   # <Trauma>
   theory:
-    ElectronicsKnowledge: 1
-    InfrastructureKnowledge: 1
+    ElectronicsKnowledge: 0
+    InfrastructureKnowledge: 0
   practical:
     ElectronicsKnowledge: 1
     MetalworkingKnowledge: 1
@@ -229,7 +229,7 @@
   mirror: DisposalRouterFlipped
   # <Trauma>
   theory:
-    InfrastructureKnowledge: 1
+    InfrastructureKnowledge: 0
   practical:
     MetalworkingKnowledge: 1
   # </Trauma>
@@ -246,7 +246,7 @@
   mirror: DisposalRouter
   # <Trauma>
   theory:
-    InfrastructureKnowledge: 1
+    InfrastructureKnowledge: 0
   practical:
     MetalworkingKnowledge: 1
   # </Trauma>
@@ -262,8 +262,8 @@
   mirror: DisposalSignalRouterFlipped
   # <Trauma>
   theory:
-    ElectronicsKnowledge: 1
-    InfrastructureKnowledge: 1
+    ElectronicsKnowledge: 0
+    InfrastructureKnowledge: 0
   practical:
     ElectronicsKnowledge: 1
     MetalworkingKnowledge: 1
@@ -281,8 +281,8 @@
   mirror: DisposalSignalRouter
   # <Trauma>
   theory:
-    ElectronicsKnowledge: 1
-    InfrastructureKnowledge: 1
+    ElectronicsKnowledge: 0
+    InfrastructureKnowledge: 0
   practical:
     ElectronicsKnowledge: 1
     MetalworkingKnowledge: 1
@@ -299,12 +299,13 @@
   mirror: DisposalJunctionFlipped
   # <Trauma>
   theory:
-    InfrastructureKnowledge: 1
+    InfrastructureKnowledge: 0
   practical:
-    MetalworkingKnowledge: 1
+    MetalworkingKnowledge: 0
   # </Trauma>
 
 - type: construction
+  parent: DisposalJunction # Trauma
   hide: true
   id: DisposalJunctionFlipped
   graph: DisposalPipe
@@ -314,12 +315,6 @@
   placementMode: SnapgridCenter
   canBuildInImpassable: false
   mirror: DisposalJunction
-  # <Trauma>
-  theory:
-    InfrastructureKnowledge: 1
-  practical:
-    MetalworkingKnowledge: 1
-  # </Trauma>
 
 - type: construction
   id: DisposalYJunction
@@ -331,7 +326,7 @@
   canBuildInImpassable: false
   # <Trauma>
   theory:
-    InfrastructureKnowledge: 1
+    InfrastructureKnowledge: 0
   practical:
     MetalworkingKnowledge: 1
   # </Trauma>
@@ -346,7 +341,7 @@
   canBuildInImpassable: false
   # <Trauma>
   theory:
-    InfrastructureKnowledge: 1
+    InfrastructureKnowledge: 0
   practical:
     MetalworkingKnowledge: 1
   # </Trauma>
@@ -381,8 +376,8 @@
   - !type:WallmountCondition {}
   # <Trauma>
   theory:
-    ElectronicsKnowledge: 1
-    InfrastructureKnowledge: 1
+    ElectronicsKnowledge: 0
+    InfrastructureKnowledge: 0
   # </Trauma>
 
 - type: construction
@@ -399,7 +394,7 @@
   - !type:WallmountCondition {}
   # <Trauma>
   theory:
-    ElectronicsKnowledge: 1
+    ElectronicsKnowledge: 0
     InfrastructureKnowledge: 0 # fire alarms are pretty obvious
   # </Trauma>
 
@@ -414,8 +409,8 @@
   canRotate: true
   # <Trauma>
   theory:
-    ElectronicsKnowledge: 1
-    InfrastructureKnowledge: 1
+    ElectronicsKnowledge: 0
+    InfrastructureKnowledge: 0
   # </Trauma>
 
 - type: construction
@@ -433,11 +428,12 @@
   - GasPipeSensorAlt2
   # <Trauma>
   theory:
-    ElectronicsKnowledge: 1
-    InfrastructureKnowledge: 1
+    ElectronicsKnowledge: 0
+    InfrastructureKnowledge: 0
   # </Trauma>
 
 - type: construction
+  parent: GasPipeSensor # Trauma
   id: GasPipeSensorAlt1
   hide: true
   graph: GasPipeSensor
@@ -451,13 +447,9 @@
   - GasPipeSensor
   - GasPipeSensorAlt1
   - GasPipeSensorAlt2
-  # <Trauma>
-  theory:
-    ElectronicsKnowledge: 1
-    InfrastructureKnowledge: 1
-  # </Trauma>
 
 - type: construction
+  parent: GasPipeSensor # Trauma
   id: GasPipeSensorAlt2
   hide: true
   graph: GasPipeSensor
@@ -471,11 +463,6 @@
   - GasPipeSensor
   - GasPipeSensorAlt1
   - GasPipeSensorAlt2
-  # <Trauma>
-  theory:
-    ElectronicsKnowledge: 1
-    InfrastructureKnowledge: 1
-  # </Trauma>
 
 # ATMOS PIPES
 - type: construction
@@ -493,12 +480,13 @@
   - GasPipeHalfAlt2
   # <Trauma>
   theory:
-    InfrastructureKnowledge: 1
+    InfrastructureKnowledge: 0
   practical:
     MetalworkingKnowledge: 1
   # </Trauma>
 
 - type: construction
+  parent: GasPipeHalf # Trauma
   id: GasPipeHalfAlt1
   hide: true
   graph: GasPipe
@@ -511,14 +499,9 @@
   - GasPipeHalf
   - GasPipeHalfAlt1
   - GasPipeHalfAlt2
-  # <Trauma>
-  theory:
-    InfrastructureKnowledge: 1
-  practical:
-    MetalworkingKnowledge: 1
-  # </Trauma>
 
 - type: construction
+  parent: GasPipeHalf # Trauma
   id: GasPipeHalfAlt2
   hide: true
   graph: GasPipe
@@ -531,12 +514,6 @@
   - GasPipeHalf
   - GasPipeHalfAlt1
   - GasPipeHalfAlt2
-  # <Trauma>
-  theory:
-    InfrastructureKnowledge: 1
-  practical:
-    MetalworkingKnowledge: 1
-  # </Trauma>
 
 - type: construction
   id: GasPipeStraight
@@ -558,6 +535,7 @@
   # </Trauma>
 
 - type: construction
+  parent: GasPipeStraight # Trauma
   id: GasPipeStraightAlt1
   hide: true
   graph: GasPipe
@@ -570,14 +548,9 @@
   - GasPipeStraight
   - GasPipeStraightAlt1
   - GasPipeStraightAlt2
-  # <Trauma>
-  theory:
-    InfrastructureKnowledge: 0 # it's a pipe
-  practical:
-    MetalworkingKnowledge: 1
-  # </Trauma>
 
 - type: construction
+  parent: GasPipeStraight # Trauma
   id: GasPipeStraightAlt2
   hide: true
   graph: GasPipe
@@ -590,12 +563,6 @@
   - GasPipeStraight
   - GasPipeStraightAlt1
   - GasPipeStraightAlt2
-  # <Trauma>
-  theory:
-    InfrastructureKnowledge: 0 # it's a pipe
-  practical:
-    MetalworkingKnowledge: 1
-  # </Trauma>
 
 - type: construction
   id: GasPipeBend
@@ -618,6 +585,7 @@
   # </Trauma>
 
 - type: construction
+  parent: GasPipeBend # Trauma
   id: GasPipeBendAlt1
   hide: true
   graph: GasPipe
@@ -630,14 +598,9 @@
   - GasPipeBend
   - GasPipeBendAlt1
   - GasPipeBendAlt2
-  # <Trauma>
-  theory:
-    InfrastructureKnowledge: 0 # it's a bent pipe
-  practical:
-    MetalworkingKnowledge: 1
-  # </Trauma>
 
 - type: construction
+  parent: GasPipeBend # Trauma
   id: GasPipeBendAlt2
   hide: true
   graph: GasPipe
@@ -650,12 +613,6 @@
   - GasPipeBend
   - GasPipeBendAlt1
   - GasPipeBendAlt2
-  # <Trauma>
-  theory:
-    InfrastructureKnowledge: 0 # it's a bent pipe
-  practical:
-    MetalworkingKnowledge: 1
-  # </Trauma>
 
 - type: construction
   id: GasPipeTJunction
@@ -678,6 +635,7 @@
   # </Trauma>
 
 - type: construction
+  parent: GasPipeTJunction # Trauma
   id: GasPipeTJunctionAlt1
   hide: true
   graph: GasPipe
@@ -690,14 +648,9 @@
   - GasPipeTJunction
   - GasPipeTJunctionAlt1
   - GasPipeTJunctionAlt2
-  # <Trauma>
-  theory:
-    InfrastructureKnowledge: 1
-  practical:
-    MetalworkingKnowledge: 1
-  # </Trauma>
 
 - type: construction
+  parent: GasPipeTJunction # Trauma
   id: GasPipeTJunctionAlt2
   hide: true
   graph: GasPipe
@@ -710,12 +663,6 @@
   - GasPipeTJunction
   - GasPipeTJunctionAlt1
   - GasPipeTJunctionAlt2
-  # <Trauma>
-  theory:
-    InfrastructureKnowledge: 1
-  practical:
-    MetalworkingKnowledge: 1
-  # </Trauma>
 
 - type: construction
   id: GasPipeFourway
@@ -732,12 +679,13 @@
   - GasPipeFourwayAlt2
   # <Trauma>
   theory:
-    InfrastructureKnowledge: 1
+    InfrastructureKnowledge: 0
   practical:
     MetalworkingKnowledge: 1
   # </Trauma>
 
 - type: construction
+  parent: GasPipeFourway # Trauma
   id: GasPipeFourwayAlt1
   hide: true
   graph: GasPipe
@@ -750,14 +698,9 @@
   - GasPipeFourway
   - GasPipeFourwayAlt1
   - GasPipeFourwayAlt2
-  # <Trauma>
-  theory:
-    InfrastructureKnowledge: 1
-  practical:
-    MetalworkingKnowledge: 1
-  # </Trauma>
 
 - type: construction
+  parent: GasPipeFourway # Trauma
   id: GasPipeFourwayAlt2
   hide: true
   graph: GasPipe
@@ -770,12 +713,6 @@
   - GasPipeFourway
   - GasPipeFourwayAlt1
   - GasPipeFourwayAlt2
-  # <Trauma>
-  theory:
-    InfrastructureKnowledge: 1
-  practical:
-    MetalworkingKnowledge: 1
-  # </Trauma>
 
 - type: construction
   id: GasPipeManifold
@@ -787,9 +724,9 @@
   canBuildInImpassable: true
   # <Trauma>
   theory:
-    InfrastructureKnowledge: 1
+    InfrastructureKnowledge: 0
   practical:
-    MetalworkingKnowledge: 1
+    MetalworkingKnowledge: 2
   # </Trauma>
 
 # ATMOS UNARY
@@ -805,7 +742,7 @@
   - !type:NoUnstackableInTile
   # <Trauma>
   theory:
-    InfrastructureKnowledge: 1
+    InfrastructureKnowledge: 0
   practical:
     MetalworkingKnowledge: 1
   # </Trauma>
@@ -822,7 +759,7 @@
   - !type:NoUnstackableInTile
   # <Trauma>
   theory:
-    InfrastructureKnowledge: 1
+    InfrastructureKnowledge: 0
   practical:
     MetalworkingKnowledge: 1
   # </Trauma>
@@ -839,7 +776,10 @@
   - !type:NoUnstackableInTile
   # <Trauma>
   theory:
-    InfrastructureKnowledge: 1
+    InfrastructureKnowledge: 0
+    ElectronicsKnowledge: 0
+  practical:
+    MetalworkingKnowledge: 1
     ElectronicsKnowledge: 1
   # </Trauma>
 
@@ -855,6 +795,9 @@
   - !type:NoUnstackableInTile
   # <Trauma>
   theory:
+    InfrastructureKnowledge: 0
+    ElectronicsKnowledge: 0
+  practical:
     InfrastructureKnowledge: 1
     ElectronicsKnowledge: 1
   # </Trauma>
@@ -876,6 +819,9 @@
   - GasPressurePumpAlt2
   # <Trauma>
   theory:
+    InfrastructureKnowledge: 0
+    ElectronicsKnowledge: 0
+  practical:
     InfrastructureKnowledge: 1
     ElectronicsKnowledge: 1
   # </Trauma>
@@ -897,6 +843,9 @@
   - GasPressurePumpAlt2
   # <Trauma>
   theory:
+    InfrastructureKnowledge: 0
+    ElectronicsKnowledge: 0
+  practical:
     InfrastructureKnowledge: 1
     ElectronicsKnowledge: 1
   # </Trauma>
@@ -918,6 +867,9 @@
   - GasPressurePumpAlt2
   # <Trauma>
   theory:
+    InfrastructureKnowledge: 0
+    ElectronicsKnowledge: 0
+  practical:
     InfrastructureKnowledge: 1
     ElectronicsKnowledge: 1
   # </Trauma>
@@ -938,11 +890,15 @@
   - GasVolumePumpAlt2
   # <Trauma>
   theory:
+    InfrastructureKnowledge: 0
+    ElectronicsKnowledge: 0
+  practical:
     InfrastructureKnowledge: 1
     ElectronicsKnowledge: 1
   # </Trauma>
 
 - type: construction
+  parent: GasVolumePump # Trauma
   id: GasVolumePumpAlt1
   hide: true
   graph: GasBinary
@@ -957,13 +913,9 @@
   - GasVolumePump
   - GasVolumePumpAlt1
   - GasVolumePumpAlt2
-  # <Trauma>
-  theory:
-    InfrastructureKnowledge: 1
-    ElectronicsKnowledge: 1
-  # </Trauma>
 
 - type: construction
+  parent: GasVolumePump # Trauma
   id: GasVolumePumpAlt2
   hide: true
   graph: GasBinary
@@ -978,11 +930,6 @@
   - GasVolumePump
   - GasVolumePumpAlt1
   - GasVolumePumpAlt2
-  # <Trauma>
-  theory:
-    InfrastructureKnowledge: 1
-    ElectronicsKnowledge: 1
-  # </Trauma>
 
 - type: construction
   id: GasPassiveGate
@@ -1000,10 +947,13 @@
   - GasPassiveGateAlt2
   # <Trauma>
   theory:
+    InfrastructureKnowledge: 0
+  practical:
     InfrastructureKnowledge: 1
   # </Trauma>
 
 - type: construction
+  parent: GasPassiveGate # Trauma
   id: GasPassiveGateAlt1
   hide: true
   graph: GasBinary
@@ -1018,12 +968,9 @@
   - GasPassiveGate
   - GasPassiveGateAlt1
   - GasPassiveGateAlt2
-  # <Trauma>
-  theory:
-    InfrastructureKnowledge: 1
-  # </Trauma>
 
 - type: construction
+  parent: GasPassiveGate # Trauma
   id: GasPassiveGateAlt2
   hide: true
   graph: GasBinary
@@ -1038,10 +985,6 @@
   - GasPassiveGate
   - GasPassiveGateAlt1
   - GasPassiveGateAlt2
-  # <Trauma>
-  theory:
-    InfrastructureKnowledge: 1
-  # </Trauma>
 
 - type: construction
   id: GasPressureRegulator
@@ -1059,11 +1002,15 @@
   - GasPressureRegulatorAlt2
   # <Trauma>
   theory:
+    InfrastructureKnowledge: 0
+    ElectronicsKnowledge: 0
+  practical:
     InfrastructureKnowledge: 1
     ElectronicsKnowledge: 1
   # </Trauma>
 
 - type: construction
+  parent: GasPressureRegulator # Trauma
   id: GasPressureRegulatorAlt1
   hide: true
   graph: GasBinary
@@ -1078,13 +1025,9 @@
   - GasPressureRegulator
   - GasPressureRegulatorAlt1
   - GasPressureRegulatorAlt2
-  # <Trauma>
-  theory:
-    InfrastructureKnowledge: 1
-    ElectronicsKnowledge: 1
-  # </Trauma>
 
 - type: construction
+  parent: GasPressureRegulator # Trauma
   id: GasPressureRegulatorAlt2
   hide: true
   graph: GasBinary
@@ -1099,11 +1042,6 @@
   - GasPressureRegulator
   - GasPressureRegulatorAlt1
   - GasPressureRegulatorAlt2
-  # <Trauma>
-  theory:
-    InfrastructureKnowledge: 1
-    ElectronicsKnowledge: 1
-  # </Trauma>
 
 - type: construction
   id: GasValve
@@ -1121,10 +1059,13 @@
   - GasValveAlt2
   # <Trauma>
   theory:
-    InfrastructureKnowledge: 1
+    InfrastructureKnowledge: 0
+  practical:
+    MetalworkingKnowledge: 1
   # </Trauma>
 
 - type: construction
+  parent: GasValve # Trauma
   id: GasValveAlt1
   hide: true
   graph: GasBinary
@@ -1139,12 +1080,9 @@
   - GasValve
   - GasValveAlt1
   - GasValveAlt2
-  # <Trauma>
-  theory:
-    InfrastructureKnowledge: 1
-  # </Trauma>
 
 - type: construction
+  parent: GasValve # Trauma
   id: GasValveAlt2
   hide: true
   graph: GasBinary
@@ -1159,10 +1097,6 @@
   - GasValve
   - GasValveAlt1
   - GasValveAlt2
-  # <Trauma>
-  theory:
-    InfrastructureKnowledge: 1
-  # </Trauma>
 
 - type: construction
   id: SignalControlledValve
@@ -1180,11 +1114,15 @@
   - SignalControlledValveAlt2
   # <Trauma>
   theory:
-    InfrastructureKnowledge: 1
+    InfrastructureKnowledge: 0
+    ElectronicsKnowledge: 0
+  theory:
+    MetalworkingKnowledge: 1
     ElectronicsKnowledge: 1
   # </Trauma>
 
 - type: construction
+  parent: SignalControlledValve # Trauma
   id: SignalControlledValveAlt1
   graph: GasBinary
   startNode: start
@@ -1198,13 +1136,9 @@
   - SignalControlledValve
   - SignalControlledValveAlt1
   - SignalControlledValveAlt2
-  # <Trauma>
-  theory:
-    InfrastructureKnowledge: 1
-    ElectronicsKnowledge: 1
-  # </Trauma>
 
 - type: construction
+  parent: SignalControlledValve # Trauma
   id: SignalControlledValveAlt2
   graph: GasBinary
   startNode: start
@@ -1218,11 +1152,6 @@
   - SignalControlledValve
   - SignalControlledValveAlt1
   - SignalControlledValveAlt2
-  # <Trauma>
-  theory:
-    InfrastructureKnowledge: 1
-    ElectronicsKnowledge: 1
-  # </Trauma>
 
 - type: construction
   id: GasPort
@@ -1236,7 +1165,9 @@
     - !type:NoUnstackableInTile
   # <Trauma>
   theory:
-    InfrastructureKnowledge: 1
+    InfrastructureKnowledge: 0
+  practical:
+    MetalworkingKnowledge: 1
   # </Trauma>
 
 - type: construction
@@ -1249,7 +1180,9 @@
   canBuildInImpassable: false
   # <Trauma>
   theory:
-    InfrastructureKnowledge: 1
+    InfrastructureKnowledge: 0
+  practical:
+    MetalworkingKnowledge: 1
   # </Trauma>
 
 - type: construction
@@ -1262,7 +1195,9 @@
   canBuildInImpassable: false
   # <Trauma>
   theory:
-    InfrastructureKnowledge: 1
+    InfrastructureKnowledge: 0
+  practical:
+    MetalworkingKnowledge: 1
   # </Trauma>
 
 - type: construction
@@ -1276,7 +1211,9 @@
   canBuildInImpassable: false
   # <Trauma>
   theory:
-    InfrastructureKnowledge: 1
+    InfrastructureKnowledge: 0
+  practical:
+    MetalworkingKnowledge: 1
   # </Trauma>
 
 # ATMOS TRINARY
@@ -1293,11 +1230,15 @@
     - !type:NoUnstackableInTile
   # <Trauma>
   theory:
-    InfrastructureKnowledge: 1
+    InfrastructureKnowledge: 0
+    ElectronicsKnowledge: 0
+  practical:
+    MetalworkingKnowledge: 1
     ElectronicsKnowledge: 1
   # </Trauma>
 
 - type: construction
+  parent: GasFilter # Trauma
   id: GasFilterFlipped
   hide: true
   graph: GasTrinary
@@ -1309,11 +1250,6 @@
   mirror: GasFilter
   conditions:
     - !type:NoUnstackableInTile
-  # <Trauma>
-  theory:
-    InfrastructureKnowledge: 1
-    ElectronicsKnowledge: 1
-  # </Trauma>
 
 - type: construction
   id: GasMixer
@@ -1328,11 +1264,15 @@
     - !type:NoUnstackableInTile
   # <Trauma>
   theory:
-    InfrastructureKnowledge: 1
+    InfrastructureKnowledge: 0
+    ElectronicsKnowledge: 0
+  practical:
+    MetalworkingKnowledge: 1
     ElectronicsKnowledge: 1
   # </Trauma>
 
 - type: construction
+  parent: GasMixer # Trauma
   id: GasMixerFlipped
   hide: true
   graph: GasTrinary
@@ -1344,11 +1284,6 @@
   mirror: GasMixer
   conditions:
     - !type:NoUnstackableInTile
-  # <Trauma>
-  theory:
-    InfrastructureKnowledge: 1
-    ElectronicsKnowledge: 1
-  # </Trauma>
 
 - type: construction
   id: PressureControlledValve
@@ -1362,7 +1297,10 @@
     - !type:NoUnstackableInTile
   # <Trauma>
   theory:
-    InfrastructureKnowledge: 1
+    InfrastructureKnowledge: 0
+    ElectronicsKnowledge: 0
+  practical:
+    MetalworkingKnowledge: 1
     ElectronicsKnowledge: 1
   # </Trauma>
 
@@ -1381,7 +1319,7 @@
   - !type:WallmountCondition {}
   # <Trauma>
   theory:
-    ElectronicsKnowledge: 1
+    ElectronicsKnowledge: 0
   # </Trauma>
 
 # TIMERS
@@ -1398,7 +1336,7 @@
   - !type:WallmountCondition
   # <Trauma>
   theory:
-    ElectronicsKnowledge: 1
+    ElectronicsKnowledge: 0
   # </Trauma>
 
 - type: construction
@@ -1415,7 +1353,7 @@
   - !type:WallmountCondition
   # <Trauma>
   theory:
-    ElectronicsKnowledge: 1
+    ElectronicsKnowledge: 0
     InfrastructureKnowledge: 0
   practical:
     ElectronicsKnowledge: 1
@@ -1435,7 +1373,7 @@
   - !type:WallmountCondition
   # <Trauma>
   theory:
-    ElectronicsKnowledge: 1
+    ElectronicsKnowledge: 0
     InfrastructureKnowledge: 0
   practical:
     ElectronicsKnowledge: 1

--- a/Resources/Prototypes/Recipes/Construction/utilities.yml
+++ b/Resources/Prototypes/Recipes/Construction/utilities.yml
@@ -1116,7 +1116,7 @@
   theory:
     InfrastructureKnowledge: 0
     ElectronicsKnowledge: 0
-  theory:
+  practical:
     MetalworkingKnowledge: 1
     ElectronicsKnowledge: 1
   # </Trauma>

--- a/Resources/Prototypes/Recipes/Construction/web.yml
+++ b/Resources/Prototypes/Recipes/Construction/web.yml
@@ -12,7 +12,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    SpiderCraftKnowledge: 1
+    SpiderCraftKnowledge: 0
   practical:
     TailoringKnowledge: 2
   useQuality: false
@@ -32,7 +32,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    SpiderCraftKnowledge: 1
+    SpiderCraftKnowledge: 0
   practical:
     TailoringKnowledge: 2
   # </Trauma>
@@ -51,7 +51,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    SpiderCraftKnowledge: 1
+    SpiderCraftKnowledge: 0
   practical:
     TailoringKnowledge: 2
   # </Trauma>
@@ -67,7 +67,7 @@
   canBuildInImpassable: false
   # <Trauma>
   theory:
-    SpiderCraftKnowledge: 1
+    SpiderCraftKnowledge: 0
   practical:
     TailoringKnowledge: 2
   # </Trauma>
@@ -84,7 +84,7 @@
   canBuildInImpassable: false
   # <Trauma>
   theory:
-    SpiderCraftKnowledge: 1
+    SpiderCraftKnowledge: 0
   practical:
     TailoringKnowledge: 2
   # </Trauma>
@@ -102,7 +102,7 @@
     - !type:TileNotBlocked
   # <Trauma>
   theory:
-    SpiderCraftKnowledge: 1
+    SpiderCraftKnowledge: 0
   practical:
     TailoringKnowledge: 2
   # </Trauma>

--- a/Resources/Prototypes/Recipes/Crafting/artifact.yml
+++ b/Resources/Prototypes/Recipes/Crafting/artifact.yml
@@ -7,6 +7,6 @@
   objectType: Item
   # <Trauma>
   theory:
-    ScienceKnowledge: 1
+    ScienceKnowledge: 0
   useQuality: false
   # </Trauma>

--- a/Resources/Prototypes/Recipes/Crafting/bots.yml
+++ b/Resources/Prototypes/Recipes/Crafting/bots.yml
@@ -7,7 +7,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    BotsKnowledge: 1
+    BotsKnowledge: 0
   practical:
     ElectronicsKnowledge: 1
   # </Trauma>
@@ -21,7 +21,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    BotsKnowledge: 1
+    BotsKnowledge: 0
   practical:
     ElectronicsKnowledge: 1
   # </Trauma>
@@ -35,8 +35,8 @@
   objectType: Item
   # <Trauma>
   theory:
-    BotsKnowledge: 1
-    BananiumKnowledge: 1
+    BotsKnowledge: 0
+    BananiumKnowledge: 0
   practical:
     ElectronicsKnowledge: 1
   # </Trauma>
@@ -50,7 +50,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    BotsKnowledge: 1
+    BotsKnowledge: 0
   practical:
     ElectronicsKnowledge: 1
   # </Trauma>
@@ -64,8 +64,8 @@
   objectType: Item
   # <Trauma>
   theory:
-    BotsKnowledge: 1
-    ChemistryKnowledge: 1
+    BotsKnowledge: 0
+    ChemistryKnowledge: 0
   practical:
     ElectronicsKnowledge: 1
   # </Trauma>
@@ -79,7 +79,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    BotsKnowledge: 1
+    BotsKnowledge: 0
   practical:
     ElectronicsKnowledge: 1
   # </Trauma>
@@ -93,7 +93,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    BotsKnowledge: 1
+    BotsKnowledge: 0
   practical:
     ElectronicsKnowledge: 1
   # </Trauma>
@@ -107,7 +107,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    BotsKnowledge: 1
+    BotsKnowledge: 0
   practical:
     ElectronicsKnowledge: 1
   # </Trauma>

--- a/Resources/Prototypes/Recipes/Crafting/crates.yml
+++ b/Resources/Prototypes/Recipes/Crafting/crates.yml
@@ -7,7 +7,7 @@
   objectType: Structure
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     CarvingKnowledge: 1
   useQuality: false
@@ -22,7 +22,7 @@
   objectType: Structure
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     MetalworkingKnowledge: 1
   useQuality: false
@@ -37,8 +37,8 @@
   objectType: Structure
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
-    ElectronicsKnowledge: 1
+    FurnitureKnowledge: 0
+    ElectronicsKnowledge: 0
   practical:
     MetalworkingKnowledge: 1
   useQuality: false
@@ -54,7 +54,7 @@
   objectType: Structure
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     MetalworkingKnowledge: 1
   useQuality: false
@@ -69,7 +69,7 @@
   objectType: Structure
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   useQuality: false
   # </Trauma>
 
@@ -83,7 +83,7 @@
   objectType: Structure
   # <Trauma>
   theory:
-    FabricationKnowledge: 1
+    FabricationKnowledge: 0
   practical:
     CarvingKnowledge: 1
   useQuality: false
@@ -99,7 +99,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    FabricationKnowledge: 1
+    FabricationKnowledge: 0
   useQuality: false
   # </Trauma>
 
@@ -113,7 +113,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    FabricationKnowledge: 1
+    FabricationKnowledge: 0
   useQuality: false
   # </Trauma>
 
@@ -127,7 +127,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    FabricationKnowledge: 1
+    FabricationKnowledge: 0
   useQuality: false
   # </Trauma>
 
@@ -140,7 +140,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    FabricationKnowledge: 1
+    FabricationKnowledge: 0
   useQuality: false
   # </Trauma>
 
@@ -153,7 +153,7 @@
   objectType: Structure
   # <Trauma>
   theory:
-    FabricationKnowledge: 1
+    FabricationKnowledge: 0
   practical:
     CarvingKnowledge: 2
   useQuality: false

--- a/Resources/Prototypes/Recipes/Crafting/defib_cabinet.yml
+++ b/Resources/Prototypes/Recipes/Crafting/defib_cabinet.yml
@@ -12,7 +12,7 @@
   - !type:WallmountCondition
   # <Trauma>
   theory:
-    ElectronicsKnowledge: 1
+    ElectronicsKnowledge: 0
   practical:
     MetalworkingKnowledge: 1
   useQuality: false

--- a/Resources/Prototypes/Recipes/Crafting/improvised.yml
+++ b/Resources/Prototypes/Recipes/Crafting/improvised.yml
@@ -23,7 +23,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    FabricationKnowledge: 1
+    FabricationKnowledge: 0
   practical:
     TailoringKnowledge: 1
   useQuality: false
@@ -67,7 +67,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    FabricationKnowledge: 3
+    FabricationKnowledge: 0
   practical:
     TailoringKnowledge: 1
   useQuality: false
@@ -129,8 +129,7 @@
   category: construction-category-clothing
   objectType: Item
   # <Trauma>
-  theory:
-    FabricationKnowledge: 1
+  theory: {}
   useQuality: false
   # </Trauma>
 

--- a/Resources/Prototypes/Recipes/Crafting/potato.yml
+++ b/Resources/Prototypes/Recipes/Crafting/potato.yml
@@ -7,7 +7,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    FabricationKnowledge: 3
+    FabricationKnowledge: 0
   practical:
     ElectronicsKnowledge: 1
   # </Trauma>
@@ -21,7 +21,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    FabricationKnowledge: 3
+    FabricationKnowledge: 0
   practical:
     ElectronicsKnowledge: 2
   # </Trauma>
@@ -35,7 +35,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    FabricationKnowledge: 3
+    FabricationKnowledge: 0
   practical:
     ElectronicsKnowledge: 3
   # </Trauma>

--- a/Resources/Prototypes/Recipes/Crafting/smokeables.yml
+++ b/Resources/Prototypes/Recipes/Crafting/smokeables.yml
@@ -7,7 +7,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    SmokeablesKnowledge: 1
+    SmokeablesKnowledge: 0
   practical:
     SmokeablesKnowledge: 1
   # </Trauma>
@@ -22,7 +22,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    SmokeablesKnowledge: 2
+    SmokeablesKnowledge: 0
   practical:
     SmokeablesKnowledge: 2
   # </Trauma>
@@ -36,7 +36,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    SmokeablesKnowledge: 1
+    SmokeablesKnowledge: 0
   practical:
     SmokeablesKnowledge: 1
   # </Trauma>
@@ -51,7 +51,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    SmokeablesKnowledge: 2
+    SmokeablesKnowledge: 0
   practical:
     SmokeablesKnowledge: 2
   # </Trauma>
@@ -65,7 +65,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    SmokeablesKnowledge: 1
+    SmokeablesKnowledge: 0
   practical:
     SmokeablesKnowledge: 1
   # </Trauma>
@@ -82,7 +82,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    SmokeablesKnowledge: 1
+    SmokeablesKnowledge: 0
   practical:
     SmokeablesKnowledge: 1
   # </Trauma>
@@ -96,7 +96,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    SmokeablesKnowledge: 2
+    SmokeablesKnowledge: 0
   practical:
     SmokeablesKnowledge: 2
   # </Trauma>
@@ -111,7 +111,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    SmokeablesKnowledge: 1
+    SmokeablesKnowledge: 0
   practical:
     SmokeablesKnowledge: 1
   # </Trauma>

--- a/Resources/Prototypes/Recipes/Crafting/tallbox.yml
+++ b/Resources/Prototypes/Recipes/Crafting/tallbox.yml
@@ -7,7 +7,7 @@
   objectType: Structure
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     MetalworkingKnowledge: 1
     MechanicsKnowledge: 1
@@ -22,8 +22,8 @@
   objectType: Structure
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
-    ElectronicsKnowledge: 1
+    FurnitureKnowledge: 0
+    ElectronicsKnowledge: 0
   practical:
     MetalworkingKnowledge: 1
     MechanicsKnowledge: 1
@@ -39,7 +39,7 @@
   objectType: Structure
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     MetalworkingKnowledge: 1
     MechanicsKnowledge: 1
@@ -54,7 +54,7 @@
   objectType: Structure
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     MetalworkingKnowledge: 2
     MechanicsKnowledge: 2
@@ -74,7 +74,7 @@
     - !type:WallmountCondition
   # <Trauma>
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   practical:
     MetalworkingKnowledge: 1
     MechanicsKnowledge: 1

--- a/Resources/Prototypes/Recipes/Crafting/tiles.yml
+++ b/Resources/Prototypes/Recipes/Crafting/tiles.yml
@@ -9,97 +9,69 @@
   objectType: Item
   # <Trauma>
   theory:
-    FabricationKnowledge: 1
+    FabricationKnowledge: 0
   useQuality: false # annoying for construction, masterwork tiles as weapons is sad but not worth the hassle
   # </Trauma>
 
 - type: construction
+  parent: TileSteel # Trauma
   id: TileWood
   graph: TileWood
   startNode: start
   targetNode: woodtile
   category: construction-category-tiles
   objectType: Item
-  # <Trauma>
-  theory:
-    FabricationKnowledge: 1
-  useQuality: false
-  # </Trauma>
 
 - type: construction
+  parent: TileSteel # Trauma
   id: TileBrassFilled
   graph: TilesBrass
   startNode: start
   targetNode: filledPlate
   category: construction-category-tiles
   objectType: Item
-  # <Trauma>
-  theory:
-    FabricationKnowledge: 1
-  useQuality: false
-  # </Trauma>
 
 - type: construction
+  parent: TileSteel # Trauma
   id: TileBrassReebe
   graph: TilesBrass
   startNode: start
   targetNode: reebe
   category: construction-category-tiles
   objectType: Item
-  # <Trauma>
-  theory:
-    FabricationKnowledge: 1
-  useQuality: false
-  # </Trauma>
 
 - type: construction
+  parent: TileSteel # Trauma
   id: TileWhite
   graph: TileWhite
   startNode: start
   targetNode: whitetile
   category: construction-category-tiles
   objectType: Item
-  # <Trauma>
-  theory:
-    FabricationKnowledge: 1
-  useQuality: false
-  # </Trauma>
 
 - type: construction
+  parent: TileSteel # Trauma
   id: TileDark
   graph: TileDark
   startNode: start
   targetNode: darktile
   category: construction-category-tiles
   objectType: Item
-  # <Trauma>
-  theory:
-    FabricationKnowledge: 1
-  useQuality: false
-  # </Trauma>
 
 - type: construction
+  parent: TileSteel # Trauma
   id: TileFlesh
   graph: TileFlesh
   startNode: start
   targetNode: fleshTile
   category: construction-category-tiles
   objectType: Item
-  # <Trauma>
-  theory:
-    FabricationKnowledge: 1
-  useQuality: false
-  # </Trauma>
 
 - type: construction
+  parent: TileSteel # Trauma
   id: TileWoodLarge
   graph: TileWoodLarge
   startNode: start
   targetNode: woodtilelarge
   category: construction-category-tiles
   objectType: Item
-  # <Trauma>
-  theory:
-    FabricationKnowledge: 1
-  useQuality: false
-  # </Trauma>

--- a/Resources/Prototypes/Recipes/Crafting/toys.yml
+++ b/Resources/Prototypes/Recipes/Crafting/toys.yml
@@ -7,7 +7,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    ToysKnowledge: 2
+    ToysKnowledge: 0
   practical:
     TailoringKnowledge: 1
   # </Trauma>
@@ -21,7 +21,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    ToysKnowledge: 2
+    ToysKnowledge: 0
   practical:
     TailoringKnowledge: 2
   # </Trauma>
@@ -35,8 +35,8 @@
   objectType: Item
   # <Trauma>
   theory:
-    FabricationKnowledge: 2
-    ToysKnowledge: 2
+    FabricationKnowledge: 0
+    ToysKnowledge: 0
   practical:
     TailoringKnowledge: 1
   # </Trauma>

--- a/Resources/Prototypes/Recipes/Crafting/web.yml
+++ b/Resources/Prototypes/Recipes/Crafting/web.yml
@@ -7,7 +7,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    SpiderCraftKnowledge: 2
+    SpiderCraftKnowledge: 0
   useQuality: false
   practical:
     TailoringKnowledge: 2
@@ -22,7 +22,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    SpiderCraftKnowledge: 2
+    SpiderCraftKnowledge: 0
   practical:
     TailoringKnowledge: 4
   # </Trauma>
@@ -36,7 +36,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    SpiderCraftKnowledge: 2
+    SpiderCraftKnowledge: 0
   practical:
     TailoringKnowledge: 4
   # </Trauma>
@@ -50,7 +50,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    SpiderCraftKnowledge: 2
+    SpiderCraftKnowledge: 0
   practical:
     TailoringKnowledge: 4
   # </Trauma>
@@ -65,10 +65,8 @@
   objectType: Item
   # <Trauma>
   theory:
-    SpiderCraftKnowledge: 2
+    SpiderCraftKnowledge: 0
   useQuality: false
-  practical:
-    TailoringKnowledge: 2
   # </Trauma>
 
 - type: construction
@@ -80,7 +78,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    SpiderCraftKnowledge: 2
+    SpiderCraftKnowledge: 0
   practical:
     TailoringKnowledge: 4
   # </Trauma>
@@ -94,7 +92,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    SpiderCraftKnowledge: 2
+    SpiderCraftKnowledge: 0
   practical:
     TailoringKnowledge: 4
   # </Trauma>

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Medical/medical_patch.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Medical/medical_patch.yml
@@ -225,7 +225,7 @@
   category: construction-category-tools
   objectType: Item
   theory:
-    FirstAidKnowledge: 1
+    FirstAidKnowledge: 0
     FabricationKnowledge: 1
   practical:
     TailoringKnowledge: 1
@@ -252,7 +252,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    SpiderCraftKnowledge: 1
+    SpiderCraftKnowledge: 0
   practical:
     TailoringKnowledge: 1
   useQuality: false

--- a/Resources/Prototypes/_Goobstation/Recipes/Construction/altars.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Construction/altars.yml
@@ -8,6 +8,6 @@
   canRotate: false
   canBuildInImpassable: false
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0
   conditions:
   - !type:TileNotBlocked

--- a/Resources/Prototypes/_Goobstation/Recipes/Construction/clothing.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Construction/clothing.yml
@@ -35,7 +35,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    ElectronicsKnowledge: 2
+    ElectronicsKnowledge: 1
   # </Trauma>
 
 - type: construction
@@ -46,7 +46,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    ElectronicsKnowledge: 2
+    ElectronicsKnowledge: 1
   # </Trauma>
 
 - type: construction
@@ -57,7 +57,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    ElectronicsKnowledge: 2
+    ElectronicsKnowledge: 1
   # </Trauma>
 
 - type: construction
@@ -68,7 +68,7 @@
   objectType: Item
   # <Trauma>
   theory:
-    ElectronicsKnowledge: 2
+    ElectronicsKnowledge: 1
   # </Trauma>
 
 - type: construction
@@ -79,5 +79,5 @@
   objectType: Item
   # <Trauma>
   theory:
-    ElectronicsKnowledge: 2
+    ElectronicsKnowledge: 1
   # </Trauma>

--- a/Resources/Prototypes/_Goobstation/Recipes/Construction/contraband_detector.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Construction/contraband_detector.yml
@@ -7,8 +7,8 @@
   canBuildInImpassable: false
   targetNode: detector
   theory:
-    ElectronicsKnowledge: 1
-    InfrastructureKnowledge: 1
+    ElectronicsKnowledge: 0
+    InfrastructureKnowledge: 0
   practical:
     MetalworkingKnowledge: 2
     ElectronicsKnowledge: 2

--- a/Resources/Prototypes/_Goobstation/Recipes/Construction/fun.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Construction/fun.yml
@@ -5,9 +5,10 @@
   category: construction-category-weapons
   objectType: Item
   theory:
-    BananiumKnowledge: 2
+    BananiumKnowledge: 0
   practical:
     WeaponsKnowledge: 2
+    BananiumKnowledge: 2
 
 - type: construction
   id: boomerang

--- a/Resources/Prototypes/_Goobstation/Recipes/Construction/furniture.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Construction/furniture.yml
@@ -24,4 +24,4 @@
   conditions:
     - !type:TileNotBlocked
   theory:
-    FurnitureKnowledge: 1
+    FurnitureKnowledge: 0

--- a/Resources/Prototypes/_Goobstation/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Construction/structures.yml
@@ -8,7 +8,7 @@
   canRotate: true
   canBuildInImpassable: true
   theory:
-    WallsKnowledge: 1
+    WallsKnowledge: 0
   practical:
     MetalworkingKnowledge: 1
 
@@ -20,7 +20,7 @@
   objectType: Structure
   placementMode: SnapgridCenter
   theory:
-    ElectronicsKnowledge: 1
+    ElectronicsKnowledge: 0
 
 # Barricades
 

--- a/Resources/Prototypes/_Goobstation/Recipes/Construction/utilities.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Construction/utilities.yml
@@ -6,40 +6,20 @@
   placementMode: SnapgridCenter
   canBuildInImpassable: false
   theory:
-    InfrastructureKnowledge: 1
-    ElectronicsKnowledge: 1
+    InfrastructureKnowledge: 0
+    ElectronicsKnowledge: 0
 
 - type: construction
+  parent: GasFilter
   id: GasFilterInline
-  graph: GasTrinary
   targetNode: inline_filter
-  category: construction-category-utilities
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-  - !type:NoUnstackableInTile
-  theory:
-    InfrastructureKnowledge: 1
-    ElectronicsKnowledge: 1
 
 - type: construction
+  parent: HeatExchanger
   id: HeatExchangerInline
-  graph: GasBinary
   targetNode: inlineradiator
-  category: construction-category-utilities
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  theory:
-    InfrastructureKnowledge: 1
-    ElectronicsKnowledge: 1
 
 - type: construction
+  parent: HeatExchangerBend
   id: HeatExchangerInlineBend
-  graph: GasBinary
   targetNode: bendinlineradiator
-  category: construction-category-utilities
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  theory:
-    InfrastructureKnowledge: 1
-    ElectronicsKnowledge: 1

--- a/Resources/Prototypes/_Goobstation/Recipes/Crafting/chemical_mixer.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Crafting/chemical_mixer.yml
@@ -5,4 +5,4 @@
   category: construction-category-misc
   objectType: Item
   theory:
-    ElectronicsKnowledge: 2
+    ElectronicsKnowledge: 1

--- a/Resources/Prototypes/_Goobstation/Recipes/Crafting/filters.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Crafting/filters.yml
@@ -5,7 +5,7 @@
   category: construction-category-misc
   objectType: Item
   theory:
-    ElectronicsKnowledge: 1
+    ElectronicsKnowledge: 0
   useQuality: false
 
 - type: construction

--- a/Resources/Prototypes/_Goobstation/Recipes/Crafting/fun.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Crafting/fun.yml
@@ -5,6 +5,6 @@
   category: construction-category-misc
   objectType: Item
   theory:
-    FabricationKnowledge: 1
+    FabricationKnowledge: 0
   practical:
     MetalworkingKnowledge: 2

--- a/Resources/Prototypes/_Goobstation/Recipes/Crafting/goidabot.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Crafting/goidabot.yml
@@ -5,6 +5,6 @@
   category: construction-category-utilities
   objectType: Item
   theory:
-    BotsKnowledge: 1
+    BotsKnowledge: 0
   practical:
     ElectronicsKnowledge: 1

--- a/Resources/Prototypes/_Goobstation/Wizard/airlock.yml
+++ b/Resources/Prototypes/_Goobstation/Wizard/airlock.yml
@@ -93,10 +93,8 @@
   canBuildInImpassable: false
   conditions:
     - !type:TileNotBlocked
-  # <Trauma>
   theory:
-    AirlocksKnowledge: 1
-  # </Trauma>
+    AirlocksKnowledge: 0
 
 - type: construction
   id: AirlockUraniumGlass
@@ -108,10 +106,8 @@
   canBuildInImpassable: false
   conditions:
     - !type:TileNotBlocked
-  # <Trauma>
   theory:
-    AirlocksKnowledge: 1
-  # </Trauma>
+    AirlocksKnowledge: 0
 
 # Construction
 - type: constructionGraph

--- a/Resources/Prototypes/_Trauma/Recipes/Construction/forging.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Construction/forging.yml
@@ -9,7 +9,7 @@
   conditions:
   - !type:TileNotBlocked
   theory:
-    FabricationKnowledge: 2
+    FabricationKnowledge: 0
   useQuality: false
 
 - type: construction

--- a/Resources/Prototypes/_Trauma/Recipes/Crafting/robotic.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Crafting/robotic.yml
@@ -5,8 +5,8 @@
   category: construction-category-utilities
   objectType: Item
   theory:
-    ToysKnowledge: 1
-    BotsKnowledge: 1
+    ToysKnowledge: 0
+    BotsKnowledge: 0
   practical:
     ElectronicsKnowledge: 1
 
@@ -17,7 +17,7 @@
 #  category: construction-category-utilities
 #  objectType: Item
 #  theory:
-#    BotsKnowledge: 1
+#    BotsKnowledge: 0
 
 - type: construction
   id: DuckBot
@@ -26,8 +26,8 @@
   category: construction-category-utilities
   objectType: Item
   theory:
-    CookingKnowledge: 2
-    BotsKnowledge: 1
+    CookingKnowledge: 0
+    BotsKnowledge: 0
   practical:
     ElectronicsKnowledge: 1
 
@@ -38,7 +38,7 @@
   category: construction-category-utilities
   objectType: Item
   theory:
-    ElectronicsKnowledge: 1
-    BotsKnowledge: 1
+    ElectronicsKnowledge: 0
+    BotsKnowledge: 0
   practical:
     ElectronicsKnowledge: 1


### PR DESCRIPTION
also use inheritance where i can be bothered

weapons, ai core and ai turret control panel still have them

:cl:
- tweak: Most non-weapon crafting recipes no longer require levels in any skills to make.