### PR TITLE
fix stuff

### DIFF
--- a/Content.Goobstation.Server/NTR/NTRTaskSystem.cs
+++ b/Content.Goobstation.Server/NTR/NTRTaskSystem.cs
@@ -182,7 +182,7 @@ public sealed class NtrTaskSystem : EntitySystem
     {
         if (!TryComp<NtrTaskDatabaseComponent>(station, out var db)
             || !TryComp<NtrBankAccountComponent>(station, out var account)
-            || !_proto.TryIndex(taskData.Task, out NtrTaskPrototype? taskProto))
+            || !_proto.Resolve(taskData.Task, out NtrTaskPrototype? taskProto))
             return;
 
         var amount = success ? taskProto.Reward : -taskProto.Penalty;

--- a/Content.Goobstation.Shared/Changeling/Systems/FleshmendSystem.cs
+++ b/Content.Goobstation.Shared/Changeling/Systems/FleshmendSystem.cs
@@ -75,7 +75,7 @@ public sealed class FleshmendSystem : EntitySystem
         var now = _timing.CurTime;
         while (query.MoveNext(out var uid, out var comp))
         {
-            if (comp.UpdateTimer > now)
+            if (comp.UpdateTimer < now)
                 continue;
 
             comp.UpdateTimer = now + comp.UpdateDelay;

--- a/Resources/Locale/en-US/_Trauma/prototypes/entity/weapons/grenades.ftl
+++ b/Resources/Locale/en-US/_Trauma/prototypes/entity/weapons/grenades.ftl
@@ -1,2 +1,6 @@
 ent-EmpGrenade = impact EMP grenade
     .desc = An impact grenade designed to wreak havoc on electronic systems.
+
+ent-PipeBombGunpowder = pipe bomb casing
+
+ent-PipeBombCable = unfinished pipe bomb

--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -5,6 +5,12 @@
   description: A shield!
   abstract: true
   components:
+    # <Trauma>
+    - type: DisarmMalus
+      malus: 1
+    - type: CosmicTransmutable
+      transmuteTo: ShieldCosmicCult
+    # </Trauma>
     - type: Sprite
       sprite: Objects/Weapons/Melee/shields.rsi
       state: riot-icon
@@ -61,10 +67,6 @@
                   max: 2
     - type: StaticPrice
       price: 100
-    - type: DisarmMalus # Goobstation
-      malus: 1
-    - type: CosmicTransmutable # Trauma
-      transmuteTo: ShieldCosmicCult
 
 - type: entity
   name: base repairable shield
@@ -92,6 +94,17 @@
   id: RiotShield
   description: A large tower shield. Good for controlling crowds.
   components:
+    # <Trauma>
+    - type: Parry
+      maxParries: 5
+      maxReflects: 0
+      parryMinSkill: 30
+      soundOnParry:
+        path: /Audio/Weapons/block_metal1.ogg
+        params:
+          variation: 0.2
+          volume: -11
+    # </Trauma>
     - type: StaticPrice
       price: 90
     - type: Blocking
@@ -106,17 +119,6 @@
         flatReductions:
           Blunt: 1
           Slash: 1
-    # <Trauma>
-    - type: Parry
-      maxParries: 5
-      maxReflects: 0
-      parryMinSkill: 30
-      soundOnParry:
-        path: /Audio/Weapons/block_metal1.ogg
-        params:
-          variation: 0.2
-          volume: -11
-    # </Trauma>
 
 - type: entity
   name: laser shield
@@ -124,19 +126,6 @@
   id: RiotLaserShield
   description: A shield built for withstanding lasers, but not much else.
   components:
-    - type: Sprite
-      state: riot_laser-icon
-    - type: Item
-      heldPrefix: riot_laser
-    - type: Blocking
-      passiveBlockModifier:
-        coefficients:
-          Heat: 0.7
-      activeBlockModifier:
-        coefficients:
-          Heat: 0.5
-        flatReductions:
-          Heat: 1
     # <Trauma>
     - type: Parry
       maxParries: 0
@@ -151,6 +140,19 @@
       reflects:
       - Energy
     # </Trauma>
+    - type: Sprite
+      state: riot_laser-icon
+    - type: Item
+      heldPrefix: riot_laser
+    - type: Blocking
+      passiveBlockModifier:
+        coefficients:
+          Heat: 0.7
+      activeBlockModifier:
+        coefficients:
+          Heat: 0.5
+        flatReductions:
+          Heat: 1
 
 - type: entity
   name: ballistic shield
@@ -158,20 +160,6 @@
   id: RiotBulletShield
   description: A shield built for protecting against ballistics, but not much else.
   components:
-    - type: Sprite
-      sprite: _Goobstation/Objects/Shields/riotbulletshield.rsi # Goobstation
-      state: ballistic-icon
-    - type: Item
-      heldPrefix: ballistic
-    - type: Blocking
-      passiveBlockModifier:
-        coefficients:
-          Piercing: 0.7
-      activeBlockModifier:
-        coefficients:
-          Piercing: 0.5
-        flatReductions:
-          Piercing: 1
     # <Trauma>
     - type: Parry
       maxParries: 0
@@ -186,6 +174,21 @@
       reflects:
       - NonEnergy
     # </Trauma>
+    - type: Sprite
+      sprite: _Goobstation/Objects/Shields/riotbulletshield.rsi # Trauma
+      state: ballistic-icon
+    - type: Item
+      sprite: _Goobstation/Objects/Shields/riotbulletshield.rsi # Trauma
+      heldPrefix: ballistic
+    - type: Blocking
+      passiveBlockModifier:
+        coefficients:
+          Piercing: 0.7
+      activeBlockModifier:
+        coefficients:
+          Piercing: 0.5
+        flatReductions:
+          Piercing: 1
 
 #Craftable shields
 
@@ -250,6 +253,23 @@
   id: CardShield
   description: A shield made of cardboard. Won't protect you from much.
   components:
+    # <Trauma>
+    - type: Parry
+      maxParries: 1
+      maxReflects: 0
+      parryMinSkill: 0
+      soundOnParry:
+        path: /Audio/Items/Toys/card_tube_bonk.ogg
+        params:
+          variation: 0.2
+          volume: -11
+    - type: PhysicalComposition
+      materialComposition:
+        Cardboard: 300
+    - type: Tag
+      tags:
+      - Trash
+    # </Trauma>
     - type: Sprite
       state: cardshield-icon
     - type: Item
@@ -302,23 +322,6 @@
               max: 4
     - type: StaticPrice
       price: 20
-    # <Trauma>
-    - type: Parry
-      maxParries: 1
-      maxReflects: 0
-      parryMinSkill: 0
-      soundOnParry:
-        path: /Audio/Items/Toys/card_tube_bonk.ogg
-        params:
-          variation: 0.2
-          volume: -11
-    - type: PhysicalComposition
-      materialComposition:
-        Cardboard: 300
-    - type: Tag
-      tags:
-      - Trash
-    # </Trauma>
 
 - type: entity
   name: makeshift shield


### PR DESCRIPTION
fixes #2281
fixes #2271

gave pipe bomb steps unique names so they can be properly automated

:cl:
- fix: Fixed changeling fleshmend not actually doing anything.
- fix: Fixed ballistic shields not having inhand sprites.
- tweak: Pipe bomb crafting intermediates now have unique names you can use in filters.