### PR TITLE
make magic literacy random free roll instead of point buy

### DIFF
--- a/Content.Shared/Chat/ISharedChatManager.cs
+++ b/Content.Shared/Chat/ISharedChatManager.cs
@@ -34,5 +34,6 @@ public interface ISharedChatManager
     /// Trauma - moved from server, sends a message to a single player.
     /// </summary>
     void ChatMessageToOne(ChatChannel channel, string message, string wrappedMessage, EntityUid source, bool hideChat,
-        INetChannel client, Color? colorOverride = null, bool recordReplay = false, string? audioPath = null, float audioVolume = 0, NetUserId? author = null, bool canCoalesce = true, bool hidePopup = false); // Trauma added hidePopup
+        INetChannel client, Color? colorOverride = null, bool recordReplay = false, string? audioPath = null, float audioVolume = 0, NetUserId? author = null,
+        bool canCoalesce = true, bool hidePopup = false); // Trauma
 }

--- a/Content.Trauma.Shared/EntityEffects/ChatMessage.cs
+++ b/Content.Trauma.Shared/EntityEffects/ChatMessage.cs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Shared.Chat;
+using Content.Shared.EntityEffects;
+using Robust.Shared.Player;
+
+namespace Content.Trauma.Shared.EntityEffects;
+
+/// <summary>
+/// Sends the target entity a chat message only seen by them.
+/// </summary>
+public sealed partial class ChatMessage : EntityEffectBase<ChatMessage>
+{
+    [DataField(required: true)]
+    public ChatChannel Channel = ChatChannel.None;
+
+    /// <summary>
+    /// The message text.
+    /// </summary>
+    [DataField(required: true)]
+    public string Message = string.Empty;
+
+    /// <summary>
+    /// The wrapped message including extra markup tags.
+    /// Falls back to <see cref="Message"/> if null.
+    /// </summary>
+    [DataField]
+    public string? WrappedMessage;
+
+    [DataField]
+    public bool HideChat = false;
+
+    [DataField]
+    public Color? Color;
+}
+
+public sealed partial class ChatMessageEffectSystem : EntityEffectSystem<ActorComponent, ChatMessage>
+{
+    [Dependency] private ISharedChatManager _chat = default!;
+
+    protected override void Effect(Entity<ActorComponent> ent, ref EntityEffectEvent<ChatMessage> args)
+    {
+        var e = args.Effect;
+        var wrapped = e.WrappedMessage ?? e.Message;
+        var source = args.User ?? ent.Owner;
+        var channel = ent.Comp.PlayerSession.Channel;
+        _chat.ChatMessageToOne(e.Channel, e.Message, wrapped, source, e.HideChat, channel, e.Color);
+    }
+}

--- a/Resources/Prototypes/_Trauma/Entities/Knowledge/intellectual.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Knowledge/intellectual.yml
@@ -5,7 +5,7 @@
   components:
   - type: Knowledge
     experienceCost: 30
-    costs: [0, 3, 4, 5, 7, 8] # magic is hard...
+    costs: [0, 2] # need to randomly roll MagicalGift to get more, or get a j*b/antag
 
 - type: entity
   parent: BaseIntellectualKnowledge

--- a/Resources/Prototypes/_Trauma/EntityEffects/magical_gift.yml
+++ b/Resources/Prototypes/_Trauma/EntityEffects/magical_gift.yml
@@ -1,0 +1,27 @@
+- type: entityEffect
+  id: MagicalGift
+  conditions:
+  - !type:WhitelistCondition
+    whitelist:
+      components:
+      - KnowledgeHolder
+    blacklist:
+      components:
+      - BorgChassis
+      - Silicon # lol
+  effects:
+  - !type:GrantSkills
+    skills:
+      MagicalLiteracyKnowledge: 80 # need to already have a point in it to become master
+  - !type:ChatMessage
+    channel: Server
+    message: "Something deep inside your spirit has just awoken... You have an epiphany with magic!"
+    color: "#8d12a6"
+
+# All crew have a random chance of being magically gifted, regardless of role
+- type: playerEffects
+  id: MagicalGift
+  effects:
+  - !type:NestedEffect
+    proto: MagicalGift
+    probability: 0.1


### PR DESCRIPTION
you can no longer get anything past novice with your character skills

now theres a 10% chance for you to get 80 levels in magic literacy, meaning you can summon major demons if you were previously novice from your character skills or job

cant metagame a guy that wants to play with demons a lot if its random and he doesnt have 9 points put into it every round

## Media
<img width="845" height="172" alt="13:01:20" src="https://github.com/user-attachments/assets/d8b76631-9cb4-480d-beac-bd9067151d70" />
