### PR TITLE
dont delete reagent ones, update wrong uses of reagent

### DIFF
--- a/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t1/metal.yml
+++ b/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t1/metal.yml
@@ -15,7 +15,7 @@
       methods: [ Touch, Injection ]
       effects:
       - !type:NestedEffect
-        proto: XenobioExtractReagent
+        proto: XenobioExtractReaction
       - !type:SpawnEntity
         entity: SheetGlass15
       - !type:SpawnEntity

--- a/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t4/light_pink.yml
+++ b/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t4/light_pink.yml
@@ -14,7 +14,7 @@
       methods: [ Touch, Injection ]
       effects:
       - !type:NestedEffect
-        proto: XenobioExtractReagent
+        proto: XenobioExtractReaction
       - !type:DoSmokeEffect
         duration: 15
         spreadAmount: 50

--- a/Resources/Prototypes/_Trauma/EntityEffects/xenobio.yml
+++ b/Resources/Prototypes/_Trauma/EntityEffects/xenobio.yml
@@ -42,8 +42,15 @@
 - type: entityEffect
   id: XenobioExtractReagent
   effects:
-  - !type:NestedEffect
-    proto: XenobioExtractBase
+  - !type:RemoveComponents
+    guidebookText: entity-effect-guidebook-remove-reactive
+    components:
+    - type: Reactive # prevent double dipping if it somehow reacts again in the same tick
+  - !type:PlaySoundEffect
+    sound: /Audio/Effects/Chemistry/bubbles.ogg
+  - !type:AddTag
+    tag: Trash
+    guidebookText: entity-effect-guidebook-add-trash-tag
   - !type:PopupMessage
     type: Pvs
     messages: [ "xeno-extract-reaction-reagent" ]


### PR DESCRIPTION
extracts that make reagents dont get deleted
made a few extract reactions use the correct effect proto, previously the only difference was popup but now they actually matter. spawning steel doesnt need the extract to keep existing