### PR TITLE
fix bingles

### DIFF
--- a/Content.Server/Access/Systems/IdCardSystem.cs
+++ b/Content.Server/Access/Systems/IdCardSystem.cs
@@ -1,4 +1,6 @@
-using Content.Shared.Kitchen.Components; // Trauma - moved microwaved event to shared
+// <Trauma>
+using Content.Shared.Kitchen.Components; // moved microwaved event to shared
+// </Trauma>
 using System.Linq;
 using Content.Server.Administration.Logs;
 using Content.Server.Chat.Systems;

--- a/Resources/Prototypes/_Goobstation/Entities/Markers/Spawners/bingle.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Markers/Spawners/bingle.yml
@@ -1,22 +1,10 @@
-# SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 Aiden <aiden@djkraz.com>
-# SPDX-FileCopyrightText: 2025 Aidenkrz <aiden@djkraz.com>
-# SPDX-FileCopyrightText: 2025 Errant <35878406+Errant-4@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 Fishbait <Fishbait@git.ml>
-# SPDX-FileCopyrightText: 2025 GMWQ <garethquaile@gmail.com>
-# SPDX-FileCopyrightText: 2025 Gareth Quaile <garethquaile@gmail.com>
-# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
-# SPDX-FileCopyrightText: 2025 Theodore Lukin <66275205+pheenty@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 fishbait <gnesse@gmail.com>
-# SPDX-FileCopyrightText: 2025 unknown <Administrator@DESKTOP-PMRIVVA.kommune.indresogn.no>
-#
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 - type: entity
-  id: SpawnPointGhostBingle
-  name: ghost role spawn point
-  suffix: Bingle
+  abstract: true
   parent: MarkerBase
+  id: BaseSpawnPointGhostBingle
+  name: bingle spawn point
   components:
   - type: GhostRole
     name: ghost-role-information-bingle-name
@@ -26,17 +14,56 @@
     - MindRoleGhostRoleTeamAntagonist
     raffle: null # no raffle for spammed role fuck you
   - type: GhostRoleMobSpawner
-    prototype: MobBingleRandom
   - type: Sprite
     sprite: Markers/jobs.rsi
     layers:
-      - state: green
-      - sprite: _Goobstation/Mobs/Bingle/bingle.rsi
-        state: icon
+    - state: green
+    - sprite: _Goobstation/Mobs/Bingle/bingle.rsi
+      state: icon
+
+# Random spawner
+- type: entity
+  parent: MarkerBase
+  id: SpawnPointGhostBingle
+  name: random bingle spawner
+  components:
+  - type: Sprite
+    sprite: _Goobstation/Mobs/Bingle/bingle.rsi
+    state: alive
+  - type: EntityTableSpawner
+    table: !type:GroupSelector
+      children:
+      - id: SpawnPointGhostBingleHunk
+      - id: SpawnPointGhostBingleSlavering
+      - id: SpawnPointGhostBingleBoney
 
 - type: entity
+  parent: BaseSpawnPointGhostBingle
+  id: SpawnPointGhostBingleHunk
+  suffix: Hunk
+  components:
+  - type: GhostRoleMobSpawner
+    prototype: MobBingleHunk
+
+- type: entity
+  parent: BaseSpawnPointGhostBingle
+  id: SpawnPointGhostBingleSlavering
+  suffix: Slavering
+  components:
+  - type: GhostRoleMobSpawner
+    prototype: MobBingleSlavering
+
+- type: entity
+  parent: BaseSpawnPointGhostBingle
+  id: SpawnPointGhostBingleBoney
+  suffix: Boney
+  components:
+  - type: GhostRoleMobSpawner
+    prototype: MobBingleBoney
+
+- type: entity
+  parent: BaseSpawnPointGhostBingle
   id: SpawnPointGhostBinglePrime
-  parent: SpawnPointGhostBingle
   suffix: Prime
   components:
   - type: GhostRoleMobSpawner

--- a/Resources/Prototypes/_Goobstation/Entities/Mobs/Player/bingle.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Mobs/Player/bingle.yml
@@ -1,26 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-# This is for random skins
-- type: entity
-  id: MobBingleRandom
-  parent: MarkerBase
-  name: bingle
-  suffix: Random
-  components:
-  - type: Sprite
-    sprite: _Goobstation/Mobs/Bingle/bingle.rsi
-    state: alive
-  - type: EntityTableSpawner
-    table: !type:GroupSelector
-      children:
-      - id: MobBingleHunk
-        weight: 1
-      - id: MobBingleSlavering
-        weight: 1
-      - id: MobBingleBoney
-        weight: 1
-
-
 # Base bingle
 - type: entity
   name: bingle
@@ -106,6 +85,7 @@
     speechVerb: Bingle
     speechSounds: Slime
   - type: LanguageSpeaker
+    currentLanguage: Bingle
     speaks:
     - Bingle
     understands:

--- a/Resources/Prototypes/_Shitmed/Entities/Structures/Machines/autodoc.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Structures/Machines/autodoc.yml
@@ -1,10 +1,3 @@
-# SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
-# SPDX-FileCopyrightText: 2025 JohnOakman <sremy2012@hotmail.fr>
-# SPDX-FileCopyrightText: 2025 deltanedas <39013340+deltanedas@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>
-# SPDX-FileCopyrightText: 2025 pheenty <fedorlukin2006@gmail.com>
-#
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # Autodocs
 


### PR DESCRIPTION
fixes #2878

change the ghost role from being for a random spawner to it spawning a random ghost role

also fixed them speaking tau ceti basic unless you explicitly switched to bingle :face_holding_back_tears: 

:cl:
- fix: Fixed bingles speaking tau-ceti basic and having to take the ghost role twice.