### PR TITLE
Man i fheel that

### DIFF
--- a/Resources/Prototypes/_Goobstation/Actions/lootbug.yml
+++ b/Resources/Prototypes/_Goobstation/Actions/lootbug.yml
@@ -16,6 +16,7 @@
     canTargetSelf: false
     whitelist:
       tags:
+      - RodMetal
       - Ingot
       - Metal
       - Steel

--- a/Resources/Prototypes/_Goobstation/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Mobs/NPCs/animals.yml
@@ -293,6 +293,7 @@
     structureDevourTime: 3
     foodPreferenceWhitelist:
       tags:
+      - RodMetal
       - Ingot
       - Metal
       - Steel
@@ -305,6 +306,7 @@
     healRate: 7.5
     whitelist:
       tags:
+      - RodMetal
       - Ingot
       - Metal
       - Steel


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->
Allowed Lootbugs to eat items that are tagged RodMetal

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This would likely have little effect on balance, while also allowing a small extra reward if a lootbug decided to eat anything with RodMetal. I changed it because it personally annoyed me and also because lootbugs can eat metal spoons but not metal rods.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Goober
- tweak: Lootbugs can now eat metal rods.
