### PR TITLE
kill martial art effect scaling

### DIFF
--- a/Content.Trauma.Common/Knowledge/KnowledgeEvents.cs
+++ b/Content.Trauma.Common/Knowledge/KnowledgeEvents.cs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-
 namespace Content.Trauma.Common.Knowledge;
 
 /// <summary>
@@ -23,15 +22,3 @@ public record struct UpdateExperienceEvent();
 /// </summary>
 [ByRefEvent]
 public record struct UpdateItemQualityEvent(EntityUid User);
-
-/// <summary>
-/// Called in order to invoke damage modifiers for martial arts. Call on the art itself.
-/// </summary>
-[ByRefEvent]
-public record struct MartialArtDamageModifierEvent(EntityUid User, float Coefficient = 1.0f);
-
-/// <summary>
-///
-/// </summary>
-[ByRefEvent]
-public record struct MissAttackEvent(int Adjust, bool Miss = false);

--- a/Content.Trauma.Shared/MartialArts/Components/FastSpeedComponent.cs
+++ b/Content.Trauma.Shared/MartialArts/Components/FastSpeedComponent.cs
@@ -22,10 +22,4 @@ public sealed partial class FastSpeedComponent : Component
     /// </summary>
     [DataField(required: true)]
     public SkillCurve DamageScaleCurve = default!;
-
-    /// <summary>
-    /// Makes it so that when you scale when you have less speed, and hit weaker when you have more.
-    /// </summary>
-    [DataField]
-    public bool InvertSpeed;
 }

--- a/Content.Trauma.Shared/MartialArts/MartialArtModifyScaleEvent.cs
+++ b/Content.Trauma.Shared/MartialArts/MartialArtModifyScaleEvent.cs
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Content.Trauma.Shared.MartialArts;
+
+/// <summary>
+/// Raised on a martial art entity to change the scale of its effects.
+/// </summary>
+[ByRefEvent]
+public record struct MartialArtModifyScaleEvent(EntityUid User, float Scale = 1f);

