### PR TITLE
add cvar for disabling vision and clean up properly

### DIFF
--- a/Content.Trauma.Client/Viewcone/ViewconeOverlaySystem.cs
+++ b/Content.Trauma.Client/Viewcone/ViewconeOverlaySystem.cs
@@ -55,6 +55,8 @@ public sealed partial class ViewconeOverlaySystem : EntitySystem
     // reduced motion locks it to 0
     private float _grainScale;
     private bool _reducedMotion;
+    private bool _active;
+    private bool _disabled;
 
     public override void Initialize()
     {
@@ -77,6 +79,7 @@ public sealed partial class ViewconeOverlaySystem : EntitySystem
         _resetAlphaOverlay = new();
 
         Subs.CVar(_cfg, TraumaCVars.VisionGrainScale, SetGrainScale, true);
+        Subs.CVar(_cfg, TraumaCVars.DisableVisionCones, SetConesDisabled, true);
         Subs.CVar(_cfg, CCVars.ReducedMotion, SetReducedMotion, true);
     }
 
@@ -150,6 +153,18 @@ public sealed partial class ViewconeOverlaySystem : EntitySystem
             _coneOverlay.GrainScale = scale;
     }
 
+    private void SetConesDisabled(bool disabled)
+    {
+        _disabled = disabled;
+        if (!_active)
+            return;
+
+        if (_disabled)
+            RemoveOverlays(setActive: false); // remove unless and until cvar is reenabled
+        else
+            AddOverlays(); // add them back
+    }
+
     private void SetReducedMotion(bool on)
     {
         _reducedMotion = on;
@@ -203,16 +218,40 @@ public sealed partial class ViewconeOverlaySystem : EntitySystem
 
     private void AddOverlays()
     {
+        if (_disabled)
+            return;
+
+        _active = true;
+
         _overlay.AddOverlay(_coneOverlay);
         _overlay.AddOverlay(_setAlphaOverlay);
         _overlay.AddOverlay(_resetAlphaOverlay);
     }
 
-    private void RemoveOverlays()
+    private void RemoveOverlays(bool setActive = true)
     {
+        if (setActive) // keep its value if cvar is changed live
+            _active = false;
+
         _overlay.RemoveOverlay(_coneOverlay);
         _overlay.RemoveOverlay(_setAlphaOverlay);
         _overlay.RemoveOverlay(_resetAlphaOverlay);
+
+        // hide memories
+        var query = EntityQueryEnumerator<ViewconeOccludableComponent>();
+        while (query.MoveNext(out var comp))
+        {
+            if (comp.Memory is { } memory)
+                _sprite.SetVisible(memory, false);
+        }
+
+        // reset everythings opacity
+        var query2 = EntityQueryEnumerator<ViewconeOccludedComponent>();
+        while (query2.MoveNext(out var uid, out var comp))
+        {
+            _sprite.SetVisible(uid, true);
+            RemCompDeferred(uid, comp);
+        }
     }
 
     // Logic for disabling occluding of entities that you're currently pulling.

--- a/Content.Trauma.Common/CCVar/TraumaCVars.Vision.cs
+++ b/Content.Trauma.Common/CCVar/TraumaCVars.Vision.cs
@@ -13,6 +13,12 @@ public sealed partial class TraumaCVars
         CVarDef.Create("trauma.disable_vision_effects", false, CVar.SERVER | CVar.REPLICATED);
 
     /// <summary>
+    /// Whether to disable vision cone overlays.
+    /// </summary>
+    public static readonly CVarDef<bool> DisableVisionCones =
+        CVarDef.Create("trauma.disable_vision_cones", false, CVar.SERVER | CVar.REPLICATED);
+
+    /// <summary>
     /// Scale for how strong out-of-vision graininess is, 0 is just pure greyscale.
     /// </summary>
     public static readonly CVarDef<float> VisionGrainScale =


### PR DESCRIPTION
if armok isnt larping it now has a cvar
also revealed all hidden things if overlays get removed, e.g. /ghost

:cl:
- fix: Things out of vision can now be seen after /ghosting etc. that would remove your vision cone.
ADMIN:
- add: Added trauma.disable_vision_cones cvar