### PR TITLE
give initial infected their own faction

### DIFF
--- a/Content.Server/Zombies/ZombieSystem.Trauma.cs
+++ b/Content.Server/Zombies/ZombieSystem.Trauma.cs
@@ -1,0 +1,15 @@
+using Content.Shared.Blocking;
+using Content.Shared.NPC.Prototypes;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.Zombies;
+
+public sealed partial class ZombieSystem
+{
+    public readonly ProtoId<NpcFactionPrototype> IIFaction = "InitialInfected";
+
+    private bool IsUserBlocking(EntityUid uid)
+        => TryComp<BlockingUserComponent>(uid, out var user) &&
+            TryComp<BlockingComponent>(user.BlockingItem, out var blockComp) &&
+            blockComp.IsBlocking;
+}

--- a/Content.Server/Zombies/ZombieSystem.cs
+++ b/Content.Server/Zombies/ZombieSystem.cs
@@ -1,7 +1,6 @@
 // <Trauma>
 using Content.Medical.Common.Damage;
 using Content.Medical.Common.Targeting;
-using Content.Shared.Blocking;
 // </Trauma>
 using Content.Shared.NPC.Prototypes;
 using Content.Server.Actions;
@@ -95,7 +94,7 @@ namespace Content.Server.Zombies
         private void OnPendingMapInit(EntityUid uid, IncurableZombieComponent component, MapInitEvent args)
         {
             _actions.AddAction(uid, ref component.Action, component.ZombifySelfActionPrototype);
-            _faction.AddFaction(uid, Faction);
+            _faction.AddFaction(uid, HasComp<InitialInfectedComponent>(uid) ? IIFaction : Faction); // Trauma - separate faction for II
 
             if (HasComp<ZombieComponent>(uid) || HasComp<ZombieImmuneComponent>(uid))
                 return;
@@ -217,11 +216,6 @@ namespace Content.Server.Zombies
             }
         }
 
-        private bool IsUserBlocking(BlockingUserComponent? component) // Goobstation
-        {
-            return (TryComp<BlockingComponent>(component?.BlockingItem, out var blockComp) && blockComp.IsBlocking);
-        }
-
         private float GetZombieInfectionChance(EntityUid uid, ZombieComponent zombieComponent)
         {
             var chance = zombieComponent.BaseZombieInfectionChance;
@@ -262,8 +256,10 @@ namespace Content.Server.Zombies
                 if (!TryComp<MobStateComponent>(uid, out var mobState))
                     continue;
 
-                if (TryComp<BlockingUserComponent>(entity, out var blockingUser) && IsUserBlocking(blockingUser)) // Goobstation edit - prevents infection if user is actively blocking
-                    return;
+                // <Trauma> - prevents infection if user is actively blocking
+                if (IsUserBlocking(uid))
+                    continue;
+                // </Trauma>
 
                 if (HasComp<ZombieComponent>(uid) || HasComp<IncurableZombieComponent>(uid))
                 {
@@ -277,7 +273,7 @@ namespace Content.Server.Zombies
                     _damageable.TryChangeDamage(args.User, entity.Comp.HealingOnBite, true, false);
 
                     // If we cannot infect the living target, the zed will just heal itself.
-                    if (HasComp<ZombieImmuneComponent>(uid) || cannotSpread || _random.Prob(GetZombieInfectionChance(uid, entity.Comp)))
+                    if (HasComp<ZombieImmuneComponent>(uid) || cannotSpread || !_random.Prob(GetZombieInfectionChance(uid, entity.Comp)))
                         continue;
 
                     EnsureComp<PendingZombieComponent>(uid);
@@ -333,7 +329,7 @@ namespace Content.Server.Zombies
         // Remove the role when getting cloned, getting gibbed and borged, or leaving the body via any other method.
         private void OnMindRemoved(Entity<ZombieComponent> ent, ref MindRemovedMessage args)
         {
-            _role.MindRemoveRole<ZombieRoleComponent>((args.Mind.Owner, args.Mind.Comp));
+            _role.MindRemoveRole<ZombieRoleComponent>((args.Mind.Owner,  args.Mind.Comp));
         }
     }
 }

--- a/Resources/Prototypes/_Trauma/ai_factions.yml
+++ b/Resources/Prototypes/_Trauma/ai_factions.yml
@@ -26,3 +26,8 @@
   id: InsurgentDestroyer9000
   hostile:
   - Insurgent
+
+- type: npcFaction
+  id: InitialInfected
+  friendly:
+  - Zombie

--- a/Resources/Prototypes/ai_factions.yml
+++ b/Resources/Prototypes/ai_factions.yml
@@ -171,8 +171,11 @@
 
 - type: npcFaction
   id: Zombie
+  # <Trauma>
+  friendly:
+  - InitialInfected
   hostile:
-  # <Goob>
+  - Insurgent
   - Changeling
   - Heretic
   - Blob
@@ -180,7 +183,7 @@
   - PirateFaction
   - Wraith
   - Lavafauna
-  # </Goob>
+  # </Trauma>
   - NanoTrasen
   - SimpleNeutral
   - SimpleHostile
@@ -192,9 +195,6 @@
   - Wizard
   - Dragon
   - Xenoborg
-  # <Trauma>
-  - Insurgent
-  # </Trauma>
 
 - type: npcFaction
   id: Revolutionary


### PR DESCRIPTION
fixes #2185

theyre friendly with zombies and nothing is hostile to them
still gets reset to zombie faction when turning

## Media
simplemobs only hunt zombie not II

<img width="210" height="221" alt="09:51:23" src="https://github.com/user-attachments/assets/d2f317f2-95b4-47ff-9c5e-c556e34a54f0" />

zombie is nice to II

<img width="206" height="157" alt="09:52:56" src="https://github.com/user-attachments/assets/35b67c1e-0252-4ebe-9d30-bfb538fa5e5a" />

**Changelog**
:cl:
- fix: Fixed simplemobs metagaming initial infected.
