### PR TITLE
Increase lobby time again

### DIFF
--- a/Resources/ConfigPresets/_Trauma/trauma.toml
+++ b/Resources/ConfigPresets/_Trauma/trauma.toml
@@ -2,7 +2,7 @@
 role_timers = true
 role_timer_override = "Trauma"
 round_end_pvs_overrides = true
-lobbyduration = 90
+lobbyduration = 180
 fallbackpreset = "Traitor"
 [chat]
 max_announcement_length = 512


### PR DESCRIPTION
## About the PR
1.5 minutes -> 3 minutes.

## Why / Balance
Kill Armos. A lot of people had stated that it is way too short right now.
Resolves #2239 

**Changelog**
:cl:
- tweak: Lobby time increased from 1.5 to 3 minutes.
