### PR TITLE
fix vending machines not being emaggable

### DIFF
--- a/Content.Shared/VendingMachines/SharedVendingMachineSystem.cs
+++ b/Content.Shared/VendingMachines/SharedVendingMachineSystem.cs
@@ -148,7 +148,8 @@ public abstract partial class SharedVendingMachineSystem : EntitySystem
 
     protected virtual void OnMapInit(EntityUid uid, VendingMachineComponent component, MapInitEvent args)
     {
-        RestockInventoryFromPrototype(uid, component, component.InitialStockQuality);
+        RestockInventoryFromPrototype(uid, component, component.InitialStockQuality,
+            contra: true); // Trauma - need to add contra/emag when it spawns
     }
 
     private void OnEmpPulse(Entity<VendingMachineComponent> ent, ref EmpPulseEvent args)
@@ -318,7 +319,8 @@ public abstract partial class SharedVendingMachineSystem : EntitySystem
     }
 
     public void RestockInventoryFromPrototype(EntityUid uid,
-        VendingMachineComponent? component = null, float restockQuality = 1f)
+        VendingMachineComponent? component = null, float restockQuality = 1f,
+        bool contra = false) // Trauma - false for actual restocking, true for initial stock
     {
         if (!Resolve(uid, ref component))
         {
@@ -329,10 +331,13 @@ public abstract partial class SharedVendingMachineSystem : EntitySystem
             return;
 
         AddInventoryFromPrototype(uid, packPrototype.StartingInventory, InventoryType.Regular, component, restockQuality);
-        /* Trauma - only restock the halal inventory
-        AddInventoryFromPrototype(uid, packPrototype.EmaggedInventory, InventoryType.Emagged, component, restockQuality);
-        AddInventoryFromPrototype(uid, packPrototype.ContrabandInventory, InventoryType.Contraband, component, restockQuality);
-        */
+        // <Trauma> - dont give free contra/emag items when usings restocks
+        if (contra)
+        {
+            AddInventoryFromPrototype(uid, packPrototype.EmaggedInventory, InventoryType.Emagged, component, restockQuality);
+            AddInventoryFromPrototype(uid, packPrototype.ContrabandInventory, InventoryType.Contraband, component, restockQuality);
+        }
+        // </Trauma>
         Dirty(uid, component);
     }
 

--- a/Resources/Prototypes/_Trauma/Entities/Structures/Specific/insulation.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Structures/Specific/insulation.yml
@@ -43,4 +43,3 @@
   - type: Construction
     graph: WallInsulation
     node: insulation
-

--- a/Resources/Prototypes/_Trauma/Recipes/Construction/Graphs/constructions.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Construction/Graphs/constructions.yml
@@ -15,4 +15,3 @@
 
   - node: insulation
     entity: WallInsulation
-


### PR DESCRIPTION
fixes #2542

shitcode did infact use same thing for restocking for the initial stocks...

## Media

emag works

<img width="400" height="326" alt="20:38:57" src="https://github.com/user-attachments/assets/cf4f98da-bafb-4e27-9008-1f93597c9d30" />

restock works and no free emag shit

<img width="397" height="251" alt="20:39:22" src="https://github.com/user-attachments/assets/8a6de85d-91b5-4ecf-b6cc-350e80327cf6" />

**Changelog**
:cl:
- fix: Fixed not being able to emag vending machines.