### PR TITLE
admin 1984

### DIFF
--- a/Content.Goobstation.Client/Administration/AdminInfoSystem.cs
+++ b/Content.Goobstation.Client/Administration/AdminInfoSystem.cs
@@ -1,11 +1,12 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using System.Linq;
-using Content.Shared.Administration.Events;
+using Content.Goobstation.Shared.Administration;
 using Robust.Client.Player;
 using Robust.Shared.ContentPack;
-using Robust.Shared.Network;
 using Robust.Shared.Utility;
 
-namespace Content.Client.Administration.Systems;
+namespace Content.Goobstation.Client.Administration;
 
 public sealed class AdminInfoSystem : EntitySystem
 {

--- a/Content.Goobstation.Server/Administration/Systems/AdminInfoSystem.cs
+++ b/Content.Goobstation.Server/Administration/Systems/AdminInfoSystem.cs
@@ -1,27 +1,30 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Goobstation.Shared.Administration;
+using Content.Server.Administration;
 using Content.Server.Administration.Logs;
 using Content.Server.Chat.Managers;
-using Content.Shared.Administration.Events;
 using Content.Shared.Database;
 
-namespace Content.Server.Administration.Systems;
+namespace Content.Goobstation.Server.Administration.Systems;
 
 public sealed class AdminInfoSystem : EntitySystem
 {
     [Dependency] private readonly IAdminLogManager _adminLog = default!;
-    [Dependency] private readonly IChatManager _chatManager = default!;
+    [Dependency] private readonly IChatManager _chat = default!;
     [Dependency] private readonly IPlayerLocator _locator = default!;
 
     public override void Initialize()
     {
         base.Initialize();
 
-        SubscribeNetworkEvent<AdminInfoEvent>(OnAdminInfoEvent);
+        SubscribeNetworkEvent<AdminInfoEvent>(OnAdminInfo);
     }
 
-    private async void OnAdminInfoEvent(AdminInfoEvent ev, EntitySessionEventArgs eventArgs)
+    private async void OnAdminInfo(AdminInfoEvent ev, EntitySessionEventArgs args)
     {
-        var name = eventArgs.SenderSession.Name;
-        if (ev.user == eventArgs.SenderSession.UserId)
+        var name = args.SenderSession.Name;
+        if (ev.user == args.SenderSession.UserId)
             return;
 
         // Try to get original account for this session
@@ -32,7 +35,6 @@ public sealed class AdminInfoSystem : EntitySystem
             return;
 
         _adminLog.Add(LogType.AdminMessage, LogImpact.High, $"{name} is attempting to connect with a userid from {main.Username}");
-        _chatManager.SendAdminAlert($"{name} is attempting to connect with a userid from {main.Username}");
-
+        _chat.SendAdminAlert($"{name} is attempting to connect with a userid from {main.Username}");
     }
 }

--- a/Content.Goobstation.Shared/Administration/AdminInfoEvent.cs
+++ b/Content.Goobstation.Shared/Administration/AdminInfoEvent.cs
@@ -1,7 +1,6 @@
-using Robust.Shared.Network;
-using Robust.Shared.Serialization;
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
-namespace Content.Shared.Administration.Events;
+namespace Content.Goobstation.Shared.Administration;
 
 [Serializable, NetSerializable]
 public sealed class AdminInfoEvent(NetUserId userid) : EntityEventArgs

--- a/Content.Trauma.Server/Administration/CommandLoggingSystem.cs
+++ b/Content.Trauma.Server/Administration/CommandLoggingSystem.cs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Server.Administration.Logs;
+using Content.Server.Administration.Managers;
+using Content.Shared.Database;
+using Robust.Shared.Console;
+
+namespace Content.Trauma.Server.Administration;
+
+/// <summary>
+/// Logs admin commands used to the AdminCommands admin log category.
+/// </summary>
+public sealed class CommandLoggingSystem : EntitySystem
+{
+    [Dependency] private readonly IAdminManager _admin = default!;
+    [Dependency] private readonly IAdminLogManager _adminLog = default!;
+    [Dependency] private readonly IConsoleHost _console = default!;
+
+    public static readonly Dictionary<string, LogImpact> CommandImpacts = new()
+    {
+        // Extreme
+        {"cvar", LogImpact.Extreme},
+        {"endround", LogImpact.Extreme},
+        {"golobby", LogImpact.Extreme},
+        {"restartround", LogImpact.Extreme},
+        {"restartroundnow", LogImpact.Extreme},
+        // High
+        {"ban", LogImpact.High},
+        {"pardon", LogImpact.High},
+        {"readmin", LogImpact.High}, // heres to you yonsim
+        // Medium
+        {"aghost", LogImpact.Medium},
+        {"delaystart", LogImpact.Medium},
+        {"startround", LogImpact.Medium}
+    };
+    public static readonly List<string> Ignored = new()
+    {
+        "adminlogs" // yeah... dont need to spam db for this
+    };
+    public const LogImpact DefaultImpact = LogImpact.Low;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        _console.AnyCommandExecuted += OnAnyCommandExecuted;
+    }
+
+    private void OnAnyCommandExecuted(IConsoleShell shell, string command, string argStr, string[] args)
+    {
+        // ignore non-admins to avoid spamming/DOS
+        if (shell.Player is { } player && _admin.GetAdminData(player) == null ||
+            Ignored.Contains(command))
+            return;
+
+        if (!CommandImpacts.TryGetValue(command, out var impact))
+            impact = DefaultImpact;
+        _adminLog.Add(LogType.AdminCommands, impact, $"Admin {shell.Player} ran command '{argStr}'");
+    }
+}


### PR DESCRIPTION
admins running commands now logs them, some with higher severity than others
this is our bodycam copslop equivalent

also moved troll back to modules idk why idiot put it in upstream

## Media
so real

<img width="531" height="101" alt="19:01:39" src="https://github.com/user-attachments/assets/1cb2036f-b5d8-4414-863c-c843b50ed471" />

<img width="523" height="112" alt="19:10:09" src="https://github.com/user-attachments/assets/8249fcca-5ef6-45f6-b1cf-06bef4091166" />


## Changelog
:cl:
ADMIN:
- add: Admin commands are now logged with the previously almost unused AdminCommands category.