### PR TITLE
Plasmamen and Slimeperson brought down to 5 skillpoints.

### DIFF
--- a/Resources/Prototypes/_Trauma/Entities/Knowledge/Profiles/plasmaman.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Knowledge/Profiles/plasmaman.yml
@@ -1,6 +1,6 @@
 - type: knowledgeProfile
   id: Plasmaman
-  pointsLimit: 10 # Already a challenge, leave them as is
+  pointsLimit: 5
   mastery:
     # Crafting Recipe Skills
     CookingKnowledge: 0

--- a/Resources/Prototypes/_Trauma/Entities/Knowledge/Profiles/slimePerson.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Knowledge/Profiles/slimePerson.yml
@@ -1,6 +1,6 @@
 - type: knowledgeProfile
   id: Slimeperson
-  pointsLimit: 10
+  pointsLimit: 5
   mastery:
     # Crafting Recipe Skills
     CookingKnowledge: 0


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->
Species knowledge points
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Humans were supposed to be the only species with 10, because they are vercitile and the literal base.
Slime gets it because??????? 
Plasmamen get it because "challenge species has it hard enough". No handouts for challenge species.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Plasmamen only get 5 skillpoints from their original 10.
- tweak: Slimepeople only get 5 skillpoints from their original 10. 