### PR TITLE
fix area grid splitting and other things

### DIFF
--- a/Content.IntegrationTests/Tests/_Trauma/MonoSoundsTest.cs
+++ b/Content.IntegrationTests/Tests/_Trauma/MonoSoundsTest.cs
@@ -25,7 +25,7 @@ public sealed class MonoSoundsTests : GameTest
     public async Task AllPositionalSoundsMono()
     {
         // NFI why i have to do this but sure, loading resources completely fails without it
-        IoCManager.InitThread(Client.InstanceDependencyCollection);
+        IoCManager.InitThread(Client.InstanceDependencyCollection, true);
         var proto = Client.ProtoMan;
         var cache = Client.ResolveDependency<IResourceCache>();
         var failed = new List<string>();

--- a/Content.Shared/Decals/SharedDecalSystem.cs
+++ b/Content.Shared/Decals/SharedDecalSystem.cs
@@ -90,6 +90,7 @@ public abstract partial class SharedDecalSystem : EntitySystem
         _meta.AddFlag(ent.Owner, MetaDataFlags.Undetachable);
 
         ent.Comp.Data.Ent = ent;
+        TryAddToChunk(ent, Transform(ent));
     }
 
     private void OnMove(Entity<DecalComponent> ent, ref MoveEvent args)
@@ -101,8 +102,13 @@ public abstract partial class SharedDecalSystem : EntitySystem
         var indices = ent.Comp.Chunk;
         if (oldGrid.IsValid())
             GetGridChunk(oldGrid, indices)?.Decals.Remove(ent.Comp.Data);
-        if (args.Component.GridUid is { } newGrid)
-            GetGridChunk(newGrid, indices, true)?.Decals.Add(ent.Comp.Data);
+        TryAddToChunk(ent, args.Component);
+    }
+
+    private void TryAddToChunk(Entity<DecalComponent> ent, TransformComponent xform)
+    {
+        if (xform.GridUid is { } newGrid)
+            GetGridChunk(newGrid, ent.Comp.Chunk, true)?.Decals.Add(ent.Comp.Data);
         else
             PredictedQueueDel(ent); // can't have decals in space
     }

--- a/Content.Trauma.Server/Logging/ErrorWebhookSystem.cs
+++ b/Content.Trauma.Server/Logging/ErrorWebhookSystem.cs
@@ -43,8 +43,24 @@ public sealed partial class ErrorWebhookSystem : EntitySystem
     {
         base.Shutdown();
 
-        if (_enabled)
-            _log.RootSawmill.RemoveHandler(_handler);
+        if (!_enabled)
+            return;
+
+        _log.RootSawmill.RemoveHandler(_handler);
+
+        if (_identifier is not {} identifier)
+            return;
+
+        // if server shuts down try send any buffered errors
+        _handler.Buffer.Drain(async (content) =>
+        {
+            var payload = new WebhookPayload()
+            {
+                Content = content
+            };
+            // do have to wait for this or they may be dropped
+            await _discord.CreateMessage(identifier, payload);
+        });
     }
 
     public override void Update(float frameTime)

--- a/Content.Trauma.Shared/Areas/AreaSystem.cs
+++ b/Content.Trauma.Shared/Areas/AreaSystem.cs
@@ -48,9 +48,8 @@ public sealed partial class AreaSystem : EntitySystem
 
     private void OnAnchorStateChanged(Entity<AreaComponent> ent, ref AnchorStateChangedEvent args)
     {
-        // delete areas that get unanchored by explosions, someone removing the floor etc
-        // don't do it if client is detaching or it will break PVS
-        if (!args.Anchored && !args.Detaching)
+        // delete areas that get unanchored by explosions or other more cursed things
+        if (!args.Anchored)
             PredictedQueueDel(ent);
     }
 

