### PR TITLE
chestbursters no longer gib people

### DIFF
--- a/Content.Trauma.Server/Xenomorphs/Larva/XenomorphLarvaSystem.cs
+++ b/Content.Trauma.Server/Xenomorphs/Larva/XenomorphLarvaSystem.cs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Content.Server.DoAfter;
 using Content.Server.Ghost.Roles.Components;
 using Content.Server.Jittering;

--- a/Content.Trauma.Server/Xenomorphs/Larva/XenomorphLarvaSystem.cs
+++ b/Content.Trauma.Server/Xenomorphs/Larva/XenomorphLarvaSystem.cs
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-
 using Content.Server.DoAfter;
 using Content.Server.Ghost.Roles.Components;
 using Content.Server.Jittering;
@@ -14,6 +12,8 @@ using Content.Shared.Popups;
 using Robust.Server.Containers;
 using Robust.Shared.Containers;
 using Robust.Shared.Player;
+using Content.Shared.Damage;
+using Content.Shared._Shitmed.Targeting;
 
 namespace Content.Trauma.Server.Xenomorphs.Larva;
 
@@ -24,6 +24,7 @@ public sealed partial class XenomorphLarvaSystem : EntitySystem
     [Dependency] private GibbingSystem _gibbing = default!;
     [Dependency] private JitteringSystem _jitter = default!;
     [Dependency] private PopupSystem _popup = default!;
+    [Dependency] private readonly DamageableSystem _damageableSystem = default!;
 
     public override void Initialize()
     {
@@ -84,6 +85,9 @@ public sealed partial class XenomorphLarvaSystem : EntitySystem
             return;
 
         _container.Remove(uid, container);
-        _gibbing.Gib(victim);
+        var damage = new DamageSpecifier();
+        damage.DamageDict.Add("Blunt", 120);
+        damage.DamageDict.Add("Piercing", 80);
+        _damageableSystem.TryChangeDamage(uid: victim, damage: damage, ignoreResistances: true, interruptsDoAfters: false, targetPart: TargetBodyPart.Chest);
     }
 }


### PR DESCRIPTION

<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->
made it so chestbursters no longer gib, ported from goob
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
a lot of the complaints i see with xenomorphs is how they round remove a lot of people
## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [ ] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [ ] I have tested this pull request and written instructions on how to test it
- [ ] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
--> 🆑 assripper.

 - tweak: chestbursters no longer gib people and instead apply 200 damage
