### PR TITLE
Kill saltern

### DIFF
--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -18,7 +18,7 @@
   - Oasis
   - Omega
   - Origin
-  - Saltern
+  #- Saltern # DEATH TO SALTERN
   - Packed
   #- Barratry
   - Kettle

--- a/Resources/Prototypes/_Trauma/Maps/omega.yml
+++ b/Resources/Prototypes/_Trauma/Maps/omega.yml
@@ -2,7 +2,7 @@
   id: Omega
   mapName: 'Omega'
   mapPath: /Maps/_Trauma/omega.yml
-  minPlayers: 7
+  minPlayers: 0
   maxPlayers: 35
   stations:
     Omega:


### PR DESCRIPTION

<img width="282" height="96" alt="image" src="https://github.com/user-attachments/assets/72c13f95-d338-467b-a252-0cc9d974052b" />
<img width="203" height="67" alt="image" src="https://github.com/user-attachments/assets/13c5b6a1-4118-412b-99dd-223203927e38" />
<img width="200" height="62" alt="image" src="https://github.com/user-attachments/assets/cec3d047-04e3-4d85-a2fd-4985e855ca51" />

:cl:
- remove: Derotated saltern(A new map is in works to replace saltern)
- tweak: Omega station can now roll on 0 pop, replacing saltern.

