### PR TITLE
add intercom radio signal

### DIFF
--- a/Content.Trauma.Server/Radio/SignalRadioReceiverSystem.cs
+++ b/Content.Trauma.Server/Radio/SignalRadioReceiverSystem.cs
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Server.DeviceLinking.Systems;
+using Content.Server.Radio;
+using Content.Shared.DeviceNetwork;
+using Content.Shared.Power.EntitySystems;
+using Content.Trauma.Shared.Radio;
+
+namespace Content.Trauma.Server.Radio;
+
+public sealed partial class SignalRadioReceiverSystem : EntitySystem
+{
+    [Dependency] private DeviceLinkSystem _device = default!;
+    [Dependency] private SharedPowerReceiverSystem _power = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<SignalRadioReceiverComponent, RadioReceiveEvent>(OnRadioReceive);
+    }
+
+    private void OnRadioReceive(Entity<SignalRadioReceiverComponent> ent, ref RadioReceiveEvent args)
+    {
+        if (ent.Owner == args.RadioSource || !_power.IsPowered(ent.Owner))
+            return;
+
+        var data = new NetworkPayload()
+        {
+            // language is ignored unlucky
+            ["logic_string"] = args.OriginalChatMsg.Message
+        };
+        _device.InvokePort(ent.Owner, ent.Comp.Port, data);
+    }
+}

--- a/Content.Trauma.Shared/Radio/SignalRadioReceiverComponent.cs
+++ b/Content.Trauma.Shared/Radio/SignalRadioReceiverComponent.cs
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Shared.DeviceLinking;
+
+namespace Content.Trauma.Shared.Radio;
+
+/// <summary>
+/// Sends a signal string with message text when this entity receives a radio message.
+/// Integrated circuits can then work with the string.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class SignalRadioReceiverComponent : Component
+{
+    [DataField(required: true)]
+    public ProtoId<SourcePortPrototype> Port;
+}

--- a/Resources/Locale/en-US/_Trauma/machines/intercom.ftl
+++ b/Resources/Locale/en-US/_Trauma/machines/intercom.ftl
@@ -1,0 +1,3 @@
+signal-port-name-radio-message = Radio Message
+
+signal-port-description-radio-message = Signal port invoked when a radio message is received while turned on. Circuits can receive the message string.

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/intercom.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/intercom.yml
@@ -1,36 +1,3 @@
-# SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 Leon Friedrich <60421075+ElectroJr@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 Morb <14136326+Morb0@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 qwerltaz <69696513+qwerltaz@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Andrew <blackledgecreates@gmail.com>
-# SPDX-FileCopyrightText: 2024 Emisse <99158783+Emisse@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Errant <35878406+Errant-4@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 IProduceWidgets <107586145+IProduceWidgets@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Ilya246 <57039557+Ilya246@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 JustCone <141039037+JustCone14@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Kara <lunarautomaton6@gmail.com>
-# SPDX-FileCopyrightText: 2024 Mervill <mervills.email@gmail.com>
-# SPDX-FileCopyrightText: 2024 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 PJBot <pieterjan.briers+bot@gmail.com>
-# SPDX-FileCopyrightText: 2024 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
-# SPDX-FileCopyrightText: 2024 Piras314 <p1r4s@proton.me>
-# SPDX-FileCopyrightText: 2024 PopGamer46 <yt1popgamer@gmail.com>
-# SPDX-FileCopyrightText: 2024 Spessmann <156740760+Spessmann@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Tayrtahn <tayrtahn@gmail.com>
-# SPDX-FileCopyrightText: 2024 Winkarst <74284083+Winkarst-cpu@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 beck-thompson <107373427+beck-thompson@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 coolboy911 <85909253+coolboy911@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 deltanedas <39013340+deltanedas@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 deltanedas <@deltanedas:kde.org>
-# SPDX-FileCopyrightText: 2024 lunarcomets <140772713+lunarcomets@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 saintmuntzer <47153094+saintmuntzer@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 Minemoder5000 <minemoder50000@gmail.com>
-#
-# SPDX-License-Identifier: AGPL-3.0-or-later
-
 - type: entity
   parent: BaseWallmountMachine
   id: BaseIntercom
@@ -38,6 +5,17 @@
   description: An intercom. For when the station just needs to know something.
   abstract: true
   components:
+  # <Trauma>
+  - type: DeviceNetwork
+    deviceNetId: Wireless
+  - type: WirelessNetworkConnection
+    range: 200
+  - type: DeviceLinkSource
+    ports:
+    - RadioMessage
+  - type: SignalRadioReceiver
+    port: RadioMessage
+  # </Trauma>
   - type: StationAiWhitelist
   - type: Electrified
     enabled: false

--- a/Resources/Prototypes/_Trauma/DeviceLink/sink_ports.yml
+++ b/Resources/Prototypes/_Trauma/DeviceLink/sink_ports.yml
@@ -1,3 +1,5 @@
+# Circuits
+
 - type: sinkPort
   id: Circuit1
   name: signal-port-name-circuit-1

--- a/Resources/Prototypes/_Trauma/DeviceLink/source_ports.yml
+++ b/Resources/Prototypes/_Trauma/DeviceLink/source_ports.yml
@@ -1,3 +1,5 @@
+# Circuits
+
 - type: sourcePort
   id: Circuit1
   name: signal-port-name-circuit-1
@@ -37,3 +39,10 @@
   id: Circuit8
   name: signal-port-name-circuit-8
   description: signal-port-description-circuit-output
+
+# Intercom
+
+- type: sourcePort
+  id: RadioMessage
+  name: signal-port-name-radio-message
+  description: signal-port-description-radio-message


### PR DESCRIPTION
intercoms now send a signal to their Radio Message port
circuits can use the message text, it ignores language because who cares

## Media
<img width="879" height="91" alt="01:51:11" src="https://github.com/user-attachments/assets/0f692ebb-9c6e-499f-bf76-359c4a2a1d02" />


## Changelog
:cl:
- tweak: Intercoms now send a signal when receiving a radio message while turned on, circuits can work with the message text.