### PR TITLE
fix floor goblin vision occlusion

### DIFF
--- a/Content.Trauma.Client/Viewcone/Overlays/ViewconeSetAlphaOverlay.cs
+++ b/Content.Trauma.Client/Viewcone/Overlays/ViewconeSetAlphaOverlay.cs
@@ -123,7 +123,8 @@ public sealed partial class ViewconeSetAlphaOverlay : Overlay
             if (!comp.OccludeIfAnchored && xform.Anchored)
                 continue;
 
-            if (_container.IsEntityInContainer(uid))
+            // floor goblin and maybe other things set ContainerOccluded without being inside a container
+            if (sprite.ContainerOccluded || _container.IsEntityInContainer(uid))
             {
                 if (comp.Memory is { } containedMemory)
                     _sprite.SetVisible(containedMemory, false);


### PR DESCRIPTION
## Media
<img width="106" height="158" alt="14:49:55" src="https://github.com/user-attachments/assets/ccbdc149-cdbc-4ba6-8a63-5091113d3188" />

<img width="112" height="203" alt="14:50:00" src="https://github.com/user-attachments/assets/a19a7837-f3bc-45eb-83c4-0a68715de0e0" />

<img width="75" height="142" alt="14:50:12" src="https://github.com/user-attachments/assets/b0de2a72-f6d0-4bda-9a49-1aaac7d500b1" />


## Changelog
:cl:
- fix: Fixed floor goblins getting doxxed by vision cones.