### PR TITLE
make command pinpointer ignore dead bodies

### DIFF
--- a/Resources/Prototypes/_Trauma/Entities/Objects/Devices/pinpointers.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Objects/Devices/pinpointers.yml
@@ -19,3 +19,6 @@
     whitelist:
       components:
       - CommandStaff
+    blacklist:
+      components:
+      - DeadMob


### PR DESCRIPTION
fixes #2743

:cl:
- tweak: Revs command pinpointer now ignores dead bodies.