### PR TITLE
increase wheelchair item size

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Vehicles/vehicles.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Vehicles/vehicles.yml
@@ -1,20 +1,3 @@
-# SPDX-FileCopyrightText: 2024 Aviu00 <93730715+Aviu00@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 BombasterDS <115770678+BombasterDS@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Piras314 <p1r4s@proton.me>
-# SPDX-FileCopyrightText: 2024 Scruq445 <storchdamien@gmail.com>
-# SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 Aidenkrz <aiden@djkraz.com>
-# SPDX-FileCopyrightText: 2025 BramvanZijp <56019239+BramvanZijp@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 Fishbait <Fishbait@git.ml>
-# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
-# SPDX-FileCopyrightText: 2025 Ilya246 <ilyukarno@gmail.com>
-# SPDX-FileCopyrightText: 2025 Killerqu00 <47712032+Killerqu00@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 SX-7 <92227810+SX-7@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>
-# SPDX-FileCopyrightText: 2025 Theodore Lukin <66275205+pheenty@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 Thom <119594676+ItsMeThom@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 fishbait <gnesse@gmail.com>
-#
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 - type: entity
@@ -237,6 +220,10 @@
       map: ["foldedLayer"]
       visible: false
     noRot: true
+  - type: Item
+    size: Large
+    shape:
+    - 0,0,2,1
   - type: Vehicle
     requiredHands: 0
     engineRunning: true


### PR DESCRIPTION
its now 3x2 large instead of same size as a cig pack

resolves #2384

## Media
<img width="143" height="86" alt="20:45:08" src="https://github.com/user-attachments/assets/11e30fd8-19d0-4e2e-b205-4710da511f62" />


**Changelog**
:cl:
- tweak: Increased folded wheelchair's item size to 3x2.