### PR TITLE
add vision grain scale accessibility option

### DIFF
--- a/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml
+++ b/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml
@@ -19,6 +19,7 @@
                 <CheckBox Name="HighlightSoundCheckBox" Text="{Loc 'ui-options-highlight-sound'}" />
                 <CheckBox Name="SkillPopupsCheckBox" Text="{Loc 'ui-options-show-skill-popups'}" />
                 <CheckBox Name="MovieCreditsCheckBox" Text="{Loc 'round-end-credits-trauma-show-credits'}" />
+                <ui:OptionSlider Name="VisionGrainScaleSlider" Title="Vision cone grainyness"/>
                 <!-- </Trauma> -->
                 <ui:OptionColorSlider Name="HighlightsColorSlider"
                     Title="{Loc 'ui-options-highlights-color'}"

--- a/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml.cs
@@ -29,6 +29,7 @@ public sealed partial class AccessibilityTab : Control
         Control.AddOptionCheckBox(TraumaCVars.ChatHighlightSound, HighlightSoundCheckBox);
         Control.AddOptionCheckBox(TraumaCVars.SkillPopups, SkillPopupsCheckBox);
         Control.AddOptionCheckBox(TraumaCVars.PlayMovieEndCredits, MovieCreditsCheckBox);
+        Control.AddOptionPercentSlider(TraumaCVars.VisionGrainScale, VisionGrainScaleSlider);
         // </Trauma>
 
         Control.AddOptionCheckBox(CCVars.AccessibilityClientCensorNudity, CensorNudityCheckBox);

--- a/Content.Trauma.Client/Viewcone/Overlays/ViewconeConeOverlay.cs
+++ b/Content.Trauma.Client/Viewcone/Overlays/ViewconeConeOverlay.cs
@@ -87,7 +87,7 @@ public sealed partial class ViewconeConeOverlay : Overlay
         _viewconeShader.SetParameter("ConeFeather", _coneFeather);
         _viewconeShader.SetParameter("ConeIgnoreRadius", _coneIgnoreRadius);
         _viewconeShader.SetParameter("ConeIgnoreFeather", _coneIgnoreFeather);
-        _viewconeShader.SetParameter("GrainScale", _grainScale);
+        _viewconeShader.SetParameter("GrainScale", GrainScale);
 
         worldHandle.UseShader(_viewconeShader);
         worldHandle.DrawRect(viewport, Color.White);

--- a/Content.Trauma.Client/Viewcone/Overlays/ViewconeConeOverlay.cs
+++ b/Content.Trauma.Client/Viewcone/Overlays/ViewconeConeOverlay.cs
@@ -28,6 +28,7 @@ public sealed partial class ViewconeConeOverlay : Overlay
     private float _coneFeather;
     private float _coneIgnoreRadius;
     private float _coneIgnoreFeather;
