### PR TITLE
make armory override key a little easier to make

### DIFF
--- a/Resources/Prototypes/_Trauma/Recipes/Crafting/Graphs/other.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Crafting/Graphs/other.yml
@@ -55,14 +55,6 @@
         icon:
           sprite: _Trauma/Objects/Tools/overridecomponents.rsi
           state: icon
-      - tag: OverrideKeyComponents
-        doAfter: 5
-        name: construction-graph-tag-overridekeycomponents
-        icon:
-          sprite: _Trauma/Objects/Tools/overridecomponents.rsi
-          state: icon
-      - tool: Screwing
-        doAfter: 3
 
   - node: finished
     entity: ArmoryOverrideKey


### PR DESCRIPTION
- only needs 3 pieces instead of 4
- no screwdriver step, ummmm cmo you didnt powergame a screwdriver now you get mowed down by nukies or whatever

:cl:
- tweak: Armory override key now only needs 3 pieces instead of 4.