### PR TITLE
Death to Xenoborg Eswords

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -1707,7 +1707,7 @@
     - state: icon-xenoborg-sword
   - type: ItemBorgModule
     hands:
-    - item: EnergyDaggerLoudBlue # Trauma - was KukriKnife (I think)
+    - item: KukriKnife
     - item: BorgJetpackXenoborg # Trauma - Durability
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: xenoborg-sword-module }
@@ -1724,7 +1724,7 @@
     - state: icon-xenoborg-sword2
   - type: ItemBorgModule
     hands:
-    - item: EnergySwordXenoborg # Trauma - was EnergyDaggerLoudBlue
+    - item: EnergyDaggerLoudBlue
     - item: BorgJetpackXenoborg # Trauma - Durability
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: xenoborg-sword2-module }


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->
Reverted the changes to scout modules made in #2525
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Because energy swords are really good, and shouldn't be able to be mass produced by lategame xorgs? especially with vision cones, there's not much you can do when there's 2 scouts with eswords. Edaggers are more manageable and lend themselves to a higher TTK, which is what we want for trauma weapons.
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
🆑 Graves
- tweak: Reverted Scout Xenoborg modules to kukri and energy dagger respectively.