### PR TITLE
fixes maintspawnrule spawning shit in walls

### DIFF
--- a/Content.Goobstation.Server/Antag/MaintsSpawn/MaintsSpawnRuleSystem.cs
+++ b/Content.Goobstation.Server/Antag/MaintsSpawn/MaintsSpawnRuleSystem.cs
@@ -46,7 +46,7 @@ public sealed class MaintsSpawnRule : StationEventSystem<MaintsSpawnRuleComponen
                 continue;
 
             var coords = xform.Coordinates; // areas should always be parented to a grid, just round the coords
-            var tile = new Vector2i((int) MathF.Floor(coords.X), (int) MathF.Floor(coords.Y)); // Trauma
+            var tile = new Vector2i((int) MathF.Floor(coords.X), (int) MathF.Floor(coords.Y));
             if (_atmos.IsTileAirBlockedCached(grid, tile))
                 continue;
 

--- a/Content.Goobstation.Server/Antag/MaintsSpawn/MaintsSpawnRuleSystem.cs
+++ b/Content.Goobstation.Server/Antag/MaintsSpawn/MaintsSpawnRuleSystem.cs
@@ -46,7 +46,7 @@ public sealed class MaintsSpawnRule : StationEventSystem<MaintsSpawnRuleComponen
                 continue;
 
             var coords = xform.Coordinates; // areas should always be parented to a grid, just round the coords
-            var tile = new Vector2i((int) coords.X, (int) coords.Y);
+            var tile = new Vector2i((int) MathF.Floor(coords.X), (int) MathF.Floor(coords.Y)); // Trauma
             if (_atmos.IsTileAirBlockedCached(grid, tile))
                 continue;
 


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->
fixes things using maintspawnrule spawning inside walls leading to chudshift
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [ ] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [ ] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
--> 🆑 assripper.

 - fix: maintspawnrule no longer spawns antags inside walls
