### PR TITLE
fix triple ai trait not anchoring the cores

### DIFF
--- a/Content.Trauma.Shared/EntityEffects/SpawnAttached.cs
+++ b/Content.Trauma.Shared/EntityEffects/SpawnAttached.cs
@@ -21,19 +21,12 @@ public sealed partial class SpawnAttachedEntityEffectSystem : EntityEffectSystem
         var proto = args.Effect.Entity;
         var coords = entity.Owner.ToCoordinates();
 
-        if (args.Effect.Predicted)
+        if (_net.IsClient && !args.Effect.Predicted)
+            return;
+
+        for (var i = 0; i < quantity; i++)
         {
-            for (var i = 0; i < quantity; i++)
-            {
-                PredictedSpawnAttachedTo(proto, coords);
-            }
-        }
-        else if (_net.IsServer)
-        {
-            for (var i = 0; i < quantity; i++)
-            {
-                SpawnAttachedTo(proto, coords);
-            }
+            PredictedSpawnAttachedTo(proto, coords);
         }
     }
 }

--- a/Resources/Prototypes/_Trauma/Entities/Stations/Traits/neutral.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Stations/Traits/neutral.yml
@@ -43,7 +43,7 @@
     max: 2
     checkBlocked: false # don't get cucked by windoors
     effects:
-    - !type:SpawnEntity
+    - !type:SpawnAttached
       entity: PlayerStationAi
 
 - type: stationTrait


### PR DESCRIPTION
fixes #2897

changed the effect it was using so its anchored
surprisingly its still attached to the grid not the spawner...

## Media
<img width="411" height="211" alt="17:59:30" src="https://github.com/user-attachments/assets/668b7167-298f-486e-8811-6f2193a462b1" />


## Changelog
:cl:
- fix: Fixed AI Triumvurate trait leaving the extra 2 cores unpowered.