### PR TITLE
Nerf gold extract

### DIFF
--- a/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t3/gold.yml
+++ b/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t3/gold.yml
@@ -32,7 +32,7 @@
         frequency: 20
       - !type:SpawnEntity
         entity: RHostileMobSpawner
-        number: 5
+        number: 2 # Trauma
     - reagents: [ Blood ]
       methods: [ Touch, Injection ]
       effects:

--- a/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t3/gold.yml
+++ b/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t3/gold.yml
@@ -21,7 +21,7 @@
         frequency: 20
       - !type:SpawnEntity
         entity: RPassiveMobSpawner
-        number: 5
+        number: 2
     - reagents: [ Plasma ]
       methods: [ Touch, Injection ]
       effects:
@@ -43,7 +43,7 @@
         frequency: 20
       - !type:SpawnEntity
         entity: RNeutralMobSpawner
-        number: 5
+        number: 2
   - type: Tag
     tags:
     - XenobiologyGoldExtract

--- a/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t3/gold.yml
+++ b/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t3/gold.yml
@@ -32,7 +32,7 @@
         frequency: 20
       - !type:SpawnEntity
         entity: RHostileMobSpawner
-        number: 2 # Trauma
+        number: 2
     - reagents: [ Blood ]
       methods: [ Touch, Injection ]
       effects:


### PR DESCRIPTION


<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->
Nerfed gold extract hostile mob spawning from 5 to 2
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
95% of the crew died to the pre-nerf gold extract without the need of antag items, plus some of the mobs spawned are rather powerful with a variety of abilities. They shouldn't be both powerful AND extremely numerous (Round #1741)
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Gold Extract summons 2 hostile mobs instead of 5
