### PR TITLE
Remove farts from everything but plasmamen

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/base.yml
@@ -6,7 +6,6 @@
   components:
   # <Trauma>
   - type: LanguageSpeaker
-  - type: Fart
   - type: CollectiveMind
   - type: SpecialAnimationViewer
   - type: Penetratable


### PR DESCRIPTION
## About the PR
Only plasmamen can fart now.

## Why / Balance
"The literal bare minimum needed to be a controllable mob" hmm seems like a great fucking place to add fart component. Clearly every single mob in the game should have a farting mechanic, including borgs, skeletons and ghosts.
Plasma farting is at least barely funny in some cases, every other use is just slop.
Also it's goob content so it's free to remove.

## Media
Not tested, probably works

## Requirements
- [X] I have read and am sometimes following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X] This PR is too based and should be merged before anybody notices.

**Changelog**
:trollface: 