--- a/Content.Trauma.Shared/Areas/MapAreaSystem.cs
+++ b/Content.Trauma.Shared/Areas/MapAreaSystem.cs
@@ -18,9 +18,10 @@ namespace Content.Trauma.Shared.Areas;
 /// </summary>
 public sealed partial class MapAreaSystem : EntitySystem
 {
-    [Dependency] private EntityQuery<AreaGridComponent> _query = default!;
     [Dependency] private IPrototypeManager _proto = default!;
+    [Dependency] private MetaDataSystem _meta = default!;
     [Dependency] private ProfManager _prof = default!;
+    [Dependency] private EntityQuery<AreaGridComponent> _query = default!;
 
     private List<Vector2i> _empty = new();
     private List<byte> _badIds = new();
@@ -32,7 +33,7 @@ public sealed partial class MapAreaSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<AreaComponent, ComponentStartup>(OnStartup);
-        SubscribeLocalEvent<AreaComponent, ComponentShutdown>(OnShutdown);
+        SubscribeLocalEvent<AreaComponent, MoveEvent>(OnMove);
 
         SubscribeLocalEvent<GridAddEvent>(OnGridAdd);
 
@@ -43,30 +44,19 @@ public sealed partial class MapAreaSystem : EntitySystem
 
     private void OnStartup(Entity<AreaComponent> ent, ref ComponentStartup args)
     {
-        if (GetChunk(ent, out var index, create: true) is not {} chunk)
-        {
-            var xform = Transform(ent);
-            if (xform.GridUid is {} grid)
-                Log.Error($"Failed to create a chunk for area {ToPrettyString(ent)} on grid {ToPrettyString(grid)}!");
-            else if (xform.MapID != MapId.Nullspace) // ignore for entity spawn menu
-                PredictedDel(ent.Owner); // no spawning areas in space...
-            return;
-        }
+        // areas virtually never change and have ~no cost so its good for clients to keep them around
+        _meta.AddFlag(ent.Owner, MetaDataFlags.Undetachable);
 
-        var added = Deleted(chunk.Areas[index]);
-        chunk.Areas[index] = ent;
-        if (added)
-            chunk.AreaCount++;
+        TryAddToChunk((ent, Transform(ent)));
     }
 
-    private void OnShutdown(Entity<AreaComponent> ent, ref ComponentShutdown args)
+    private void OnMove(Entity<AreaComponent> ent, ref MoveEvent args)
     {
-        if (GetChunk(ent, out var index) is not {} chunk)
-            return;
+        var oldGrid = args.OldPosition.EntityId;
+        if (oldGrid.IsValid())
+            RemoveFromChunk(oldGrid, args.OldPosition.Position, ent);
 
-        DebugTools.Assert(chunk.Areas[index] == ent.Owner, $"{ToPrettyString(ent)} was not at the right area!");
-        chunk.Areas[index] = EntityUid.Invalid;
-        chunk.AreaCount--;
+        TryAddToChunk((ent, args.Component));
     }
 
     private void OnGridAdd(GridAddEvent args)
@@ -229,30 +219,35 @@ public sealed partial class MapAreaSystem : EntitySystem
         }
     }
 
-    private Entity<AreaGridComponent>? GetGrid(Entity<TransformComponent> area)
+    private void RemoveFromChunk(EntityUid grid, Vector2 pos, EntityUid area)
     {
-        if (area.Comp.GridUid is not {} grid)
-            return null;
+        if (GetChunk(grid, pos, out var index) is not { } chunk || chunk.Areas[index] != area)
+            return;
 
-        if (_query.TryComp(grid, out var comp))
-            return (grid, comp);
-
-        Log.Error($"Grid {ToPrettyString(grid)} for area {ToPrettyString(area)} was missing AreaGridComponent!");
-        return null;
+        chunk.Areas[index] = EntityUid.Invalid;
+        chunk.AreaCount--;
     }
 
     /// <summary>
-    /// Gets an area chunk from an area's grid.
-    /// If <c>create</c> is true, it will create a chunk if it doesn't exist.
+    /// Add an area to the chunk it's in, or delete if it's in space
     /// </summary>
