### PR TITLE
a thing with lootbug

### DIFF
--- a/Resources/Prototypes/_Goobstation/Actions/lootbug.yml
+++ b/Resources/Prototypes/_Goobstation/Actions/lootbug.yml
@@ -21,3 +21,4 @@
       - Steel
       - Ore
       - Telecrystal
+      - RodMetal

--- a/Resources/Prototypes/_Goobstation/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Mobs/NPCs/animals.yml
@@ -298,6 +298,7 @@
       - Steel
       - Ore
       - Telecrystal
+      - RodMetal
     stomachStorageWhitelist:
       components:
       - Item
@@ -310,6 +311,7 @@
       - Steel
       - Ore
       - Telecrystal
+      - RodMetal
   - type: MobPrice
     price: 500
 


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->
I changed lootbug yml and animals yml to allow lootbugs to eat items with the "RodMetal" tag.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It felt somewhat off how lootbugs could eat metal (and metal spoons) but not metal rods.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Lootbugs have realized metal rods are just fancy metals.
-->
