### PR TITLE
clean up blob slop

### DIFF
--- a/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
@@ -243,23 +243,6 @@
       - MindRoleBlob
 
 - type: entity
-  id: BlobSpawn
-  parent: BaseGameRule
-  categories: [ HideSpawnMenu ]
-  components:
-  - type: StationEvent
-    weight: 1
-    duration: 1
-    earliestStart: 75
-    minimumPlayers: 20
-    maxOccurrences: 2
-  - type: BlobSpawnRule
-    carrierBlobProtos:
-    - SpawnPointGhostBlobRat
-    playersPerCarrierBlob: 30
-    maxCarrierBlob: 1
-
-- type: entity
   parent: BaseNukeopsRule
   id: Honkops
   components:

--- a/Resources/Prototypes/_Goobstation/threats.yml
+++ b/Resources/Prototypes/_Goobstation/threats.yml
@@ -28,7 +28,7 @@
 - type: ninjaHackingThreat
   id: Blob
   announcement: terror-blob
-  rule: BlobSpawn
+  rule: BlobMidround
 
 - type: ninjaHackingThreat
   id: VoxRaiders

--- a/Resources/Prototypes/_Trauma/GameRules/security.yml
+++ b/Resources/Prototypes/_Trauma/GameRules/security.yml
@@ -22,7 +22,7 @@
         weight: 0.5 # even more antags!
       - id: LoneOpsSpawn
         weight: 0.2
-      - id: BlobSpawn
+      - id: BlobMidround
         weight: 0.2
       - !type:AllSelector
         weight: 0.3


### PR DESCRIPTION
kill duplicate midround blob rule, BlobSpawn which had minplayers of 20...
it was only used by ninja and antag summoner threats