### PR TITLE
Nerf most guns

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/antimateriel.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/antimateriel.yml
@@ -49,4 +49,4 @@
       armorPenetration: 0.5 # Goobstation
     penetrationThreshold: 100 # Goobstation - This count as penetration health
   - type: StaminaDamageOnCollide
-    damage: 115 # Goob edit
+    damage: 50 # Goob edit

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/caseless_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/caseless_rifle.yml
@@ -7,8 +7,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 25 # Goobstation edit
-      armorPenetration: -0.3 # Goobstation
+        Piercing: 14 # Trauma, was 25
+      armorPenetration: -0.5 # Trauma
 
 - type: entity
   parent: BaseBulletPractice

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/light_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/light_rifle.yml
@@ -40,8 +40,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 19
-      armorPenetration: 0.4 # Goobstation
+        Piercing: 15 # Trauma, was 19
 
 - type: entity
   parent: BaseBulletPractice
@@ -63,8 +62,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 14
-        Heat: 5
+        Piercing: 11 # Trauma, was 14
+        # Heat: 5 # Trauma
 
 - type: entity
   parent: [BaseBulletUranium, BaseBulletKinetic] # Trauma
@@ -75,5 +74,6 @@
   - type: Projectile
     damage:
       types:
-        Radiation: 10
+        # Radiation: 10 # Trauma
         Piercing: 11
+      armorPenetration: 0.5 # Trauma

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/magnum.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/magnum.yml
@@ -7,7 +7,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 35
+        Piercing: 20 # Trauma, was 35
 
 - type: entity
   parent: BaseBulletPractice
@@ -29,8 +29,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 26
-        Heat: 9
+        Piercing: 17 # Trauama, was 26
+        # Heat: 9 # Trauma
 
 - type: entity
   parent: [BaseBulletAP, BaseBulletKinetic] # Trauma
@@ -41,7 +41,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 28 # Goobstation edit
+        Piercing: 20 # Trauma, was 28
       armorPenetration: 0.75 # Goobstation
 
 - type: entity
@@ -53,5 +53,6 @@
   - type: Projectile
     damage:
       types:
-        Radiation: 15
-        Piercing: 20
+        # Radiation: 15 # Trauma
+        Piercing: 17 # Trauma, was 20
+      armorPenetration: 0.5 # Trauma

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/pistol.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/pistol.yml
@@ -36,7 +36,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 16
+        Piercing: 11 # Trauma, was 16
 
 - type: entity
   parent: BaseBulletPractice
@@ -58,8 +58,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 12
-        Heat: 4
+        Piercing: 9 # Trauma, was 12
+        # Heat: 4 # Trauma
 
 - type: entity
   parent: [BaseBulletUranium, BaseBulletKinetic] # Trauma
@@ -70,5 +70,6 @@
   - type: Projectile
     damage:
       types:
-        Radiation: 6
-        Piercing: 10
+        # Radiation: 6
+        Piercing: 9 # Trauma, was 10
+      armorPenetration: 0.5 # Trauma

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/rifle.yml
@@ -40,8 +40,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 17
-      armorPenetration: 0.15 # Goobstation
+        Piercing: 13 # Trauma, was 17
 
 - type: entity
   parent: BaseBulletPractice
@@ -63,8 +62,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 12
-        Heat: 5
+        Piercing: 10 # Trauma, was 12
+        # Heat: 5 # Trauma
 
 - type: entity
   parent: BaseBulletUranium
@@ -75,5 +74,6 @@
   - type: Projectile
     damage:
       types:
-        Radiation: 9
-        Piercing: 10
+        Radiation: 10 # Trauma, was 9
+        # Piercing: 10 # Trauma
+      armorPenetration: 0.5 # Trauma

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
@@ -151,7 +151,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 10
+        Piercing: 7 # Trauma, was 10
         Structural: 15
 
 - type: entity
@@ -173,8 +173,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 7
-        Heat: 3
+        Piercing: 5 # Trauma, was 7
+        # Heat: 3 # Trauma
   - type: IgnitionSource
     ignited: true
 
@@ -185,7 +185,7 @@
   components:
   - type: ProjectileSpread
     proto: PelletShotgunIncendiary
-    count: 4
+    count: 6 # Trauma, was 4
     spread: 15
 
 - type: entity
@@ -310,8 +310,9 @@
   - type: Projectile
     damage:
       types:
-        Radiation: 5
+        # Radiation: 5 # Trauma
         Piercing: 5
