### PR TITLE
remove destructible from simplemobs

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
@@ -44,6 +44,10 @@
   id: SimpleSpaceMobBase # Mob without barotrauma, freezing and asphyxiation (for space carps!?)
   suffix: AI
   components:
+  # <Trauma>
+  - type: Destructible
+    thresholds: [] # Remove gibbing since it has bodyparts
+  # </Trauma>
   - type: NpcFactionMember
     factions:
     - SimpleNeutral


### PR DESCRIPTION
fixes #2891

:cl:
- fix: Fixed simplemobs gibbing at total parts damage instead of letting individual bodyparts handle it.