### PR TITLE
fix chess spawning

### DIFF
--- a/Content.Server/Tabletop/TabletopSystem.cs
+++ b/Content.Server/Tabletop/TabletopSystem.cs
@@ -1,3 +1,6 @@
+// <Trauma>
+using Content.Trauma.Common.Tabletop;
+// </Trauma>
 using Content.Server.Hands.Systems;
 using Content.Server.Popups;
 using Content.Server.Tabletop.Components;
@@ -105,6 +108,10 @@ namespace Content.Server.Tabletop
             var protoId = meta.EntityPrototype?.ID;
 
             var hologram = Spawn(protoId, session.Position.Offset(-1, 0));
+            // <Trauma>
+            var ev = new TabletopSpawnedEvent();
+            RaiseLocalEvent(hologram, ref ev);
+            // </Trauma>
 
             // Make sure the entity can be dragged and can be removed, move it into the board game world and add it to the Entities hashmap
             EnsureComp<TabletopDraggableComponent>(hologram);

--- a/Content.Server/Tabletop/TabletopSystem.cs
+++ b/Content.Server/Tabletop/TabletopSystem.cs
@@ -89,7 +89,7 @@ namespace Content.Server.Tabletop
             if (component.Session is not { } session)
                 return;
 
-            if (!_hands.TryGetActiveItem(uid, out var handEnt))
+            if (!_hands.TryGetActiveItem((args.User, hands), out var handEnt)) // Trauma - chess board has no hands, use the user instead
                 return;
 
             if (!TryComp<ItemComponent>(handEnt, out var item))

--- a/Content.Trauma.Common/Tabletop/TabletopSpawnedEvent.cs
+++ b/Content.Trauma.Common/Tabletop/TabletopSpawnedEvent.cs
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Content.Trauma.Common.Tabletop;
+
+/// <summary>
+/// Event raised on entities spawned by clicking chess board with items.
+/// </summary>
+[ByRefEvent]
+public record struct TabletopSpawnedEvent;

--- a/Content.Trauma.Shared/Viewcone/ViewconeTabletopSystem.cs
+++ b/Content.Trauma.Shared/Viewcone/ViewconeTabletopSystem.cs
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Trauma.Common.Tabletop;
+using Content.Trauma.Shared.Viewcone.Components;
+
+namespace Content.Trauma.Shared.Viewcone;
+
+/// <summary>
+/// Removes viewcone components from tabletop holograms.
+/// Lets chess be played.
+/// </summary>
+public sealed partial class ViewconeTabletopSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ViewconeComponent, TabletopSpawnedEvent>(OnSpawned);
+        SubscribeLocalEvent<ViewconeOccludableComponent, TabletopSpawnedEvent>(OnSpawned);
+    }
+
+    private void OnSpawned<T>(Entity<T> ent, ref TabletopSpawnedEvent args) where T : Component
+    {
+        RemComp(ent, ent.Comp);
+    }
+}


### PR DESCRIPTION
part of fixing #2611

remove vision related components from chess holograms just incase it was breaking anything

but chess also doesnt work upstream at all because it fucking looked for the item to add ON THE CHESS BOARD WHICH HAS NO HANDS

<img width="540" height="44" alt="17:44:56" src="https://github.com/user-attachments/assets/40f8d3a7-21e4-47e9-9566-9187dce01ccd" />

emo broke it in hands refactor a year ago :face_holding_back_tears: 

rendering doesnt work but spawning is fixed now