### PR TITLE
delete xenobio extracts when used

### DIFF
--- a/Content.Trauma.Shared/EntityEffects/Delete.cs
+++ b/Content.Trauma.Shared/EntityEffects/Delete.cs
@@ -9,6 +9,9 @@ namespace Content.Trauma.Shared.EntityEffects;
 /// </summary>
 public sealed partial class Delete : EntityEffectBase<Delete>
 {
+    [DataField]
+    public bool Queued;
+
     public override string? EntityEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
         => Loc.GetString("entity-effect-guidebook-delete-entity", ("chance", Probability));
 }
@@ -17,7 +20,13 @@ public sealed class DeleteEffectSystem : EntityEffectSystem<MetaDataComponent, D
 {
     protected override void Effect(Entity<MetaDataComponent> ent, ref EntityEffectEvent<Delete> args)
     {
-        if (!TerminatingOrDeleted(ent, ent.Comp))
-            PredictedDel(ent.AsNullable());
+        if (TerminatingOrDeleted(ent, ent.Comp))
+            return;
+
+        var meta = ent.AsNullable();
+        if (args.Effect.Queued)
+            PredictedQueueDel(meta);
+        else
+            PredictedDel(meta);
     }
 }

--- a/Resources/Prototypes/_Trauma/EntityEffects/xenobio.yml
+++ b/Resources/Prototypes/_Trauma/EntityEffects/xenobio.yml
@@ -6,10 +6,9 @@
   - !type:RemoveComponents
     guidebookText: entity-effect-guidebook-remove-reactive
     components:
-    - type: Reactive # prevent double dipping
-  - !type:AddTag
-    tag: Trash
-    guidebookText: entity-effect-guidebook-add-trash-tag
+    - type: Reactive # prevent double dipping if it somehow reacts again in the same tick
+  - !type:Delete
+    queued: true # needs to still exist for most effects to work properly
   - !type:PlaySoundEffect
     sound: /Audio/Effects/Chemistry/bubbles.ogg
 


### PR DESCRIPTION
trash tag no longer needed since they just get deleted
resolves #2425

:cl:
- tweak: Xenobio slime extracts despawn when reacting instead of just being trash.