### PR TITLE
restrict dragon rifts to station areas

### DIFF
--- a/Content.Server/Dragon/DragonSystem.cs
+++ b/Content.Server/Dragon/DragonSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.Devour.Components;
 using Content.Shared.NPC.Components;
 using Content.Shared.Sprite;
 using Content.Shared.Stunnable;
+using Content.Trauma.Common.Dragon;
 using Content.Trauma.Common.Sprite;
 using Robust.Shared.Serialization.Manager;
 // </Trauma>
@@ -200,6 +201,17 @@ public sealed partial class DragonSystem : EntitySystem
             _popup.PopupEntity(Loc.GetString("carp-rift-space-proximity", ("proximity", RiftTileRadius)), uid, uid);
             return;
         }
+
+        // <Trauma> - allow for area checks
+        var ev = new DragonSpawnRiftAttemptEvent();
+        RaiseLocalEvent(uid, ref ev);
+        if (ev.Cancelled)
+        {
+            if (ev.Popup is { } popup)
+                _popup.PopupEntity(popup, uid, uid);
+            return;
+        }
+        // </Trauma>
 
         var carpUid = Spawn(component.RiftPrototype, _transform.GetMapCoordinates(uid, xform: xform));
         Transform(carpUid).LocalRotation = Angle.Zero;

--- a/Content.Trauma.Common/Dragon/DragonSpawnRiftAttemptEvent.cs
+++ b/Content.Trauma.Common/Dragon/DragonSpawnRiftAttemptEvent.cs
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Content.Trauma.Common.Dragon;
+
+/// <summary>
+/// Event raised on the dragon when it tries to spawn a rift.
+/// Popup is shown to the user if cancelled and it's non-null.
+/// </summary>
+[ByRefEvent]
+public record struct DragonSpawnRiftAttemptEvent(bool Cancelled = false, string? Popup = null);

--- a/Content.Trauma.Shared/Areas/StationAreaComponent.cs
+++ b/Content.Trauma.Shared/Areas/StationAreaComponent.cs
@@ -3,8 +3,7 @@
 namespace Content.Trauma.Shared.Areas;
 
 /// <summary>
-/// Marker component for all areas, used for area lookup.
+/// Marker component for areas belonging to the station.
 /// </summary>
 [RegisterComponent, NetworkedComponent]
-[EntityCategory("Areas")]
-public sealed partial class AreaComponent : Component;
+public sealed partial class StationAreaComponent : Component;

--- a/Content.Trauma.Shared/Dragon/DragonAreaRiftsComponent.cs
+++ b/Content.Trauma.Shared/Dragon/DragonAreaRiftsComponent.cs
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Shared.Whitelist;
+
+namespace Content.Trauma.Shared.Dragon;
+
+/// <summary>
+/// Component for dragons that restricts rift spawning to areas matching a whitelist.
+/// Cannot spawn rifts if you aren't in an area at all either.
+/// </summary>
+[RegisterComponent, NetworkedComponent, Access(typeof(DragonAreaRiftsSystem))]
+public sealed partial class DragonAreaRiftsComponent : Component
+{
+    /// <summary>
+    /// Whitelist to check the dragon's area against.
+    /// </summary>
+    [DataField(required: true)]
+    public EntityWhitelist AreaWhitelist = default!;
+}

--- a/Content.Trauma.Shared/Dragon/DragonAreaRiftsSystem.cs
+++ b/Content.Trauma.Shared/Dragon/DragonAreaRiftsSystem.cs
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Shared.Whitelist;
+using Content.Trauma.Common.Dragon;
+using Content.Trauma.Shared.Areas;
+
+namespace Content.Trauma.Shared.Dragon;
+
+public sealed class DragonAreaRiftsSystem : EntitySystem
+{
+    [Dependency] private readonly AreaSystem _area = default!;
+    [Dependency] private readonly EntityWhitelistSystem _whitelist = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<DragonAreaRiftsComponent, DragonSpawnRiftAttemptEvent>(OnSpawnRiftAttempt);
+    }
+
+    private void OnSpawnRiftAttempt(Entity<DragonAreaRiftsComponent> ent, ref DragonSpawnRiftAttemptEvent args)
+    {
+        if (args.Cancelled)
+            return;
+
+        if (_area.GetArea(ent) is not { } area ||
+            _whitelist.IsWhitelistFail(ent.Comp.AreaWhitelist, area))
+        {
+            args.Cancelled = true;
+            args.Popup = "You need to be in a station area!";
+        }
+    }
+}

