### PR TITLE
add items for plastic tiles

### DIFF
--- a/Resources/Prototypes/Recipes/Crafting/Graphs/tiles.yml
+++ b/Resources/Prototypes/Recipes/Crafting/Graphs/tiles.yml
@@ -1,15 +1,3 @@
-# SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
-# SPDX-FileCopyrightText: 2021 Vera Aguilera Puerto <zddm@outlook.es>
-# SPDX-FileCopyrightText: 2022 Lamrr <96937466+Lamrr@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2022 ninruB <38016303+asperger-sind@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 PixelTK <85175107+PixelTheKermit@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 MACMAN2003 <macman2003c@gmail.com>
-# SPDX-FileCopyrightText: 2024 Ps3Moira <113228053+ps3moira@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
-#
-# SPDX-License-Identifier: MIT
-
 - type: constructionGraph
   id: TileSteel
   start: start

--- a/Resources/Prototypes/Tiles/floors.yml
+++ b/Resources/Prototypes/Tiles/floors.yml
@@ -232,7 +232,7 @@
   - 1.0
   - 1.0
   - 1.0
-  itemDrop: FloorTileItemSteel
+  itemDrop: FloorTileItemPlastic # Trauma - plastic tile items
   tileRipResistance: 80 # Goob
 
 - type: tile
@@ -444,7 +444,7 @@
   - 1.0
   footstepSounds:
     collection: FootstepTile
-  itemDrop: FloorTileItemWhite
+  itemDrop: FloorTileItemPlasticWhite # Trauma - plastic tile items
   tileRipResistance: 80 # Goob
 
 - type: tile
@@ -637,7 +637,7 @@
   - 1.0
   footstepSounds:
     collection: FootstepTile
-  itemDrop: FloorTileItemDark
+  itemDrop: FloorTileItemPlasticDark # Trauma - plastic tile items
   tileRipResistance: 50 # Goob
 
 - type: tile

--- a/Resources/Prototypes/_Trauma/Entities/Objects/Misc/tiles.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Objects/Misc/tiles.yml
@@ -6,3 +6,58 @@
   - type: PhysicalComposition
     materialComposition:
       Plastic: 25
+
+- type: entity
+  parent: BaseFloorTileAstro # it's made of plastic...
+  id: FloorTileItemPlastic
+  name: plastic tile
+  components:
+  - type: Sprite
+    state: steel # no plastic tile item sprites
+  - type: Item
+    heldPrefix: steel
+  - type: FloorTile
+    outputs:
+    - Plating
+    - FloorPlastic
+  - type: Stack
+    stackType: FloorTilePlastic
+  - type: Construction
+    graph: TilePlastic
+    node: plastic tile
+
+- type: entity
+  parent: FloorTileItemPlastic
+  id: FloorTileItemPlasticDark
+  name: dark plastic tile
+  components:
+  - type: Sprite
+    state: dark
+  - type: Item
+    heldPrefix: dark
+  - type: FloorTile
+    outputs:
+    - Plating
+    - FloorDarkPlastic
+  - type: Stack
+    stackType: FloorTilePlasticDark
+  - type: Construction
+    node: dark plastic tile
+
+- type: entity
+  parent: FloorTileItemPlastic
+  id: FloorTileItemPlasticWhite
+  name: white plastic tile
+  components:
+  - type: Sprite
+    state: white
+  - type: Item
+    heldPrefix: white
+  - type: FloorTile
+    outputs:
+    - Plating
+    - FloorWhitePlastic
+  - type: Stack
+    stackType: FloorTilePlasticWhite
+  - type: Construction
+    name: white plastic tile

--- a/Resources/Prototypes/_Trauma/Recipes/Crafting/Graphs/tiles.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Crafting/Graphs/tiles.yml
@@ -1,0 +1,35 @@
+- type: constructionGraph
+  id: TilePlastic
+  graph:
+  - node: start
+    edges:
+    - to: plastic tile
+      completed:
+      - !type:SetStackCount
+        amount: 4
+      steps:
+      - material: Plastic
+        amount: 1
+    - to: dark plastic tile
+      completed:
+      - !type:SetStackCount
+        amount: 4
+      steps:
+      - material: Plastic
+        amount: 1
+    - to: white plastic tile
+      completed:
+      - !type:SetStackCount
+        amount: 4
+      steps:
+      - material: Plastic
+        amount: 1
+
+  - node: plastic tile
+    entity: FloorTileItemPlastic
+
+  - node: dark plastic tile
+    entity: FloorTileItemPlasticDark
+
+  - node: white plastic tile
+    entity: FloorTileItemPlasticWhite

--- a/Resources/Prototypes/_Trauma/Recipes/Crafting/tiles.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Crafting/tiles.yml
@@ -1,0 +1,15 @@
+- type: construction
+  parent: TileSteel
+  id: TilePlastic
+  graph: TilePlastic
+  targetNode: plastic tile
+
+- type: construction
+  parent: TilePlastic
+  id: TilePlasticDark
+  targetNode: dark plastic tile
+
+- type: construction
+  parent: TilePlastic
+  id: TilePlasticWhite
+  targetNode: white plastic tile

--- a/Resources/Prototypes/_Trauma/Stacks/Tiles/plastic.yml
+++ b/Resources/Prototypes/_Trauma/Stacks/Tiles/plastic.yml
@@ -1,0 +1,17 @@
+- type: stack
+  parent: BaseTileStack
+  id: FloorTilePlastic
+  name: tiles-plastic-floor
+  spawn: FloorTileItemPlastic
+
+- type: stack
+  parent: BaseTileStack
+  id: FloorTilePlasticDark
+  name: tiles-plastic-dark-floor
+  spawn: FloorTileItemPlasticDark
+
+- type: stack
+  parent: BaseTileStack
+  id: FloorTilePlasticWhite
+  name: tiles-plastic-white-floor
+  spawn: FloorTileItemPlasticWhite


### PR DESCRIPTION
fixes #2473

plastic tiles now have items and can be crafted from plastic, like their steel counterparts

## Media
<img width="221" height="320" alt="09:28:01" src="https://github.com/user-attachments/assets/19315c3a-71e7-44b9-8f80-0965d83f2064" />

<img width="551" height="195" alt="09:27:39" src="https://github.com/user-attachments/assets/3713ed1f-3d92-4d25-ac83-0aba66ca2d86" />


**Changelog**
:cl:
- tweak: You can now craft plastic tiles, which now have their own items when pried up.