### PR TITLE
no free 40mm shiftstart

### DIFF
--- a/Resources/Prototypes/_Goobstation/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/Fills/Lockers/security.yml
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 - type: entity
-  parent: [GunSafeBaseSecure, BaseSecurityContraband]
+  parent: [GunSafeBaseSecure, BaseSecurityContraband, AlertLevelLock]
   id: GunSafeLauncherNonLethal
   name: riot launcher safe
   components:
@@ -18,6 +18,10 @@
         - id: BoxGrenadesBaton
         - id: BoxGrenadesFlash
         - id: BoxGrenadesTeargas
+  - type: StationAlertLevelLock
+    lockedAlertLevels:
+    - green
+    - yellow
 
 # Detective Locker with Hardsuit
 - type: entityTable


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->
me copy
me paste
me commit
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
40mm to the chest on green alert does something to a man
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: 40mm Riot Launcher is now alert level locked to blue alert or higher.