### PR TITLE
remove CashComponent from counterfeit spesos

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/space_cash.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/space_cash.yml
@@ -1,6 +1,7 @@
 - type: entity
+  abstract: true # Trauma
   parent: BaseItem
-  id: SpaceCash
+  id: BaseSpaceCash # Trauma - SpaceCash has CashComponent separately. i love not being able to remove components in child prototypes...
   name: spesos
   description: You gotta have money.
   components:
@@ -47,8 +48,8 @@
   - type: Tag
     tags:
     - Paper # Moth food
+  #- type: Cash # dont want this to be inherited, moved to separate SpaceCash prototype
   # </Trauma>
-  - type: Cash
   - type: Item
     shape:
     - 0,0,1,0

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Misc/space_cash.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Misc/space_cash.yml
@@ -1,5 +1,11 @@
 - type: entity
-  parent: SpaceCash
+  parent: BaseSpaceCash
+  id: SpaceCash
+  components:
+  - type: Cash
+
+- type: entity
+  parent: BaseSpaceCash
   id: SpaceCashCounterfeit
   suffix: Counterfeit
   components:


### PR DESCRIPTION
fixes #2825

big 2026 and you cant remove inherited components from prototypes...

:cl:
- fix: Fixed being able to put counterfeit spesos into cargo consoles.