--- a/Content.Trauma.Shared/MartialArts/MartialArtsSystem.Combos.cs
+++ b/Content.Trauma.Shared/MartialArts/MartialArtsSystem.Combos.cs
@@ -123,12 +123,12 @@ public partial class MartialArtsSystem
 
     public void PerformCombo(EntityUid performer, EntityUid target, ComboPrototype proto, Entity<CanPerformComboComponent> ent, int level)
     {
+        // TODO: dont hardcode this here...
         ent.Comp.Momentum += 1;
 
-        float scale = Math.Clamp(((float) (level - proto.LevelRequired)) / 10.0f, 0.1f, 2.0f) + Math.Min(((float) ent.Comp.Momentum) / 20f, 2.0f);
-        var evDamage = new MartialArtDamageModifierEvent(performer, 1);
-        RaiseLocalEvent(ent, ref evDamage);
-        scale *= evDamage.Coefficient;
+        var scaleEv = new MartialArtModifyScaleEvent(performer);
+        RaiseLocalEvent(ent, ref scaleEv);
+        var scale = scaleEv.Scale;
 
         if (proto.UserEffects != null)
             _effects.ApplyEffects(performer, proto.UserEffects, scale, user: performer);

--- a/Content.Trauma.Shared/MartialArts/MartialArtsSystem.cs
+++ b/Content.Trauma.Shared/MartialArts/MartialArtsSystem.cs
@@ -25,6 +25,13 @@ public sealed partial class MartialArtsSystem : EntitySystem
     [Dependency] private readonly SharedEntityEffectsSystem _effects = default!;
     [Dependency] private readonly SharedKnowledgeSystem _knowledge = default!;
     [Dependency] private readonly MovementSpeedModifierSystem _speed = default!;
+    [Dependency] private readonly EntityQuery<PhysicsComponent> _physicsQuery = default!;
+
+    /// <summary>
+    /// Minimum velocity in m/s to scale capoeira effects (like damage) with the user's level.
+    /// </summary>
+    public const float MinVel = 1.5f;
+    public const float MinVelSquared = MinVel * MinVel;
 
     public override void Initialize()
     {
@@ -33,7 +40,7 @@ public sealed partial class MartialArtsSystem : EntitySystem
 
         SubscribeLocalEvent<GrabStagesOverrideComponent, CheckGrabOverridesEvent>(CheckGrabStageOverride);
 
-        SubscribeLocalEvent<FastSpeedComponent, MartialArtDamageModifierEvent>(OnDamageSpeed);
+        SubscribeLocalEvent<FastSpeedComponent, MartialArtModifyScaleEvent>(OnScaleSpeed);
         SubscribeLocalEvent<FastSpeedComponent, RefreshMovementSpeedModifiersEvent>(OnMoveSpeed);
         SubscribeLocalEvent<SneakAttackComponent, ComboAttackPerformedEvent>(OnSneakAttackPerformed);
         SubscribeLocalEvent<SneakAttackComponent, TookDamageEvent>(OnSneakTookDamage);
@@ -52,7 +59,7 @@ public sealed partial class MartialArtsSystem : EntitySystem
         var queryComboComponent = EntityQueryEnumerator<CanPerformComboComponent>();
         while (queryComboComponent.MoveNext(out var ent, out var comp))
         {
-            if (comp.CurrentTarget is { } && TerminatingOrDeleted(comp.CurrentTarget.Value))
+            if (comp.CurrentTarget is { } target && TerminatingOrDeleted(target))
                 comp.CurrentTarget = null;
 
             if (_timing.CurTime < comp.ResetTime || comp.LastAttacks.Count == 0 && comp.Momentum == 0)
@@ -60,8 +67,8 @@ public sealed partial class MartialArtsSystem : EntitySystem
 
             comp.LastAttacks.Clear();
             comp.Momentum = 0;
-            // TODO: find a way to refresh speed here.
             Dirty(ent, comp);
+            // TODO: get user and do _speed.RefreshMovementSpeedModifiers(user);
         }
 
         var kravBlockedQuery = EntityQueryEnumerator<BlockedBreathingComponent>();
@@ -140,21 +147,15 @@ public sealed partial class MartialArtsSystem : EntitySystem
         args.ModifySpeed(1.0f + ((float) combo.Momentum) / 10.0f);
     }
 
-    private void OnDamageSpeed(Entity<FastSpeedComponent> ent, ref MartialArtDamageModifierEvent args)
+    private void OnScaleSpeed(Entity<FastSpeedComponent> ent, ref MartialArtModifyScaleEvent args)
     {
         var user = args.User;
-        if (!TryComp<PhysicsComponent>(user, out var physics))
+        if (!_physicsQuery.TryComp(user, out var physics) || physics.LinearVelocity.LengthSquared() < MinVelSquared)
             return;
 
         var level = _knowledge.GetLevel(ent.Owner);
         var modifier = ent.Comp.DamageScaleCurve.GetCurve(level);
-
-        if (ent.Comp.InvertSpeed)
-            args.Coefficient *= Math.Max(10 - (physics.LinearVelocity.Length()) * modifier, 0);
-        else
-            args.Coefficient *= physics.LinearVelocity.Length() * modifier;
-
-        _speed.RefreshMovementSpeedModifiers(user);
+        args.Scale *= modifier;
     }
 
     private void CheckGrabStageOverride(Entity<GrabStagesOverrideComponent> ent, ref CheckGrabOverridesEvent args)

--- a/Content.Trauma.Shared/MartialArts/MartialArtsSystem.cs
+++ b/Content.Trauma.Shared/MartialArts/MartialArtsSystem.cs
@@ -24,7 +24,7 @@ public sealed partial class MartialArtsSystem : EntitySystem
     [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly SharedEntityEffectsSystem _effects = default!;
     [Dependency] private readonly SharedKnowledgeSystem _knowledge = default!;
-    [Dependency] private readonly MovementSpeedModifierSystem _speed = default!;
+    //[Dependency] private readonly MovementSpeedModifierSystem _speed = default!;
     [Dependency] private readonly EntityQuery<PhysicsComponent> _physicsQuery = default!;
 
     /// <summary>


### PR DESCRIPTION
entity effects no longer have a scale from levels except for capoeira, which is a flat 1-3x that just gets enabled above a minimum velocity, not scaled by it. no more potential 100x damage slop

it was causing 1 minute long stuns with moves that have low skill requirement and high user skill...

:cl:
- tweak: Every martial art except capoeira no longer scales its effects with your level, so you can no longer stun someone for minutes on end with a single move...