### PR TITLE
give xorgs tools back except welder

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/xenoborgs.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/xenoborgs.yml
@@ -154,7 +154,7 @@
       - MMIFilled
       borg_module:
       - XenoborgModuleBasic
-      #- XenoborgModuleTool # Trauma - engi xorg exists
+      - XenoborgModuleTool
       - XenoborgModuleLaser
       - XenoborgModuleJammer
   - type: ItemSlots
@@ -225,7 +225,7 @@
       - MMIFilled
       borg_module:
       - XenoborgModuleBasic
-      #- XenoborgModuleTool # Trauma - engi xorg exists
+      - XenoborgModuleTool
       - XenoborgModuleSword
       - XenoborgModuleSpaceMovement
   - type: ItemSlots
@@ -296,7 +296,7 @@
       - MMIFilled
       borg_module:
       - XenoborgModuleBasic
-      #- XenoborgModuleTool # Trauma - engi xorg exists
+      - XenoborgModuleTool
       - XenoborgModuleHypo
       - XenoborgModuleChameleonProjector
       - XenoborgModuleCloakDevice
@@ -358,7 +358,7 @@
       - MMI
       borg_module:
       - XenoborgModuleBasic
-      #- XenoborgModuleTool # Trauma - engi xorg exists
+      - XenoborgModuleTool
       - XenoborgModuleLaser
       - XenoborgModuleJammer
   - type: ItemSlots
@@ -378,7 +378,7 @@
       - MMI
       borg_module:
       - XenoborgModuleBasic
-      #- XenoborgModuleTool # Trauma - engi xorg exists
+      - XenoborgModuleTool
       - XenoborgModuleSword
       - XenoborgModuleSpaceMovement
   - type: ItemSlots
@@ -398,7 +398,7 @@
       - MMI
       borg_module:
       - XenoborgModuleBasic
-      #- XenoborgModuleTool # Trauma - engi xorg exists
+      - XenoborgModuleTool
       - XenoborgModuleHypo
       - XenoborgModuleChameleonProjector
       - XenoborgModuleCloakDevice

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -1539,7 +1539,7 @@
     - item: Screwdriver
     - item: Wirecutter
     - item: Multitool
-    - item: RefuelingWelder
+    #- item: RefuelingWelder # Trauma - only engiborg gets welder
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: xenoborg-tool-module }
 


### PR DESCRIPTION
welder is still engi only via its advanced tools

:cl:
- tweak: Xenoborgs have tools again, except welder which is engi only.