+      armorPenetration: 0.5 # Trauma
 
 - type: entity
   parent: PelletShotgunUranium
@@ -320,7 +321,7 @@
   components:
   - type: ProjectileSpread
     proto: PelletShotgunUranium
-    count: 5
+    count: 6 # Trauma, was 5
     spread: 6
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -222,7 +222,7 @@
     storedOffset: 0,-2
   - type: Gun
     selectedMode: SemiAuto
-    fireRate: 1.5 # Goobstation
+    fireRate: 2 # Trauma, was 3
     availableModes:
     - SemiAuto
     soundGunshot:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -183,7 +183,7 @@
   - type: Clothing
     sprite: Objects/Weapons/Guns/Rifles/lecter.rsi
   - type: Gun
-    fireRate: 5
+    fireRate: 4 # Trauma, as 5
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/ltrifle.ogg
   - type: ItemSlots

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -124,9 +124,10 @@
 #    minAngle: -19
 #    maxAngle: -16
   - type: Gun
-#    minAngle: 21 # Base SMG already has minAngle: 2 maxAngle: 16
-#    maxAngle: 32 # Goob - one-handed C20R - end
+    minAngle: 4 # # Trauma, was 21
+    maxAngle: 36 # Trauma, was 32
     shotsPerBurst: 5
+    fireRate: 8
     availableModes:
     - Burst
     - FullAuto
@@ -221,7 +222,7 @@
       - FullAuto
       - SemiAuto
       shotsPerBurst: 3
-      burstCooldown: 0.375
+      burstCooldown: 0.75 # Trauma, was 0.375
     - type: ItemSlots
       slots:
         gun_magazine:
@@ -272,7 +273,7 @@
   - type: Gun # Goobstation - I am the one who nerfs the WT.
     minAngle: 2
     maxAngle: 16
-    fireRate: 5
+    fireRate: 4 # trauma, was 5
     burstFireRate: 8
     angleIncrease: 3
     angleDecay: 16

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -194,7 +194,7 @@
     sprite: Objects/Weapons/Guns/Snipers/heavy_sniper.rsi
   - type: GunRequiresWield
   - type: Gun
-    # fireRate: 0.4 # Goobstation
+    fireRate: 0.4 # Trauma, was 0.8
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Rifles/rifle.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Rifles/rifle.yml
@@ -30,7 +30,7 @@
   - type: Clothing
     sprite: _Goobstation/Objects/Weapons/Guns/Rifles/burner.rsi
   - type: Gun
-    fireRate: 3
+    fireRate: 2
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/sniper.ogg
   - type: ChamberMagazineAmmoProvider

--- a/Resources/Prototypes/_Trauma/Entities/Objects/PatreonItems/patreonitems.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Objects/PatreonItems/patreonitems.yml
@@ -135,10 +135,10 @@
     - TauCetiBasic
 
 - type: entity
-  parent: ClothingOuterStorageBase
+  parent: [ClothingOuterStorageBase, AllowSuitStorageClothingGasTanks]
   id: PatreonGungeonologist
-  name: bomber jacket
-  description: A green bomber jacket, dont ask what it's made out of.
+  name: bloodied bomber jacket
+  description: A worn bomber jacket with a number of aged blood stains. The inside of the collar has the word "Gunderaan" printed on it.
   components:
   - type: Sprite
     sprite: _Trauma/Objects/Patreon/TheGungeonologist/bomberjacket.rsi
@@ -148,7 +148,7 @@
 - type: entity
   parent: ClothingEyesBase
   id: PatreonGungeonologist2
-  name: cup goggles
+  name: surgical goggles
   description: Good for keeping sand out of your eyes.
   components:
   - type: Sprite
@@ -372,17 +372,23 @@
     sprite: _Trauma/Objects/Patreon/droktober.rsi
 
 - type: entity
-  parent: ClothingNeckBase
+  parent: [ClothingNeckBase, BaseToggleClothing]
   id: PatreonDaniels
   name: time cloak
   description: The clock on the back is broken...
   components:
+  - type: ToggleClothing
+    action: ActionBecomeValid
+    disableOnUnequip: true
+  - type: ComponentToggler
+    parent: true
+    components:
+    - type: KillSign
   - type: Sprite
     sprite: _Trauma/Objects/Patreon/daniels.rsi
   - type: Clothing
     quickEquip: true
     sprite: _Trauma/Objects/Patreon/daniels.rsi
