### PR TITLE
dont require admin notify for ntr

### DIFF
--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Dignitary/nanotrasen_representative.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Dignitary/nanotrasen_representative.yml
@@ -14,7 +14,6 @@
   weight: 20
   startingGear: NanotrasenRepresentativeGear
   icon: "JobIconNanotrasenRepresentative"
-  requireAdminNotify: true
   joinNotifyCrew: true
   supervisors: job-supervisors-centcom
   canBeAntag: false


### PR DESCRIPTION
this was removed from every other command role like a year+ ago but ntr never got updated when cryo was added

:cl:
- tweak: NTR no longer tells you to ahelp to leave in chat, cryo exists.