### PR TITLE
make syndicate hearts unremoveable

### DIFF
--- a/Resources/Prototypes/_Goobstation/Body/Organs/misc.yml
+++ b/Resources/Prototypes/_Goobstation/Body/Organs/misc.yml
@@ -1,7 +1,12 @@
-# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
-# SPDX-FileCopyrightText: 2025 pheenty <fedorlukin2006@gmail.com>
-#
-# SPDX-License-Identifier: AGPL-3.0-or-later
+- type: entity
+  parent: [ OrganHumanHeart, BaseSyndicateContraband ]
+  id: OrganSyndicateHeart
+  components:
+  - type: Sprite
+    layers:
+    - state: icon
+    scale: 0.5, 0.5
+  - type: UnremoveableOrgan # fuck sec chuds
 
 - type: entity
   parent: [ OrganHumanHeart, BaseSyndicateContraband ]
@@ -12,9 +17,6 @@
   - type: Cybernetics
   - type: Sprite
     sprite: _Goobstation/Objects/Misc/sandevistan.rsi
-    layers:
-    - state: icon
-    scale: 0.5, 0.5
   - type: OrganActions
     actions:
     - ActionToggleSandevistan
@@ -23,31 +25,25 @@
     - type: SandevistanUser
 
 - type: entity
-  parent: [OrganHumanHeart, BaseSyndicateContraband]
+  parent: OrganSyndicateHeart
   id: SyndicateBerserkerHeart
   name: berserker heart
   description: A next-gen combat circulatory core that allows the user to enter a berserk state, greatly increasing their speed and reflexes for a short time at the cost of endurance and some pain resistance. Highly illegal.
   components:
   - type: Sprite
     sprite: _Goobstation/Objects/Misc/berserker_heart.rsi
-    layers:
-    - state: icon
-    scale: 0.5, 0.5
   - type: OrganActions
     actions:
     - ActionActivateBerserkerImplant
 
 - type: entity
-  parent: [OrganHumanHeart, BaseSyndicateContraband]
+  parent: OrganSyndicateHeart
   id: SyndicateJumpstarterHeart
   name: jumpstarter heart
   description: A next-gen combat circulatory core that injects a large amount of omnizine into the user's bloodstream when they are critically injured, saving them from death. Highly illegal.
   components:
   - type: Sprite
     sprite: _Goobstation/Objects/Misc/jumpstarter_heart.rsi
-    layers:
-    - state: icon
-    scale: 0.5, 0.5
   - type: OrganComponents
     onAdd:
     - type: InjectOnMobState

--- a/Resources/Prototypes/_Goobstation/Body/Organs/misc.yml
+++ b/Resources/Prototypes/_Goobstation/Body/Organs/misc.yml
@@ -1,4 +1,5 @@
 - type: entity
+  abstract: true
   parent: [ OrganHumanHeart, BaseSyndicateContraband ]
   id: OrganSyndicateHeart
   components:

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Devices/autosurgeon.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Devices/autosurgeon.yml
@@ -83,6 +83,7 @@
       - type: MantisBladeArm
         actionProto: ActionToggleRightMantisBlade
       - type: Cybernetics # Disable on EMP
+      # TODO: make thing like acidifier that if your arm gets cut off the mantis blade is removed
 
 - type: entity
   parent: BaseAutosurgeonSyndicate
@@ -96,6 +97,7 @@
       - type: MantisBladeArm
         actionProto: ActionToggleLeftMantisBlade
       - type: Cybernetics # Disable on EMP
+      # TODO: make thing like acidifier that if your arm gets cut off the mantis blade is removed
 
 - type: entity
   parent: BaseAutosurgeonSyndicate


### PR DESCRIPTION
resolves #2615

:cl:
- tweak: You can no longer remove sandevistan/berserker/jumpstarter hearts.