### PR TITLE
Fix bug where dragging yourself onto secway occupies two hands

### DIFF
--- a/Content.Goobstation.Shared/Vehicles/SharedVehicleSystem.cs
+++ b/Content.Goobstation.Shared/Vehicles/SharedVehicleSystem.cs
@@ -151,6 +151,7 @@ public abstract partial class SharedVehicleSystem : EntitySystem
         if (ent.Comp.RequiredHands == 0)
             return false;
 
+        _virtualItem.DeleteInHandsMatching(driver, ent.Owner);
         for (var hands = 0; hands < ent.Comp.RequiredHands; hands++)
         {
             if (_virtualItem.TrySpawnVirtualItemInHand(ent.Owner, driver, false))

--- a/Content.Goobstation.Shared/Vehicles/SharedVehicleSystem.cs
+++ b/Content.Goobstation.Shared/Vehicles/SharedVehicleSystem.cs
@@ -151,7 +151,7 @@ public abstract partial class SharedVehicleSystem : EntitySystem
         if (ent.Comp.RequiredHands == 0)
             return false;
 
-        _virtualItem.DeleteInHandsMatching(driver, ent.Owner);
+        _virtualItem.DeleteInHandsMatching(driver, ent.Owner, queueDel: false);
         for (var hands = 0; hands < ent.Comp.RequiredHands; hands++)
         {
             if (_virtualItem.TrySpawnVirtualItemInHand(ent.Owner, driver, false))


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
Fixed bug involving secway: if you click on secway like you do 99% of the time it works as intended but if you drag yourself onto it instead it will occupy both hands.
Now with this pr both interactions result in the intended behavior of only occupying 1 hand.

## Why / Balance
It's intended that you have 1 free hand when using secway.

## Test plan
Run localhost devmap on master, spawn secway
Click secway observe 1 hand occupied, intended
Drag self onto secway, observe 2 hands occupied, bug

Run localhost devmap on this pr branch, repeat
Drag self onto secway, observe 1 hand occupied, bug fixed

## Media
super small fix

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: dragging yourself onto secway no longer occupies two hands

