### PR TITLE
Converted command no longer tracked

### DIFF
--- a/Resources/Prototypes/_Trauma/Entities/Objects/Devices/pinpointers.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Objects/Devices/pinpointers.yml
@@ -22,3 +22,4 @@
     blacklist:
       components:
       - DeadMob
+      - Revolutionary


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->
Fixes https://github.com/Trauma-Station/Trauma-Station/issues/2868
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It blacklists any converted command members
## Test plan
Tested by using 2 clients and making one captain and rev and converting them
## Media

https://github.com/user-attachments/assets/d5012c6f-14f1-45df-9f49-3d48b951b90f


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Hoodsie
- tweak: converted command is no longer tracked


