### PR TITLE
lavaland pressure and skinning fix

### DIFF
--- a/Content.Goobstation.Shared/Skinnable/SkinnableSystem.cs
+++ b/Content.Goobstation.Shared/Skinnable/SkinnableSystem.cs
@@ -89,17 +89,17 @@ public sealed partial class SkinnableSystem : EntitySystem
             _whitelist.IsWhitelistFail(target.Comp.Whitelist, target))
             return;
 
-        Skin(target);
+        Skin(target, args.User);
     }
 
-    private void Skin(Entity<SkinnableComponent> ent)
+    private void Skin(Entity<SkinnableComponent> ent, EntityUid? user)
     {
         if (ent.Comp.Skinned)
             return;
 
         ent.Comp.Skinned = true;
         Dirty(ent, ent.Comp);
-        _damageable.TryChangeDamage(ent.Owner, ent.Comp.DamageOnSkinned);
+        _damageable.ChangeDamage(ent.Owner, ent.Comp.DamageOnSkinned, origin: user);
         // mfw no api :face_holding_back_tears:
         foreach (var organ in _body.GetOrgans<VisualOrganComponent>(ent.Owner))
         {

--- a/Content.Lavaland.Server/Pressure/PressureEfficiencyChangeSystem.cs
+++ b/Content.Lavaland.Server/Pressure/PressureEfficiencyChangeSystem.cs
@@ -1,17 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-using Content.Lavaland.Common.Weapons.Ranged;
 using Content.Lavaland.Shared.Pressure;
-using Content.Lavaland.Shared.Weapons.Upgrades;
+using Content.Server.Atmos.Components;
 using Content.Server.Atmos.EntitySystems;
-using Content.Shared.Armor;
-using Content.Shared.Body;
-using Content.Shared.Damage.Systems;
-using Content.Shared.Inventory;
-using Content.Shared.Projectiles;
-using Content.Shared.Weapons.Melee.Events;
-using Content.Shared.Weapons.Ranged.Systems;
-using Content.Shared.Wieldable;
+using Content.Shared.Atmos;
 
 namespace Content.Lavaland.Server.Pressure;
 
@@ -19,67 +11,29 @@ public sealed partial class PressureEfficiencyChangeSystem : SharedPressureEffic
 {
     [Dependency] private AtmosphereSystem _atmos = default!;
 
-    private EntityQuery<PressureDamageChangeComponent> _query;
-    private EntityQuery<ProjectileComponent> _projectileQuery;
-
     public override void Initialize()
     {
         base.Initialize();
 
-        _query = GetEntityQuery<PressureDamageChangeComponent>();
-        _projectileQuery = GetEntityQuery<ProjectileComponent>();
-
-        SubscribeLocalEvent<PressureDamageChangeComponent, GetMeleeDamageEvent>(OnGetDamage,
-            after: [ typeof(GunUpgradeSystem), typeof(SharedWieldableSystem) ]);
-        SubscribeLocalEvent<PressureDamageChangeComponent, ProjectileShotEvent>(OnProjectileShot,
-            after: [ typeof(GunUpgradeSystem) ]); // let this system reduce damage upgrades' added damage automatically
-
-        SubscribeLocalEvent<PressureArmorChangeComponent, InventoryRelayedEvent<DamageModifyEvent>>(OnArmorRelayDamageModify, before: [typeof(SharedArmorSystem)]);
+        SubscribeLocalEvent<PressureTrackerComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<PressureTrackerComponent, AtmosExposedUpdateEvent>(OnAtmosExposedUpdate);
     }
 
-    private void OnGetDamage(Entity<PressureDamageChangeComponent> ent, ref GetMeleeDamageEvent args)
+    private void OnMapInit(Entity<PressureTrackerComponent> ent, ref MapInitEvent args)
     {
-        if (ent.Comp.ApplyToMelee && ApplyModifier(ent.AsNullable()))
-            args.Damage *= ent.Comp.AppliedModifier;
+        EnsureComp<AtmosExposedComponent>(ent); // should already be the case for mobs, but not necessarily for PKA turrets and stuff
+        // initialize immediately instead of waiting for next atmos tick (up to 0.5s away)
+        ent.Comp.Pressure = _atmos.GetTileMixture((ent.Owner, Transform(ent)))?.Pressure ?? 0f;
+        Dirty(ent);
     }
 
-    private void OnProjectileShot(Entity<PressureDamageChangeComponent> ent, ref ProjectileShotEvent args)
+    private void OnAtmosExposedUpdate(Entity<PressureTrackerComponent> ent, ref AtmosExposedUpdateEvent args)
     {
-        if (!ApplyModifier(ent.AsNullable())
-            || !ent.Comp.ApplyToProjectiles
-            || !_projectileQuery.TryComp(args.FiredProjectile, out var projectile))
+        var pressure = args.GasMixture.Pressure;
+        if (ent.Comp.Pressure == pressure)
             return;
 
-        projectile.Damage *= ent.Comp.AppliedModifier;
-    }
-
-    public bool ApplyModifier(Entity<PressureDamageChangeComponent?> ent)
-    {
-        if (!Resolve(ent, ref ent.Comp, false))
-            return false;
-
-        var pressure = _atmos.GetTileMixture((ent.Owner, Transform(ent)))?.Pressure ?? 0f;
-        return ent.Comp.Enabled && ((pressure >= ent.Comp.LowerBound
-            && pressure <= ent.Comp.UpperBound) == ent.Comp.ApplyWhenInRange);
-    }
-
-    /// <summary>
-    /// Get the damage modifier for a weapon, returning 1 if it doesn't have the component.
-    /// </summary>
-    public float GetModifier(Entity<PressureDamageChangeComponent?> ent)
-        => _query.Resolve(ent, ref ent.Comp, false) ? ent.Comp.AppliedModifier : 1f;
-
-    private void OnArmorRelayDamageModify(Entity<PressureArmorChangeComponent> ent, ref InventoryRelayedEvent<DamageModifyEvent> args)
-    {
-        if (!ApplyModifier(ent.Owner) ||
-            args.Args.TargetPart is not {} part ||
-            !TryComp<ArmorComponent>(ent, out var armor))
-            return;
-
-        var coverage = armor.ArmorCoverage;
-        if (!coverage.Contains(part))
-            return;
-
-        args.Args.Damage.ArmorPenetration += ent.Comp.ExtraPenetrationModifier;
+        ent.Comp.Pressure = pressure;
+        Dirty(ent);
     }
 }

--- a/Content.Lavaland.Shared/Pressure/PressureArmorChangeComponent.cs
+++ b/Content.Lavaland.Shared/Pressure/PressureArmorChangeComponent.cs
@@ -1,21 +1,14 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-using Content.Shared.Atmos;
-
 namespace Content.Lavaland.Shared.Pressure;
 
+/// <summary>
+/// Increases ArmorPenetration for this armor entity while <see cref="PressureEfficiencyComponent"/> does not apply.
+/// Used to make lavaland armor less protective on station.
+/// </summary>
 [RegisterComponent, NetworkedComponent, Access(typeof(SharedPressureEfficiencyChangeSystem))]
 public sealed partial class PressureArmorChangeComponent : Component
 {
-    [DataField]
-    public float LowerBound = Atmospherics.OneAtmosphere * 0.2f;
-
-    [DataField]
-    public float UpperBound = Atmospherics.OneAtmosphere * 0.5f;
-
-    [DataField]
-    public bool ApplyWhenInRange;
-
     [DataField]
     public float ExtraPenetrationModifier = 0.5f;
 }

--- a/Content.Lavaland.Shared/Pressure/PressureDamageChangeComponent.cs
+++ b/Content.Lavaland.Shared/Pressure/PressureDamageChangeComponent.cs
@@ -1,25 +1,12 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-using Content.Shared.Atmos;
-
 namespace Content.Lavaland.Shared.Pressure;
 
 [RegisterComponent, NetworkedComponent]
+[AutoGenerateComponentState]
 public sealed partial class PressureDamageChangeComponent : Component
 {
-    [DataField]
-    public bool Enabled = true;
-
-    [DataField]
-    public float LowerBound = Atmospherics.OneAtmosphere * 0.2f;
-
-    [DataField]
-    public float UpperBound = Atmospherics.OneAtmosphere * 0.5f;
-
-    [DataField]
-    public bool ApplyWhenInRange = true;
-
-    [DataField]
+    [DataField, AutoNetworkedField]
     public float AppliedModifier = 2f; // Becomes 2 times better when in lavaland pressure environment
 
     [DataField]

--- a/Content.Lavaland.Shared/Pressure/PressureEfficiencyComponent.cs
+++ b/Content.Lavaland.Shared/Pressure/PressureEfficiencyComponent.cs
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Shared.Atmos;
+
+namespace Content.Lavaland.Shared.Pressure;
+
+/// <summary>
+/// Data for modifying efficiency of some process based on the containing atmosphere's pressure.
+/// <seealso cref="PressureDamageChangeComponent"/>
+/// <seealso cref="PressureArmorChangeComponent"/>
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+[AutoGenerateComponentState]
+public sealed partial class PressureEfficiencyComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public bool Enabled = true;
+
+    [DataField, AutoNetworkedField]
+    public float LowerBound = Atmospherics.OneAtmosphere * 0.2f;
+
+    [DataField, AutoNetworkedField]
+    public float UpperBound = Atmospherics.OneAtmosphere * 0.5f;
+
+    [DataField, AutoNetworkedField]
+    public bool ApplyWhenInRange = true;
+}

--- a/Content.Lavaland.Shared/Pressure/PressureTrackerComponent.cs
+++ b/Content.Lavaland.Shared/Pressure/PressureTrackerComponent.cs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Content.Lavaland.Shared.Pressure;
+
+/// <summary>
+/// Tracks the atmospheric pressure this entity is exposed to and networks it for clients to use.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class PressureTrackerComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public float Pressure;
+}

--- a/Content.Lavaland.Shared/Pressure/SharedPressureEfficiencyChangeSystem.cs
+++ b/Content.Lavaland.Shared/Pressure/SharedPressureEfficiencyChangeSystem.cs
@@ -1,27 +1,44 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+using Content.Lavaland.Common.Weapons.Ranged;
+using Content.Lavaland.Shared.Weapons.Upgrades;
+using Content.Shared.Armor;
+using Content.Shared.Damage.Systems;
 using Content.Shared.Examine;
+using Content.Shared.Inventory;
+using Content.Shared.Projectiles;
+using Content.Shared.Weapons.Melee.Events;
+using Content.Shared.Weapons.Ranged.Systems;
+using Content.Shared.Wieldable;
 
 namespace Content.Lavaland.Shared.Pressure;
 
-public abstract class SharedPressureEfficiencyChangeSystem : EntitySystem
+public abstract partial class SharedPressureEfficiencyChangeSystem : EntitySystem
 {
+    [Dependency] private EntityQuery<ArmorComponent> _armorQuery = default!;
+    [Dependency] private EntityQuery<PressureEfficiencyComponent> _query = default!;
+    [Dependency] private EntityQuery<ProjectileComponent> _projectileQuery = default!;
+
     public override void Initialize()
     {
         base.Initialize();
 
         SubscribeLocalEvent<PressureDamageChangeComponent, ExaminedEvent>(OnExamined);
-
         SubscribeLocalEvent<PressureArmorChangeComponent, ExaminedEvent>(OnArmorExamined);
+
+        SubscribeLocalEvent<PressureDamageChangeComponent, GetMeleeDamageEvent>(OnGetDamage,
+            after: [ typeof(GunUpgradeSystem), typeof(SharedWieldableSystem) ]);
+        SubscribeLocalEvent<PressureDamageChangeComponent, ProjectileShotEvent>(OnProjectileShot,
+            after: [ typeof(GunUpgradeSystem) ]); // let this system reduce damage upgrades' added damage automatically
+        SubscribeLocalEvent<PressureArmorChangeComponent, InventoryRelayedEvent<DamageModifyEvent>>(OnArmorRelayDamageModify,
+            before: [typeof(SharedArmorSystem)]);
     }
 
     private void OnExamined(Entity<PressureDamageChangeComponent> ent, ref ExaminedEvent args)
     {
         var localeKey = "lavaland-examine-pressure-";
-        localeKey += ent.Comp.ApplyWhenInRange ? "in-range-" : "out-range-";
 
-        ExamineHelper(Math.Round(ent.Comp.LowerBound),
-            Math.Round(ent.Comp.UpperBound),
+        ExamineHelper(ent.Owner,
             Math.Round(ent.Comp.AppliedModifier, 2),
             localeKey,
             ref args);
@@ -30,19 +47,64 @@ public abstract class SharedPressureEfficiencyChangeSystem : EntitySystem
     private void OnArmorExamined(Entity<PressureArmorChangeComponent> ent, ref ExaminedEvent args)
     {
         var localeKey = "lavaland-examine-pressure-armor-";
-        localeKey += ent.Comp.ApplyWhenInRange ? "in-range-" : "out-range-";
-
-        ExamineHelper(Math.Round(ent.Comp.LowerBound),
-            Math.Round(ent.Comp.UpperBound),
+        ExamineHelper(ent.Owner,
             Math.Round(ent.Comp.ExtraPenetrationModifier * 100),
             localeKey,
             ref args);
     }
 
-    private void ExamineHelper(double min, double max, double modifier, string localeKey, ref ExaminedEvent args)
+    private void ExamineHelper(Entity<PressureEfficiencyComponent?> ent, double modifier, string localeKey, ref ExaminedEvent args)
     {
+        if (!_query.Resolve(ent, ref ent.Comp))
+            return;
+
+        localeKey += ent.Comp.ApplyWhenInRange ? "in-range-" : "out-range-";
         localeKey += modifier > 1f ? "debuff" : "buff";
+
         modifier = Math.Abs(modifier);
+        var min = Math.Round(ent.Comp.LowerBound);
+        var max = Math.Round(ent.Comp.UpperBound);
         args.PushMarkup(Loc.GetString(localeKey, ("min", min), ("max", max), ("modifier", modifier)));
+    }
+
+    private void OnGetDamage(Entity<PressureDamageChangeComponent> ent, ref GetMeleeDamageEvent args)
+    {
+        if (ent.Comp.ApplyToMelee && ApplyModifier(ent.Owner, args.User))
+            args.Damage *= ent.Comp.AppliedModifier;
+    }
+
+    private void OnProjectileShot(Entity<PressureDamageChangeComponent> ent, ref ProjectileShotEvent args)
+    {
+        if (!ApplyModifier(ent.Owner, args.User ?? ent)
+            || !ent.Comp.ApplyToProjectiles
+            || !_projectileQuery.TryComp(args.FiredProjectile, out var projectile))
+            return;
+
+        projectile.Damage *= ent.Comp.AppliedModifier;
+        Dirty(args.FiredProjectile, projectile);
+    }
+
+    public bool ApplyModifier(Entity<PressureEfficiencyComponent?> ent, EntityUid user)
+    {
+        if (!_query.Resolve(ent, ref ent.Comp))
+            return false;
+
+        var pressure = EnsureComp<PressureTrackerComponent>(user).Pressure;
+        var inRange = pressure >= ent.Comp.LowerBound && pressure <= ent.Comp.UpperBound;
+        return ent.Comp.Enabled && (inRange == ent.Comp.ApplyWhenInRange);
+    }
+
+    private void OnArmorRelayDamageModify(Entity<PressureArmorChangeComponent> ent, ref InventoryRelayedEvent<DamageModifyEvent> args)
+    {
+        if (args.Args.TargetPart is not {} part ||
+            ApplyModifier(ent.Owner, args.Owner) || // inverted compared to damage as armor should be weaker on station, not on lavaland
+            !_armorQuery.TryComp(ent, out var armor))
+            return;
+
+        var coverage = armor.ArmorCoverage;
+        if (!coverage.Contains(part))
+            return;
+
+        args.Args.Damage.ArmorPenetration += ent.Comp.ExtraPenetrationModifier;
     }
 }

--- a/Content.Lavaland.Shared/Weapons/Upgrades/GunUpgradeSystem.Upgrades.cs
+++ b/Content.Lavaland.Shared/Weapons/Upgrades/GunUpgradeSystem.Upgrades.cs
@@ -129,37 +129,45 @@ public sealed partial class GunUpgradeSystem
     {
         var weapon = args.Container.Owner;
         var comp = ent.Comp;
-        if (!TryComp<PressureDamageChangeComponent>(weapon, out var pdc))
+        if (!TryComp<PressureEfficiencyComponent>(weapon, out var pec) ||
+            !TryComp<PressureDamageChangeComponent>(weapon, out var pdc))
             return;
 
         comp.SavedAppliedModifier = pdc.AppliedModifier;
-        comp.SavedApplyWhenInRange = pdc.ApplyWhenInRange;
-        comp.SavedLowerBound = pdc.LowerBound;
-        comp.SavedUpperBound = pdc.UpperBound;
+        comp.SavedApplyWhenInRange = pec.ApplyWhenInRange;
+        comp.SavedLowerBound = pec.LowerBound;
+        comp.SavedUpperBound = pec.UpperBound;
 
         if (comp.NewAppliedModifier is { } newModifier)
+        {
             pdc.AppliedModifier = newModifier;
+            Dirty(weapon, pdc);
+        }
         if (comp.NewApplyWhenInRange is { } newApplyInRange)
-            pdc.ApplyWhenInRange = newApplyInRange;
+            pec.ApplyWhenInRange = newApplyInRange;
         if (comp.NewLowerBound is { } newLower)
-            pdc.LowerBound = newLower;
+            pec.LowerBound = newLower;
         if (comp.NewUpperBound is { } newUpper)
-            pdc.UpperBound = newUpper;
-        Dirty(weapon, pdc);
+            pec.UpperBound = newUpper;
+        Dirty(weapon, pec);
     }
 
     private void OnPressureEject(Entity<GunUpgradePressureComponent> ent, ref EntGotRemovedFromContainerMessage args)
     {
         var weapon = args.Container.Owner;
         var comp = ent.Comp;
-        if (!TryComp<PressureDamageChangeComponent>(weapon, out var pdc))
+        if (!TryComp<PressureEfficiencyComponent>(weapon, out var pec))
             return;
 
-        pdc.AppliedModifier = comp.SavedAppliedModifier;
-        pdc.ApplyWhenInRange = comp.SavedApplyWhenInRange;
-        pdc.LowerBound = comp.SavedLowerBound;
-        pdc.UpperBound = comp.SavedUpperBound;
-        Dirty(weapon, pdc);
+        if (TryComp<PressureDamageChangeComponent>(weapon, out var pdc))
+        {
+            pdc.AppliedModifier = comp.SavedAppliedModifier;
+            Dirty(weapon, pdc);
+        }
+        pec.ApplyWhenInRange = comp.SavedApplyWhenInRange;
+        pec.LowerBound = comp.SavedLowerBound;
+        pec.UpperBound = comp.SavedUpperBound;
+        Dirty(weapon, pec);
     }
 
     private void OnEffectsUpgradeHit(Entity<WeaponUpgradeEffectsComponent> ent, ref MeleeHitEvent args)

--- a/Resources/Prototypes/Body/species_base.yml
+++ b/Resources/Prototypes/Body/species_base.yml
@@ -47,6 +47,7 @@
     thresholds: [] # remove gib threshold, you can gib the torso instead
   - type: Tackler
   - type: KnowledgeHolder
+  - type: PressureTracker # avoid initial mispredict with PKAs and stuff, might be used by other stuff in the future too
   # </Trauma>
   # Shitmed - woundable visuals used instead
   #- type: DamageVisuals

--- a/Resources/Prototypes/Entities/Structures/Shuttles/cannons.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/cannons.yml
@@ -365,9 +365,9 @@
     count: 5
   - type: Machine
     board: ShuttleGunKineticCircuitboard
-  # <Trauma>
   - type: PressureDamageChange
-    lowerBound: 0
+  - type: PressureEfficiency
+    lowerBound: 0 # work in space
   - type: UpgradeableWeapon
   - type: ItemSlots # for upgrades
     slots:
@@ -380,4 +380,3 @@
         whitelist:
           tags:
           - PKAUpgrade
-  # </Trauma>

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/Weapons/Gun/industrial.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/Weapons/Gun/industrial.yml
@@ -1,10 +1,3 @@
-# SPDX-FileCopyrightText: 2024 NULL882 <gost6865@yandex.ru>
-# SPDX-FileCopyrightText: 2024 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
-# SPDX-FileCopyrightText: 2025 Ted Lukin <66275205+pheenty@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 pheenty <fedorlukin2006@gmail.com>
-#
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 - type: entity
@@ -31,6 +24,7 @@
   - type: Appearance
   - type: AmmoCounter
   - type: PressureDamageChange
+  - type: PressureEfficiency
   - type: UpgradeableWeapon
     maxUpgradeCapacity: 40
   - type: ContainerContainer

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -1,14 +1,3 @@
-# SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 Aidenkrz <aiden@djkraz.com>
-# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
-# SPDX-FileCopyrightText: 2025 RatherUncreative <RatherUncreativeName@proton.me>
-# SPDX-FileCopyrightText: 2025 SX-7 <92227810+SX-7@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
-# SPDX-FileCopyrightText: 2025 SolsticeOfTheWinter <solsticeofthewinter@gmail.com>
-# SPDX-FileCopyrightText: 2025 Ted Lukin <66275205+pheenty@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 Whatstone <whatston3@gmail.com>
-# SPDX-FileCopyrightText: 2025 gluesniffler <linebarrelerenthusiast@gmail.com>
-#
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 - type: entity

--- a/Resources/Prototypes/_Lavaland/Entities/Clothing/ancient_armor.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Clothing/ancient_armor.yml
@@ -40,6 +40,7 @@
     clothingPrototypes:
       head: LavalandEquipmentAncientArmorHood
   - type: PressureArmorChange
+  - type: PressureEfficiency
 
 - type: entity
   parent: ClothingHeadBase
@@ -76,3 +77,4 @@
         Heat: 0.65
         Caustic: 0.65
   - type: PressureArmorChange
+  - type: PressureEfficiency

--- a/Resources/Prototypes/_Lavaland/Entities/Clothing/explorer_suit.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Clothing/explorer_suit.yml
@@ -44,6 +44,7 @@
   - type: FireProtection
     reduction: 0.4
   - type: PressureArmorChange
+  - type: PressureEfficiency
   - type: Tag
     tags:
     - ExplorerSuit
@@ -84,6 +85,7 @@
         Heat: 0.65
         Caustic: 0.65
   - type: PressureArmorChange
+  - type: PressureEfficiency
 
 - type: entity
   parent: LavalandEquipmentExplorerSuit

--- a/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/Guns/Basic/base_pka.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/Guns/Basic/base_pka.yml
@@ -12,6 +12,7 @@
     - 0,0,1,1
   - type: PressureDamageChange
     applyToMelee: false
+  - type: PressureEfficiency
   - type: UpgradeableWeapon
   - type: ContainerContainer
     containers:

--- a/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/crushers.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/crushers.yml
@@ -22,6 +22,7 @@
     soundHit:
       collection: MetalThud
   - type: PressureDamageChange
+  - type: PressureEfficiency
   - type: Wieldable
   - type: GunRequiresWield
   - type: UseDelayBlockMelee

--- a/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/secondary.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/secondary.yml
@@ -16,8 +16,9 @@
       types:
         Slash: 12
   - type: PressureDamageChange
-    lowerBound: 0
     appliedModifier: 1.25
+  - type: PressureEfficiency
+    lowerBound: 0
   - type: EmbeddableProjectile
     sound: /Audio/Weapons/star_hit.ogg
     offset: -0.15,0.0
@@ -78,8 +79,9 @@
     mustBeEquippedToUse: true
     heavyStaminaCost: 4 # No skill?
   - type: PressureDamageChange
-    lowerBound: 0
     appliedModifier: 1.25
+  - type: PressureEfficiency
+    lowerBound: 0
   - type: Sharp
   - type: Prying
   - type: UseDelay
@@ -126,8 +128,9 @@
     range: 2 # Like a crusher, makes it possible to hit enemies without them hitting you
   # TODO make it wearable on a belt/back slot
   - type: PressureDamageChange
-    lowerBound: 0
     appliedModifier: 1.25
+  - type: PressureEfficiency
+    lowerBound: 0
   - type: Item
     size: Normal
     sprite: _Lavaland/Objects/Weapons/Secondary/kinetic_machete-inhands.rsi


### PR DESCRIPTION
- predicted pka/armor pressure efficiency change
- moved pressure efficiency data to separate component, lavaland armor shitcode was checking for damage component which obviously wasnt present on explorer suit, fixes #2784
- also gave skinning a damage origin so monkeys fight back, fixes #2780

## Media

explorer suit truncheon hit on station vs lavaland

<img width="134" height="67" alt="09:29:07" src="https://github.com/user-attachments/assets/24e4c63b-b187-42d1-9199-c2ba03d6ab71" />

<img width="132" height="72" alt="09:28:57" src="https://github.com/user-attachments/assets/b6798824-f8ce-4b85-bbe7-15f4b1af8ce8" />


## Changelog

:cl:
- fix: Fixed salv explorer suit fully protecting you on station.
- tweak: PKA/explorer suit/etc pressure efficiency changes are now predicted.