### PR TITLE
Fix wound healing and bone breaking.

### DIFF
--- a/Content.Medical.Shared/Traumas/Systems/TraumaSystem.Process.cs
+++ b/Content.Medical.Shared/Traumas/Systems/TraumaSystem.Process.cs
@@ -650,6 +650,10 @@ public partial class TraumaSystem
 
             switch (trauma)
             {
+                case TraumaType.BoneDamage:
+                    ApplyBoneTrauma(targetChosen.Value, target, inflicter, severity);
+                    break;
+
                 case TraumaType.OrganDamage:
                     var traumaEnt = AddTrauma(targetChosen.Value, target, inflicter, TraumaType.OrganDamage, severity);
 

--- a/Content.Shared/Damage/Systems/DamageableSystem.ShitmedParts.cs
+++ b/Content.Shared/Damage/Systems/DamageableSystem.ShitmedParts.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Content.Medical.Common.Damage;
+using Content.Medical.Common.Healing;
 using Content.Medical.Common.Targeting;
 using Content.Shared.Body;
 using Content.Shared.Damage.Components;
@@ -282,6 +283,21 @@ public sealed partial class DamageableSystem
 
                 goto case SplitDamageBehavior.SplitEnsureAll;
             case SplitDamageBehavior.SplitEnsureAll:
+
+                var healDamageTypes = newDamage.DamageDict.Where(x => x.Value < 0).Select(x => x.Key.Id).ToList();
+                var woundedParts = new List<EntityUid>();
+                if (healDamageTypes.Count > 0)
+                {
+                    var ev = new CheckPartWoundedEvent(healDamageTypes);
+                    foreach (var part in parts)
+                    {
+                        ev.Wounded = false;
+                        RaiseLocalEvent(part, ref ev);
+                        if (ev.Wounded)
+                            woundedParts.Add(part);
+                    }
+                }
+
                 foreach (var (type, val) in newDamage.DamageDict)
                 {
                     // project 0 comments :face_holding_back_tears:
@@ -298,8 +314,9 @@ public sealed partial class DamageableSystem
 
                         foreach (var part in parts)
                         {
-                            if (part.Comp.Damage.DamageDict.TryGetValue(type, out var currentDamage)
-                                && currentDamage > 0)
+                            if (woundedParts.Contains(part.Owner) ||
+                                part.Comp.Damage.DamageDict.TryGetValue(type, out var currentDamage) &&
+                                currentDamage > 0)
                                 count++;
                         }
 


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->

Fixes #2325
Fixes wounds not healing sometimes for SplitEnsureAll behavior - it checked parts which had damage on them but didn't check for wounds, so part would have been ignored if damage is 0 but wounds present.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Aviu
- fix: Fix bones not breaking.
- fix: Fix wounds not healing sometimes.