-    private AreaChunk? GetChunk(EntityUid area, out int index, bool create = false)
+    private void TryAddToChunk(Entity<TransformComponent> area)
     {
-        var xform = Transform(area);
-        index = 0;
-        if (GetGrid((area, xform)) is not {} grid)
-            return null;
+        if (area.Comp.GridUid is { } grid)
+            AddToChunk(grid, area.Comp.LocalPosition, area);
+        else if (area.Comp.MapID != MapId.Nullspace) // ignore entity spawn menu's nullspace entities
+            PredictedDel(area.Owner); // no areas in space
+    }
 
-        return GetChunk(grid.AsNullable(), xform.Coordinates.Position, out index, create);
+    private void AddToChunk(EntityUid grid, Vector2 pos, EntityUid area)
+    {
+        if (GetChunk(grid, pos, out var index, create: true) is not { } chunk)
+            return;
+
+        var added = Deleted(chunk.Areas[index]);
+        chunk.Areas[index] = area;
+        if (added)
+            chunk.AreaCount++;
     }
 
     /// <summary>

--- a/Content.Trauma.Shared/Speech/PigLatinAccentSystem.cs
+++ b/Content.Trauma.Shared/Speech/PigLatinAccentSystem.cs
@@ -60,7 +60,8 @@ public sealed partial class PigLatinAccentSystem : EntitySystem
         }
 
         // append all the punctuation in the message to the final result
-        _builder[0] = char.ToUpper(_builder[0]);
+        if (_builder.Length > 0)
+            _builder[0] = char.ToUpper(_builder[0]);
         _builder.Append(_punctuation);
         return _builder.ToString();
     }

--- a/Content.Trauma.Shared/Utility/RingBuffer.cs
+++ b/Content.Trauma.Shared/Utility/RingBuffer.cs
@@ -103,7 +103,7 @@ public sealed class RingBuffer<T>
 
 
     /// <summary>
-    /// Call a delegate for every item
+    /// Call a delegate for every item by-ref
     /// </summary>
     public void VisitItems(Visitor visitor)
     {
@@ -113,7 +113,20 @@ public sealed class RingBuffer<T>
         }
     }
 
+    /// <summary>
+    /// Call a delegate for every item by value and clear the buffer.
+    /// </summary>
+    public void Drain(DrainVisitor visitor)
+    {
+        for (int i = 0; i < Count; i++)
+        {
+            visitor(_items[Index(i)]);
+        }
+        Reset();
+    }
+
     public delegate void Visitor(ref T item);
+    public delegate void DrainVisitor(T item);
 
     // index of the oldest item
     private int OldIndex => Index(0);

--- a/Resources/Prototypes/_Trauma/Entities/Markers/Areas/base.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Markers/Areas/base.yml
@@ -11,6 +11,7 @@
   - type: Transform
     anchored: true
     noRot: true
+    gridTraversal: false # waste of processing
   - type: Sprite
     noRot: true
     drawdepth: Overdoors

--- a/Resources/Prototypes/_Trauma/Entities/decal.yml
+++ b/Resources/Prototypes/_Trauma/Entities/decal.yml
@@ -2,7 +2,9 @@
   save: false # DecalGrid does it
   id: Decal
   name: decal
+  categories: [ HideSpawnMenu ]
   components:
   - type: Transform
-    anchored: True
+    anchored: true
+    gridTraversal: false # waste of processing
   - type: Decal


### PR DESCRIPTION
- areas now properly handle being moved for grid splitting
- maybe send errors to webhook if the server crashes nicely
- dont detach areas, no harm in client remembering them
- disable grid traversal for decals and areas since they dont need it at all and it could cause bugs similar to map status effects + shuttle. might improve performance a little but i doubt it
- fix pig latin accent if you only said punctuation like ???, fixes #2606
- hide decal entity from spawn menu

## Media

pig latin works with pure punctuation and still works for normal messages
<img width="238" height="97" alt="13:03:42" src="https://github.com/user-attachments/assets/0809bd09-7314-4f57-8303-b174377faa01" />

grid being split (cut off janitors closet by deleting the floors) reassigns areas to the new grid, so AreaTest says its in an area where previously it didnt
<img width="406" height="398" alt="13:06:05" src="https://github.com/user-attachments/assets/8ebe1df1-9b57-42a5-9694-07632d8cac20" />
