### PR TITLE
fix abductors not showing in round end summary

### DIFF
--- a/Resources/Prototypes/_Shitmed/GameRules/events.yml
+++ b/Resources/Prototypes/_Shitmed/GameRules/events.yml
@@ -21,6 +21,7 @@
   - type: AntagLoadProfileRule
     speciesHardOverride: Abductor
   - type: AntagSelection
+    agentName: abductor-round-end-agent-name
     definitions:
     - spawnerPrototype: LoneAbductorSpawner
       min: 1


### PR DESCRIPTION
:cl:
- fix: Fixed abductors not being listed in the round end summary.