### PR TITLE
forgot to add alien belt to abductor shuttle

### DIFF
--- a/Resources/Maps/_Trauma/Shuttles/abductor_shuttle.yml
+++ b/Resources/Maps/_Trauma/Shuttles/abductor_shuttle.yml
@@ -1,11 +1,11 @@
 meta:
   format: 7
   category: Grid
-  engineVersion: 275.2.0
+  engineVersion: 276.0.0
   forkId: ""
   forkVersion: ""
-  time: 04/26/2026 15:31:39
-  entityCount: 475
+  time: 05/02/2026 12:49:14
+  entityCount: 476
 maps: []
 grids:
 - 1
@@ -117,10 +117,11 @@ entities:
       data:
         tiles:
           0,0:
-            0: 53239
+            0: 53235
+            1: 4
           0,-1:
             0: 32740
-            1: 1
+            2: 1
           -1,0:
             0: 3549
           0,1:
@@ -141,25 +142,25 @@ entities:
             0: 8
           -1,-1:
             0: 56593
-            2: 4
+            3: 4
           0,-4:
-            3: 12288
+            4: 12288
             0: 50176
           0,-3:
-            3: 887
+            4: 887
             0: 50176
           -1,-4:
-            3: 32768
+            4: 32768
             0: 25600
           -1,-3:
-            3: 2252
+            4: 2252
             0: 29697
           0,-2:
             0: 17663
-            1: 4096
+            2: 4096
           -1,-2:
             0: 4351
-            2: 16384
+            3: 16384
           1,-3:
             0: 20513
           1,-2:
@@ -174,6 +175,11 @@ entities:
           moles:
             Oxygen: 21.824879
             Nitrogen: 82.10312
+        - volume: 2500
+          temperature: 293.14975
+          moles:
+            Oxygen: 20.078888
+            Nitrogen: 75.53487
         - volume: 2500
           temperature: 293.15
           moles:
@@ -1122,6 +1128,13 @@ entities:
     - type: Transform
       pos: -1.5,6.5
       parent: 1
+- proto: ClothingAbductorBeltFilled
+  entities:
+  - uid: 457
+    components:
+    - type: Transform
+      pos: -1.5089359,-0.3125
+      parent: 1
 - proto: ClothingBackpackDuffelAbductorFilled
   entities:
   - uid: 160
@@ -1179,6 +1192,14 @@ entities:
     - type: Transform
       pos: 2.5,0.5
       parent: 1
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
 - proto: Defibrillator
   entities:
   - uid: 164


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->
added missing alien belt
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [ ] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [ ] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
--> 🆑 assripper.

 - fix: the alien belt now actually spawns on the abductor shuttle
