### PR TITLE
PTL nerf

### DIFF
--- a/Content.Goobstation.Server/Power/PTL/PTLSystem.cs
+++ b/Content.Goobstation.Server/Power/PTL/PTLSystem.cs
@@ -145,7 +145,7 @@ public sealed partial class PTLSystem : EntitySystem
 
         var usedMJ = energyUsed / megajoule;
         // some random formula i found in bounty thread i popped it into desmos i think it looks good
-        var spesos = (int) (usedMJ * 650 / (Math.Log(usedMJ * 2) + 1));
+        var spesos = (int) (usedMJ * 325 / (Math.Log(usedMJ * 2) + 1));
         if (!double.IsFinite(spesos) || spesos < 0)
             return;
 


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->
Halved the speso gain from PTL
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Engineering was consistently producing insane amounts of money every shift with the PTL up, and basically invalidating cargo. This aims to fix that issue via nerfing the PTL. A lot. 
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Graves
- tweak: Adjusted the PTL's formula to produce half the spesos that it would previously generate.
