### PR TITLE
skip bad warp points for ninja and effigy objectives

### DIFF
--- a/Content.Server/Objectives/Systems/NinjaConditionsSystem.cs
+++ b/Content.Server/Objectives/Systems/NinjaConditionsSystem.cs
@@ -52,7 +52,7 @@ public sealed partial class NinjaConditionsSystem : EntitySystem
         if (args.Cancelled || !_roles.MindHasRole<NinjaRoleComponent>(args.MindId))
             return;
         // <Trauma> - get map to check for warp points in below
-        if (args.Mind.OwnedEntity is not { } map)
+        if (args.Mind.OwnedEntity is not { } mob)
             return;
 
         var map = Transform(mob).MapID;

--- a/Content.Server/Objectives/Systems/NinjaConditionsSystem.cs
+++ b/Content.Server/Objectives/Systems/NinjaConditionsSystem.cs
@@ -51,6 +51,12 @@ public sealed partial class NinjaConditionsSystem : EntitySystem
     {
         if (args.Cancelled || !_roles.MindHasRole<NinjaRoleComponent>(args.MindId))
             return;
+        // <Trauma> - get map to check for warp points in below
+        if (args.Mind.OwnedEntity is not { } map)
+            return;
+
+        var map = Transform(mob).MapID;
+        // </Trauma>
 
         // choose spider charge detonation point
         var warps = new List<EntityUid>();
@@ -59,6 +65,10 @@ public sealed partial class NinjaConditionsSystem : EntitySystem
 
         while (allEnts.MoveNext(out var warpUid, out var warp))
         {
+            // <Trauma> - check map and ignore singularity etc
+            if (warp.Follow || Transform(warpUid).MapID != map)
+                continue;
+            // </Trauma>
             if (_whitelist.IsWhitelistFail(bombingBlacklist, warpUid)
                 && !string.IsNullOrWhiteSpace(warp.Location))
             {

--- a/Content.Trauma.Server/CosmicCult/CosmicCultObjectiveSystem.cs
+++ b/Content.Trauma.Server/CosmicCult/CosmicCultObjectiveSystem.cs
@@ -34,15 +34,18 @@ public sealed partial class CosmicCultObjectiveSystem : EntitySystem
 
     private void OnEffigyRequirementCheck(EntityUid uid, CosmicEffigyConditionComponent comp, ref RequirementCheckEvent args)
     {
-        if (args.Cancelled || !_roles.MindHasRole<CosmicColossusRoleComponent>(args.MindId))
+        if (args.Cancelled || !_roles.MindHasRole<CosmicColossusRoleComponent>(args.MindId) || args.Mind.OwnedEntity is not { } mob)
             return;
 
+        var map = Transform(mob).MapID;
         var warps = new List<EntityUid>();
         var query = EntityQueryEnumerator<WarpPointComponent>();
         while (query.MoveNext(out var warpUid, out var warp))
         {
-            if (_whitelist.IsWhitelistFail(comp.Blacklist, warpUid)
-                && !string.IsNullOrWhiteSpace(warp.Location))
+            if (_whitelist.IsWhitelistFail(comp.Blacklist, warpUid) &&
+                !string.IsNullOrWhiteSpace(warp.Location) &&
+                !warp.Follow && // no effigy in the singularity
+                Transform(warpUid).MapID == map) // no lavaland beacons etc
             {
                 warps.Add(warpUid);
             }


### PR DESCRIPTION
fixes #2242

ignore singularity etc moving warp points, and any warp points on a different map

:cl:
- fix: Fixed ninja and collosus objectives picking lavaland signals or the singularity.