### PR TITLE
Removes references to GetAnchoredEntitiesEnumerator(Vector2i) (#37796)

### DIFF
--- a/Content.Shared/Movement/Systems/SharedMoverController.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.cs
@@ -667,7 +667,7 @@ public abstract partial class SharedMoverController : VirtualController
 
         // If the coordinates have a FootstepModifier component
         // i.e. component that emit sound on footsteps emit that sound
-        var anchored = grid.GetAnchoredEntitiesEnumerator(position);
+        var anchored = _mapSystem.GetAnchoredEntitiesEnumerator(xform.GridUid.Value, grid, position);
 
         while (anchored.MoveNext(out var maybeFootstep))
         {

--- a/Content.Shared/Random/Rules/NearbyTilesPercent.cs
+++ b/Content.Shared/Random/Rules/NearbyTilesPercent.cs
@@ -45,7 +45,7 @@ public sealed partial class NearbyTilesPercentRule : RulesRule
             // Only consider collidable anchored (for reasons some subfloor stuff has physics but non-collidable)
             if (IgnoreAnchored)
             {
-                var gridEnum = grid.GetAnchoredEntitiesEnumerator(tile.GridIndices);
+                var gridEnum = mapSys.GetAnchoredEntitiesEnumerator(xform.GridUid.Value, grid, tile.GridIndices);
                 var found = false;
 
                 while (gridEnum.MoveNext(out var ancUid))


### PR DESCRIPTION
missing commit from 11 months ago :face_holding_back_tears: 