### PR TITLE
disable stunlock trait for borgs

### DIFF
--- a/Resources/Prototypes/_Goobstation/Traits/disabilities.yml
+++ b/Resources/Prototypes/_Goobstation/Traits/disabilities.yml
@@ -1,12 +1,3 @@
-# SPDX-FileCopyrightText: 2024 Piras314 <p1r4s@proton.me>
-# SPDX-FileCopyrightText: 2024 Scruq445 <storchdamien@gmail.com>
-# SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
-# SPDX-FileCopyrightText: 2025 SolsticeOfTheWinter <solsticeofthewinter@gmail.com>
-# SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
-#
-# SPDX-License-Identifier: AGPL-3.0-or-later
-
 - type: trait
   id: WheelchairBound
   name: trait-wheelchair-bound-name
@@ -14,7 +5,7 @@
   category: Disabilities
   blacklist:
     components:
-      - BorgChassis
+    - BorgChassis
   components:
   - type: BuckleOnMapInit
     prototype: VehicleWheelchair
@@ -33,8 +24,11 @@
   name: trait-social-anxiety-name
   description: trait-social-anxiety-disc
   category: Disabilities
+  blacklist:
+    components:
+    - BorgChassis
   components:
-    - type: SocialAnxiety
+  - type: SocialAnxiety
 
 - type: trait
   id: DeafTrait
@@ -45,4 +39,4 @@
     components:
     - BorgChassis
   components:
-    - type: Deaf
+  - type: Deaf


### PR DESCRIPTION
fixes #2652

:cl:
- fix: Stunlock trait no longer gets applied to borgs