### PR TITLE
chestbursting no longer gibs people

### DIFF
--- a/Content.Trauma.Server/Xenomorphs/Larva/XenomorphLarvaSystem.cs
+++ b/Content.Trauma.Server/Xenomorphs/Larva/XenomorphLarvaSystem.cs
@@ -1,36 +1,36 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-
+using Content.Server.Body.Systems;
 using Content.Server.DoAfter;
 using Content.Server.Ghost.Roles.Components;
 using Content.Server.Jittering;
 using Content.Server.Popups;
-using Content.Trauma.Shared.Xenomorphs;
-using Content.Trauma.Shared.Xenomorphs.Larva;
+using Content.Shared._White.Xenomorphs;
+using Content.Shared._White.Xenomorphs.Larva;
 using Content.Shared.DoAfter;
-using Content.Shared.Gibbing;
 using Content.Shared.IdentityManagement;
-using Content.Shared.Mind.Components;
 using Content.Shared.Popups;
 using Robust.Server.Containers;
 using Robust.Shared.Containers;
 using Robust.Shared.Player;
+using Content.Shared.Damage;
+using Content.Shared._Shitmed.Targeting;
 
-namespace Content.Trauma.Server.Xenomorphs.Larva;
+namespace Content.Server._White.Xenomorphs.Larva;
 
-public sealed partial class XenomorphLarvaSystem : EntitySystem
+public sealed class XenomorphLarvaSystem : EntitySystem
 {
-    [Dependency] private ContainerSystem _container = default!;
-    [Dependency] private DoAfterSystem _doAfter = default!;
-    [Dependency] private GibbingSystem _gibbing = default!;
-    [Dependency] private JitteringSystem _jitter = default!;
-    [Dependency] private PopupSystem _popup = default!;
+    [Dependency] private readonly BodySystem _body = default!;
+    [Dependency] private readonly ContainerSystem _container = default!;
+    [Dependency] private readonly DoAfterSystem _doAfter = default!;
+    [Dependency] private readonly JitteringSystem _jitter = default!;
+    [Dependency] private readonly PopupSystem _popup = default!;
+    [Dependency] private readonly DamageableSystem _damageableSystem = default!;
 
     public override void Initialize()
     {
         SubscribeLocalEvent<XenomorphLarvaComponent, ComponentShutdown>(OnShutdown);
         SubscribeLocalEvent<XenomorphLarvaComponent, EntGotRemovedFromContainerMessage>(OnGotRemovedFromContainer);
+        SubscribeLocalEvent<XenomorphLarvaComponent, TakeGhostRoleEvent>(OnTakeGhostRole);
         SubscribeLocalEvent<XenomorphLarvaComponent, LarvaBurstDoAfterEvent>(OnLarvaBurstDoAfter);
-        SubscribeLocalEvent<XenomorphLarvaComponent, MindAddedMessage>(OnMindAdded);
     }
 
     private void OnShutdown(EntityUid uid, XenomorphLarvaComponent component, ComponentShutdown args)
@@ -45,16 +45,9 @@ public sealed partial class XenomorphLarvaSystem : EntitySystem
             RemComp<XenomorphLarvaVictimComponent>(component.Victim.Value);
     }
 
-    private void OnMindAdded(EntityUid uid, XenomorphLarvaComponent component, MindAddedMessage args)
+    private void OnTakeGhostRole(EntityUid uid, XenomorphLarvaComponent component, TakeGhostRoleEvent args)
     {
-        if (component.Victim.HasValue
-            && _container.TryGetContainingContainer(uid, out _))
-            StartBurst(uid, component);
-    }
-
-    private void StartBurst(EntityUid uid, XenomorphLarvaComponent component)
-    {
-        if (component.Victim is not { } victim)
+        if (component.Victim is not {} victim)
             return;
 
         var doAfterEventArgs = new DoAfterArgs(EntityManager, uid, component.BurstDelay, new LarvaBurstDoAfterEvent(), uid, target: component.Victim)
@@ -84,6 +77,9 @@ public sealed partial class XenomorphLarvaSystem : EntitySystem
             return;
 
         _container.Remove(uid, container);
-        _gibbing.Gib(victim);
+        var damage = new DamageSpecifier();
+        damage.DamageDict.Add("Blunt", 120);
+        damage.DamageDict.Add("Piercing", 80);
+        _damageableSystem.TryChangeDamage(uid: victim, damage: damage, ignoreResistances: true, interruptsDoAfters: false, targetPart: TargetBodyPart.Chest);
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->
made it so chestbursting no longer gibs, ported from goob
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
one of the reasons i see complaints about xenomorphs is how they round remove a lot of people
## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [ ] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [ ] I have tested this pull request and written instructions on how to test it
- [ ] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
--> 🆑 assripper.

 - tweak: chestbursters no longer gib people
