### PR TITLE
demon 1984

### DIFF
--- a/Resources/Prototypes/_Trauma/Recipes/Construction/enchanting.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Construction/enchanting.yml
@@ -1,43 +1,36 @@
 - type: construction
+  abstract: true
+  id: BaseDemonologyRune
+  targetNode: finish
+  category: construction-category-demonology
+  objectType: Structure
+  placementMode: SnapgridCenter
+  theory:
+    MagicalLiteracyKnowledge: 1
+  useQuality: false
+
+- type: construction
+  parent: BaseDemonologyRune
   id: EnchantingRune
   graph: EnchantingRune
-  targetNode: finish
-  category: construction-category-demonology
-  objectType: Structure
-  placementMode: SnapgridCenter
-  theory:
-    MagicalLiteracyKnowledge: 1
-  useQuality: false
 
 - type: construction
+  parent: BaseDemonologyRune
   id: MinorSummoning
   graph: MinorSummoning
-  targetNode: finish
-  category: construction-category-demonology
-  objectType: Structure
-  placementMode: SnapgridCenter
-  theory:
-    MagicalLiteracyKnowledge: 1
-  useQuality: false
-
-- type: construction
-  id: MediumSummoning
-  graph: MediumSummoning
-  targetNode: finish
-  category: construction-category-demonology
-  objectType: Structure
-  placementMode: SnapgridCenter
-  theory:
-    MagicalLiteracyKnowledge: 2
-  useQuality: false
-
-- type: construction
-  id: MajorSummoning
-  graph: MajorSummoning
-  targetNode: finish
-  category: construction-category-demonology
-  objectType: Structure
-  placementMode: SnapgridCenter
   theory:
     MagicalLiteracyKnowledge: 3
-  useQuality: false
+
+- type: construction
+  parent: BaseDemonologyRune
+  id: MediumSummoning
+  graph: MediumSummoning
+  theory:
+    MagicalLiteracyKnowledge: 4
+
+- type: construction
+  parent: BaseDemonologyRune
+  id: MajorSummoning
+  graph: MajorSummoning
+  theory:
+    MagicalLiteracyKnowledge: 5


### PR DESCRIPTION
demon summoning now needs mastery 3-5 instead of 1 bruh

mfw random tider can summon a demon without years and years of study in the wizard tower

:cl:
- tweak: Demonology runes now require magical literacy mastery levels 3-5 to make instead of 1.