-
 
 - type: entity
   parent: ClothingNeckBase
@@ -398,7 +404,7 @@
 
 - type: entity
   parent: BaseFigurine
-  id: PatreonSupermage
+  id: PatreonSuperMage
   name: tweaking mouse
   description: Tweaks!
   components:

--- a/Resources/Prototypes/_Trauma/Loadouts/exclusive.yml
+++ b/Resources/Prototypes/_Trauma/Loadouts/exclusive.yml
@@ -115,6 +115,42 @@
   - !type:PlayerGUIDLoadoutEffect
     guid: 179d5e03-6b1a-4f92-bb31-2f4fe4fd631d
 
+- type: loadoutEffectGroup
+  id: LtKRY
+  effects:
+  - !type:PlayerGUIDLoadoutEffect
+    guid: 5b4f2f1b-2422-4b59-b8de-d9853d683332
+
+- type: loadoutEffectGroup
+  id: DrOktober
+  effects:
+  - !type:PlayerGUIDLoadoutEffect
+    guid: ed870ec2-2e3d-4585-8a3e-fe0087eecbd2
+
+- type: loadoutEffectGroup
+  id: Daniels
+  effects:
+  - !type:PlayerGUIDLoadoutEffect
+    guid: bce4d1a7-7bed-499a-96ce-798902c4aeb0
+
+- type: loadoutEffectGroup
+  id: Catdere
+  effects:
+  - !type:PlayerGUIDLoadoutEffect
+    guid: a64de73b-9435-467c-b0dc-8e3607e17ea4
+
+- type: loadoutEffectGroup
+  id: SuperMage
+  effects:
+  - !type:PlayerGUIDLoadoutEffect
+    guid: c425e547-0f6c-470d-b588-e3ebd736ac57
+
+- type: loadoutEffectGroup
+  id: Dino
+  effects:
+  - !type:PlayerGUIDLoadoutEffect
+    guid: 46ed7573-2b2c-475a-94c3-038ebab10bf1
+
 #Items (ADD TO ExclusiveItems OR IT WONT EXIST)
 - type: loadout
   id: CybersunFlippo
@@ -261,3 +297,58 @@
   storage:
     back:
     - PatreonToasterStrudels
+
+- type: loadout
+  id: PatreonLtKRY
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: LtKRY
+  storage:
+    back:
+    - PatreonltKRYSuit
+    - PatreonltKRYHat
+
+- type: loadout
+  id: PatreonDrOktober
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: DrOktober
+  storage:
+    back:
+    - PatreonDrOktober
+
+- type: loadout
+  id: PatreonDaniels
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: Daniels
+  storage:
+    back:
+    - PatreonDaniels
+
+- type: loadout
+  id: PatreonCatdere
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: Catdere
+  storage:
+    back:
+    - PatreonCatdere
+
+- type: loadout
+  id: PatreonSuperMage
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SuperMage
+  storage:
+    back:
+    - PatreonSuperMage
+
+- type: loadout
+  id: PatreonDino
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: Dino
+  storage:
+    back:
+    - PatreonDino

--- a/Resources/Prototypes/_Trauma/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_Trauma/Loadouts/loadout_groups.yml
@@ -53,3 +53,9 @@
   - PatreoniDoppel
   - PatreonWraith_man
   - PatreonToasterStrudels
+  - PatreonLtKRY
+  - PatreonDrOktober
+  - PatreonDaniels
+  - PatreonCatdere
+  - PatreonSuperMage
+  - PatreonDino


### PR DESCRIPTION

:cl: Asardonicsailor (Joel)
- tweak: All incend ammo loses its heat damage and some pierce damage
- tweak: All uranium ammo loses its radiation damage and some pierce damage
- tweak: All uranium ammo gains bonus AP
- tweak: Burner firerate 3 > 2
- tweak: Hristov stam damage 115 > 50
- tweak: Hristov firerate 0.8 > 0.4
- tweak: cobra damage 25 > 14
- tweak: cobra ap -0.3 > -0.5
- tweak: light rifle damage 19 > 15
- tweak: magnum damage 35 > 20
- tweak: pistol damage 16 > 11
- tweak: heavy rifle damage 17 > 13
- tweak: shotgun pellet damage 10 > 7
- tweak: Python firerate 1.5 > 2
- tweak: Lecter firerate 5 > 4
- tweak: C20-R spread increased significantly
- tweak: Drozd burst cooldown 0.375 > 0.75
- tweak: WT550 firerate 5 > 4
