### PR TITLE
Remove scram grab + fixes

### DIFF
--- a/Content.Shared/Weapons/Melee/MeleeWeaponComponent.Trauma.cs
+++ b/Content.Shared/Weapons/Melee/MeleeWeaponComponent.Trauma.cs
@@ -38,7 +38,7 @@ public sealed partial class MeleeWeaponComponent
     public EntityWhitelist? AltClickAttackWhitelist;
 
     /// <summary>
-    /// If true, melee weapon won't miss on click attacks
+    /// If false, melee weapon won't miss on click attacks
     /// </summary>
     [DataField]
     public bool CanMiss = true;

--- a/Content.Trauma.Shared/Teleportation/RandomTeleportComponent.cs
+++ b/Content.Trauma.Shared/Teleportation/RandomTeleportComponent.cs
@@ -14,18 +14,30 @@ public partial class RandomTeleportComponent : Component
     /// <summary>
     ///     Up to how far to teleport the user in tiles.
     /// </summary>
-    [DataField] public MinMax Radius = new MinMax(10, 20);
+    [DataField]
+    public MinMax Radius = new MinMax(10, 20);
 
     /// <summary>
     ///     How many times to try to pick the destination. Larger number means the teleport is more likely to be safe.
     /// </summary>
-    [DataField] public int TeleportAttempts = 10;
+    [DataField]
+    public int TeleportAttempts = 10;
 
     /// <summary>
     ///     Will try harder to find a safe teleport.
     /// </summary>
-    [DataField] public bool ForceSafeTeleport = true;
+    [DataField]
+    public bool ForceSafeTeleport = true;
 
-    [DataField] public SoundSpecifier ArrivalSound = new SoundPathSpecifier("/Audio/Effects/teleport_arrival.ogg");
-    [DataField] public SoundSpecifier DepartureSound = new SoundPathSpecifier("/Audio/Effects/teleport_departure.ogg");
+    /// <summary>
+    ///     Whether teleporting should teleport pulled entity as well
+    /// </summary>
+    [DataField]
+    public bool TeleportPulled;
+
+    [DataField]
+    public SoundSpecifier ArrivalSound = new SoundPathSpecifier("/Audio/Effects/teleport_arrival.ogg");
+    [DataField]
+
+    public SoundSpecifier DepartureSound = new SoundPathSpecifier("/Audio/Effects/teleport_departure.ogg");
 }

--- a/Content.Trauma.Shared/Teleportation/RandomTeleportComponent.cs
+++ b/Content.Trauma.Shared/Teleportation/RandomTeleportComponent.cs
@@ -37,7 +37,7 @@ public partial class RandomTeleportComponent : Component
 
     [DataField]
     public SoundSpecifier ArrivalSound = new SoundPathSpecifier("/Audio/Effects/teleport_arrival.ogg");
-    [DataField]
 
+    [DataField]
     public SoundSpecifier DepartureSound = new SoundPathSpecifier("/Audio/Effects/teleport_departure.ogg");
 }

--- a/Content.Trauma.Shared/Teleportation/RandomTeleportSystem.cs
+++ b/Content.Trauma.Shared/Teleportation/RandomTeleportSystem.cs
@@ -8,8 +8,6 @@ using Content.Shared.Interaction.Events;
 using Content.Shared.Physics;
 using Content.Shared.Random.Helpers;
 using Content.Shared.Stacks;
-using Content.Shared.Teleportation;
-using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map;
 using Robust.Shared.Physics;
@@ -76,13 +74,15 @@ public sealed partial class RandomTeleportSystem : EntitySystem
 
         // play sound before and after teleport if sound is true
         var oldCoords = Transform(target).Coordinates;
-        if (sound) _audio.PlayPvs(rtp.DepartureSound, oldCoords, AudioParams.Default);
+        if (sound)
+            _audio.PlayPredicted(rtp.DepartureSound, oldCoords, predicted ? user : null);
         _sparks.DoSparks(oldCoords); // also sparks!!
 
-        finalWorldPos = RandomTeleport(target, rtp.Radius, rtp.TeleportAttempts, rtp.ForceSafeTeleport);
+        finalWorldPos = RandomTeleport(target, rtp.Radius, rtp.TeleportAttempts, rtp.ForceSafeTeleport, rtp.TeleportPulled);
 
         var newCoords = Transform(target).Coordinates;
-        if (sound) _audio.PlayPvs(rtp.ArrivalSound, newCoords, AudioParams.Default);
+        if (sound)
+            _audio.PlayPredicted(rtp.ArrivalSound, oldCoords, predicted ? user : null);
         _sparks.DoSparks(newCoords);
 
         return true;
@@ -97,7 +97,7 @@ public sealed partial class RandomTeleportSystem : EntitySystem
         return rand.NextAngle().ToVec() * distance;
     }
 
-    public Vector2 RandomTeleport(EntityUid uid, MinMax radius, int triesBase = 10, bool forceSafe = true, EntityUid? user = null, bool predicted = true)
+    public Vector2 RandomTeleport(EntityUid uid, MinMax radius, int triesBase = 10, bool forceSafe = true, bool pulled = true, EntityUid? user = null, bool predicted = true)
     {
         var seed = SharedRandomExtensions.HashCodeCombine((int) _timing.CurTick.Value, GetNetEntity(uid).Id);
         IRobustRandom rand = new RobustRandom();
@@ -157,9 +157,8 @@ public sealed partial class RandomTeleportSystem : EntitySystem
         // We haven't found a valid teleport, so just teleport to any spot in range
         if (!foundValid) targetCoords = entityCoords.Offset(GetTeleportVector(rand, radius.Min, extraRadiusBase));
 
-        var map = xform.MapID;
         var newPos = _xform.ToCoordinates(targetCoords);
-        _teleport.Teleport(uid, newPos, user, predicted, pulled: true);
+        _teleport.Teleport(uid, newPos, user, predicted, pulled);
         return newPos.Position;
     }
 }

--- a/Resources/Prototypes/_Goobstation/Actions/Heretic/path_blade.yml
+++ b/Resources/Prototypes/_Goobstation/Actions/Heretic/path_blade.yml
@@ -1,7 +1,7 @@
 - type: entity
   parent: BaseAction
   id: ActionHereticChampionHook
-  name: Champpion Hook
+  name: Champion Hook
   description: Knockdown and hook your next heretic blade light attack target.
   components:
   - type: Action


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->

Teleporting with heretic blade no longer takes pulled entity with you.
Also fixed some typos and made random teleport sounds PlayPredicted instead of PlayPvs

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Scram grab makes isolating your target trivial, especially as blade path with hook ability.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Aviu
- remove: Teleporting with heretic blade no longer takes pulled entity with you.