### PR TITLE
fix being able to xenovac humans

### DIFF
--- a/Content.Trauma.Shared/Whitelist/XenoVacTargetComponent.cs
+++ b/Content.Trauma.Shared/Whitelist/XenoVacTargetComponent.cs
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Content.Trauma.Shared.Whitelist;
+
+/// <summary>
+/// Marker component for mobs that can be sucked up by a xenovac.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class XenoVacTargetComponent : Component;

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1431,6 +1431,7 @@
   # stupid monkey needs clever mutation to be literate
   - type: BlockReading
   - type: BlockWriting
+  - type: XenoVacTarget # dead monkey cleaner 9000
   # </Trauma>
   - type: CombatMode
     canDisarm: true

--- a/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Devices/xenovac.yml
+++ b/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Devices/xenovac.yml
@@ -76,7 +76,7 @@
     entityWhitelist:
       components:
       - Slime
-      - Skinnable # only monkeys have it as far as im aware, if not, skin john poland
+      - XenoVacTarget
   - type: UseDelay
     delays:
       release:


### PR DESCRIPTION
it was checking for skinnable, made a dedicated comp for it to use that monkeys and kobolds have

:cl:
- fix: Fixed xenobio vacuum being able to suck up humans instead of just slimes and monkeys.