### PR TITLE
buzzochloric bee damage fix

### DIFF
--- a/Resources/Prototypes/Reagents/fun.yml
+++ b/Resources/Prototypes/Reagents/fun.yml
@@ -1,34 +1,3 @@
-# SPDX-FileCopyrightText: 2021 Leon Friedrich <60421075+ElectroJr@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2022 Alex Evgrashin <aevgrashin@yandex.ru>
-# SPDX-FileCopyrightText: 2022 CrudeWax <75271456+CrudeWax@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2022 Flipp Syder <76629141+vulppine@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
-# SPDX-FileCopyrightText: 2022 Moony <moonheart08@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2022 Sam Weaver <weaversam8@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2022 ShadowCommander <10494922+ShadowCommander@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2022 metalgearsloth <comedian_vs_clown@hotmail.com>
-# SPDX-FileCopyrightText: 2022 mirrorcult <lunarautomaton6@gmail.com>
-# SPDX-FileCopyrightText: 2022 moonheart08 <moonheart08@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 CrigCrag <137215465+CrigCrag@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 LankLTE <135308300+LankLTE@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 Ubaser <134914314+UbaserB@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Aidenkrz <aiden@djkraz.com>
-# SPDX-FileCopyrightText: 2024 ArtisticRoomba <145879011+ArtisticRoomba@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Ashley Woodiss-Field <ash@DESKTOP-H64M4AI.localdomain>
-# SPDX-FileCopyrightText: 2024 Avalon <148660190+BYONDFuckery@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 ColesMagnum <98577947+AW-FulCode@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Tayrtahn <tayrtahn@gmail.com>
-# SPDX-FileCopyrightText: 2024 Verm <32827189+Vermidia@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Whisper <121047731+QuietlyWhisper@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 potato1234_x <79580518+potato1234x@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 UpAndLeaves <92269094+Alpha-Two@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 Velken <8467292+Velken@users.noreply.github.com>
-#
-# SPDX-License-Identifier: AGPL-3.0-or-later
-
 - type: reagent
   id: Carpetium
   name: reagent-name-carpetium
@@ -84,7 +53,7 @@
   color: "#FFD35D"
   tileReactions:
   - !type:CreateEntityTileReaction
-    entity: MobAngryBee # Goob edit
+    entity: MobAngryBee # Trauma - was MobBee
     usage: 2
     maxOnTile: 2
     randomOffsetMax: 0.3
@@ -163,6 +132,10 @@
           types:
             Poison: 2
             Piercing: 2
+        conditions:
+        - !type:TagCondition
+          inverted: true
+          tag: Bee
 
 - type: reagent
   id: GroundBee

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -71,7 +71,7 @@
       - !type:ModifyStatusEffect
         effectProto: StatusEffectDrowsiness
         time: 4
-        type: Add
+        type: Add # Trauma - was Update, it was completely useless
       - !type:HealthChange
         conditions:
         - !type:ReagentCondition
@@ -310,12 +310,14 @@
   metabolisms:
     Bloodstream:
       effects:
+      # <Trauma>
+      - !type:MutateDiseases
+        mutationRate: 0.08 # 5u equivalent to one normal disease hop
+      # </Trauma>
       - !type:HealthChange
         damage:
           types:
             Radiation: 3
-      - !type:MutateDiseases
-        mutationRate: 0.08 # 5u equivalent to one normal disease hop
 
 - type: reagent
   id: HeartbreakerToxin
@@ -528,8 +530,8 @@
           type: [ Animal, Vox, Plant ]
           inverted: true
     Bloodstream:
-      effects:
     # </Trauma>
+      effects:
       - !type:HealthChange
         conditions:
         - !type:MetabolizerTypeCondition
@@ -757,7 +759,7 @@
       - !type:HealthChange
         conditions:
         - !type:MetabolizerTypeCondition
-          type: [ Arachnid ]
+          type: [Arachnid]
           inverted: true
         damage:
           types:
@@ -768,7 +770,7 @@
           reagent: Mechanotoxin
           min: 2
         - !type:MetabolizerTypeCondition
-          type: [ Arachnid ]
+          type: [Arachnid]
           inverted: true
         walkSpeedModifier: 0.8
         sprintSpeedModifier: 0.8
@@ -778,7 +780,7 @@
           reagent: Mechanotoxin
           min: 4
         - !type:MetabolizerTypeCondition
-          type: [ Arachnid ]
+          type: [Arachnid]
           inverted: true
         walkSpeedModifier: 0.4
         sprintSpeedModifier: 0.4


### PR DESCRIPTION
fixes #2140

cant find what removed the bee blacklist from damage so just reverted to upstream for it

it works ingame but 0.1u isnt enough to spawn bees anyway, who cares