--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -6,6 +6,35 @@
   description: A flying leviathan, loosely related to space carps.
   abstract: true
   components:
+  # <Trauma>
+  - type: CollectiveMind
+    defaultChannel: Dragonmind
+    channels:
+    - Dragonmind
+  - type: Damageable
+    damageContainer: Biological
+    damageModifierSet: Dragon
+  - type: NightVision
+    color: "#808080"
+    activateSound: null
+    deactivateSound: null
+  - type: Fauna
+  - type: LanguageSpeaker # carp language (keeping basic as an option because the space monster gloating is funny)
+    speaks:
+    - TauCetiBasic
+    - Carptongue
+    understands:
+    - TauCetiBasic
+    - Carptongue
+  - type: InnateWaypointer
+    waypointerProtoIds:
+    - NTStationWaypointer
+    - DragonRiftWaypointer
+  - type: DragonAreaRifts
+    areaWhitelist:
+      components:
+      - StationArea # no being a chud
+  # </Trauma>
   - type: Bloodstream
     bleedReductionAmount: 5 #goob
     bloodReferenceSolution:
@@ -145,14 +174,14 @@
     stomachStorageWhitelist:
       components:
       - MobState
-      - Item
+      - Item # Trauma
     chemical: Ichor
     healRate: 7.5
     whitelist:
       components:
       - MobState
       - Door
-      - Item
+      - Item # Trauma
       tags:
       - Wall
   - type: Tag
@@ -160,14 +189,6 @@
     - CannotSuicide
     - DoorBumpOpener
     - StunImmune
-  # Goobstation - Collective mind
-  - type: CollectiveMind
-    defaultChannel: Dragonmind
-    channels:
-    - Dragonmind
-  - type: Damageable # Goobstation
-    damageContainer: Biological
-    damageModifierSet: Dragon
   - type: Puller
     needsHands: false
   - type: RandomMetadata
@@ -175,36 +196,20 @@
     - NamesDragon
     - NamesDragonTitle
     nameFormat: name-format-dragon
-  - type: NightVision # Goobstation - Nigthvision
-    color: "#808080"
-    activateSound: null
-    deactivateSound: null
-  - type: Fauna # Lavaland Change
   - type: Prying
     pryPowered: true
     force: true
     speedModifier: 2.5 # fast because dragon strong
     useSound:
       path: /Audio/Items/crowbar.ogg
-  - type: InnateWaypointer
-    waypointerProtoIds:
-    - NTStationWaypointer
-    - DragonRiftWaypointer
-  - type: LanguageSpeaker # Trauma - carp language (keeping basic as an option because the space monster gloating is funny)
-    speaks:
-    - TauCetiBasic
-    - Carptongue
-    understands:
-    - TauCetiBasic
-    - Carptongue
 
 - type: entity
   parent: BaseMobDragon
   id: MobDragon
   components:
   - type: Dragon
-    # <Trauma>
     spawnRiftAction: ActionSpawnRift
+    # <Trauma>
     carpRiftHealing:
       types:
         Blunt: -1.33

--- a/Resources/Prototypes/_Trauma/Entities/Markers/Areas/base.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Markers/Areas/base.yml
@@ -27,4 +27,4 @@
   components:
   - type: Sprite
     state: station
-  # maybe do something with this in the future
+  - type: StationArea


### PR DESCRIPTION
resolves #2449

## Media
<img width="323" height="286" alt="17:11:50" src="https://github.com/user-attachments/assets/72e59343-731c-4054-8a6e-bd0a1ee5ff95" />

<img width="196" height="283" alt="17:11:57" src="https://github.com/user-attachments/assets/0e58a499-d8af-4e65-84ff-2c1bc726ff90" />

**Changelog**
:cl:
- tweak: Dragons can now only spawn rifts inside station areas.