+    public float GrainScale = 1f;
 
     public ViewconeConeOverlay()
     {
@@ -86,6 +87,7 @@ public sealed partial class ViewconeConeOverlay : Overlay
         _viewconeShader.SetParameter("ConeFeather", _coneFeather);
         _viewconeShader.SetParameter("ConeIgnoreRadius", _coneIgnoreRadius);
         _viewconeShader.SetParameter("ConeIgnoreFeather", _coneIgnoreFeather);
+        _viewconeShader.SetParameter("GrainScale", _grainScale);
 
         worldHandle.UseShader(_viewconeShader);
         worldHandle.DrawRect(viewport, Color.White);

--- a/Content.Trauma.Client/Viewcone/ViewconeOverlaySystem.cs
+++ b/Content.Trauma.Client/Viewcone/ViewconeOverlaySystem.cs
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 using Content.Client.Eye;
+using Content.Shared.CCVar;
 using Content.Shared.MouseRotator;
 using Content.Shared.Movement.Pulling.Events;
 using Content.Trauma.Client.Viewcone.Overlays;
+using Content.Trauma.Common.CCVar;
 using Content.Trauma.Common.Popups;
 using Content.Trauma.Shared.Viewcone;
 using Content.Trauma.Shared.Viewcone.Components;
@@ -11,6 +13,7 @@ using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Client.Input;
 using Robust.Client.Player;
+using Robust.Shared.Configuration;
 using Robust.Shared.Map;
 using Robust.Shared.Player;
 using Robust.Shared.Timing;
@@ -23,6 +26,7 @@ namespace Content.Trauma.Client.Viewcone;
 /// </summary>
 public sealed partial class ViewconeOverlaySystem : EntitySystem
 {
+    [Dependency] private IConfigurationManager _cfg = default!;
     [Dependency] private IEyeManager _eye = default!;
     [Dependency] private IGameTiming _timing = default!;
     [Dependency] private IInputManager _input = default!;
@@ -47,6 +51,11 @@ public sealed partial class ViewconeOverlaySystem : EntitySystem
     // one wont start rendering in the middle of rendering another
     internal List<(Entity<SpriteComponent> ent, float baseAlpha)> CachedBaseAlphas = new(128);
 
+    // raw grain scale ignoring reduced motion setting
+    // reduced motion locks it to 0
+    private float _grainScale;
+    private bool _reducedMotion;
+
     public override void Initialize()
     {
         base.Initialize();
@@ -66,6 +75,9 @@ public sealed partial class ViewconeOverlaySystem : EntitySystem
         _coneOverlay = new();
         _setAlphaOverlay = new();
         _resetAlphaOverlay = new();
+
+        Subs.CVar(_cfg, TraumaCVars.VisionGrainScale, SetGrainScale, true);
+        Subs.CVar(_cfg, CCVars.ReducedMotion, SetReducedMotion, true);
     }
 
     public override void FrameUpdate(float frameTime)
@@ -129,6 +141,21 @@ public sealed partial class ViewconeOverlaySystem : EntitySystem
             // convert to angle first so we lerp thru shortestdistance
             viewcone.ViewAngle = Angle.Lerp(viewcone.ViewAngle, viewcone.DesiredViewAngle.Value, 1f - MathF.Pow(2f, -(frameTime / LerpHalfLife)));
         }
+    }
+
+    private void SetGrainScale(float scale)
+    {
+        _grainScale = scale;
+        if (!_reducedMotion)
+            _coneOverlay.GrainScale = scale;
+    }
+
+    private void SetReducedMotion(bool on)
+    {
+        _reducedMotion = on;
+        _coneOverlay.GrainScale = on
+            ? 0f
+            : _grainScale;
     }
 
     /// <summary>

--- a/Content.Trauma.Common/CCVar/TraumaCVars.Vision.cs
+++ b/Content.Trauma.Common/CCVar/TraumaCVars.Vision.cs
@@ -11,4 +11,10 @@ public sealed partial class TraumaCVars
     /// </summary>
     public static readonly CVarDef<bool> DisableVisionEffects =
         CVarDef.Create("trauma.disable_vision_effects", false, CVar.SERVER | CVar.REPLICATED);
+
+    /// <summary>
+    /// Scale for how strong out-of-vision graininess is, 0 is just pure greyscale.
+    /// </summary>
+    public static readonly CVarDef<float> VisionGrainScale =
+        CVarDef.Create("trauma.vision_grain_scale", 0.75f, CVar.CLIENTONLY | CVar.ARCHIVE);
 }

--- a/Resources/Textures/_Trauma/Shaders/viewcone.swsl
+++ b/Resources/Textures/_Trauma/Shaders/viewcone.swsl
@@ -9,6 +9,7 @@ uniform highp float ConeAngle;
 uniform highp float ConeFeather;
 uniform highp float ConeIgnoreRadius;
 uniform highp float ConeIgnoreFeather;
+uniform highp float GrainScale;
 
 uniform highp float ViewAngle;
 
@@ -44,7 +45,7 @@ void fragment(){
     mask = 1.0 - clamp(mask, 0.0, 1.0);
 
     // So grim.. so dark
-    highp float grain = zRandom(FRAGCOORD.xy * sin(TIME * 0.01)).x;
+    highp float grain = GrainScale * zRandom(FRAGCOORD.xy * sin(TIME * 0.01)).x;
 
     // Lil bit of grayscale for good measure, too
     highp float grayscale = zGrayscale(color.rgb) * (grain * grainMult + grainBase);


### PR DESCRIPTION
accessibility tab now has an option to change how grainy outside your vision cone is
reduce motion setting automatically disables the grain for you

## Media

the slider

<img width="806" height="46" alt="19:56:35" src="https://github.com/user-attachments/assets/5777dea2-91e4-4f83-b77c-3a61a31a57ca" />

0%

<img width="392" height="386" alt="19:56:57" src="https://github.com/user-attachments/assets/1a1340ec-b6e7-4cc6-92b8-2bda77520197" />

100%

<img width="371" height="366" alt="19:57:02" src="https://github.com/user-attachments/assets/6cf17db1-5b87-427c-9320-5287c77ff33a" />



## Changelog
:cl:
- tweak: You can now change how grainy things outside your vision cone are, reduced motion setting will automatically disable it.