### PR TITLE
Nerf beanbags, kammerer and buff enforcer

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
@@ -140,7 +140,7 @@
       types:
         Blunt: 10
   - type: StaminaDamageOnCollide
-    damage: 45 # Goob edit
+    damage: 45 # Trauma - was 40
 
 - type: entity
   parent: BaseBulletKinetic # Trauma

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
@@ -140,7 +140,7 @@
       types:
         Blunt: 10
   - type: StaminaDamageOnCollide
-    damage: 60 # Goob edit
+    damage: 35 # Goob edit
 
 - type: entity
   parent: BaseBulletKinetic # Trauma

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
@@ -140,7 +140,7 @@
       types:
         Blunt: 10
   - type: StaminaDamageOnCollide
-    damage: 35 # Goob edit
+    damage: 45 # Goob edit
 
 - type: entity
   parent: BaseBulletKinetic # Trauma

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -171,7 +171,7 @@
   - type: BallisticAmmoProvider
   - type: GunRequiresWield #remove when inaccuracy on spreads is fixed
   - type: Gun
-    fireRate: 1 # Trauma, was 2
+    fireRate: 1.5 # Trauma, was 2
 - type: entity
   parent: WeaponShotgunEnforcer
   id: WeaponShotgunEnforcerRubber

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -194,7 +194,7 @@
     sprite: Objects/Weapons/Guns/Shotguns/pump.rsi
   - type: GunRequiresWield #remove when inaccuracy on spreads is fixed
   - type: Gun
-    # fireRate: 1 # goob
+    fireRate: 1 # Trauma
   - type: GunSpreadModifier
     spread: 0.6
   - type: Tag


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
Nerfed beanbags, they don't do 60 stamina damage anymore, now they deal 35. Enough to 3 shot anyone. If anyone complains that now it's not as good against people with armour: GOOD, you shouldn't be incentivized to use beanbags against armoured people.

## Why / Balance
In its current state it's laughably strong. I had a scenario where one sec off was able to take on 3 people as they can cycle through shells so quickly and all it takes is 2 shots to knock someone out of the fight for a good bit. Beanbag shells are also not balanced around the rest of the ammo/stamina damage dealers in the server. You can legit stamcrit someone in like half a second with 2 successive shots.

## Test plan
Shoot someone with beanbags

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Changelog

:cl: TechnicFighter

- tweak: Nerfed beanbags. Their stamina damage is now lower. 60>45.
- tweak: Nerfed Kammerer firerate to not make it better than the Enforcer. 2>1.
- tweak: Buffed Enforcer firerate. 1>1.5.