### PR TITLE
fix volatile organ

### DIFF
--- a/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/extract_items.yml
+++ b/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/extract_items.yml
@@ -1,14 +1,14 @@
 - type: entity
+  parent: [ OrganBaseHeart, BasePowerCell ]
   id: XenobioVolatileOrgan
-  parent: [ OrganBaseInternal, BasePowerCell ]
   name: volatile organ
-  description: A pulsating mass of slime, it seems to react to nearby devices.
   suffix: Full
+  description: A pulsating mass of slime, it seems to react to nearby devices.
   components:
   - type: Sprite
     layers:
-      - sprite: _Goobstation/Xenobiology/Specific/Xenobiology/volatile_organ.rsi
-        state: icon
+    - sprite: _Goobstation/Xenobiology/Specific/Xenobiology/volatile_organ.rsi
+      state: icon
   - type: GenericVisualizer
     visuals: {} # disable battery visuals
   - type: Item
@@ -34,11 +34,6 @@
       reagents:
       - ReagentId: Slime
         Quantity: 15
-  - type: Heart
-  - type: Organ
-    category: Heart
-  - type: ChildOrgan
-    parents: [ Torso ]
   - type: OrganComponents
     onAdd:
     - type: LightningArcShooter
@@ -56,7 +51,6 @@
       Damaged: 9
       Destroyed: 0
   - type: Metabolizer
-    maxReagents: 2
     metabolizerTypes: [ Cybernetic ]
   - type: Tag
     tags:


### PR DESCRIPTION
metabolism refactor broke it since it didnt have bloodstream stages anymore
just made it inherit actual heart who cares if it gets GibbableComponent

fixes #2376

## Media

it metabolise

<img width="311" height="167" alt="20:08:13" src="https://github.com/user-attachments/assets/a510d5b3-7539-4bfc-9fcc-a9cd8c19c416" />


**Changelog**
:cl:
- fix: Fixed xenobio volatile organ making you stop metabolizing chemicals.