### PR TITLE
fix item switch shitcode

### DIFF
--- a/Content.Medical.Shared/ItemSwitch/SharedItemSwitchSystem.cs
+++ b/Content.Medical.Shared/ItemSwitch/SharedItemSwitchSystem.cs
@@ -204,7 +204,7 @@ public abstract partial class SharedItemSwitchSystem : EntitySystem
 
         if (TryComp<ItemComponent>(uid, out var item) && _container.TryGetContainingContainer((uid, null, null), out var container))
         {
-            if (TryComp(container.Owner, out StorageComponent? storage))
+            if (container.ID == StorageComponent.ContainerId && TryComp(container.Owner, out StorageComponent? storage))
             {
                 _transform.AttachToGridOrMap(uid);
                 if (!_storage.Insert(container.Owner, uid, out _, null, storage, false))


### PR DESCRIPTION
fixes #2695

item switch shitcode now actually checks that it it's in StorageComponent storage before trying to insert it...

:cl:
- fix: Fixed some items like Betty getting inserted into slime storage when used.