### PR TITLE
fix vision modifier examine

### DIFF
--- a/Content.Trauma.Shared/Viewcone/ViewconeAngleSystem.cs
+++ b/Content.Trauma.Shared/Viewcone/ViewconeAngleSystem.cs
@@ -42,8 +42,9 @@ public sealed partial class ViewconeAngleSystem : EntitySystem
         var dir = ent.Comp.AngleModifier < 1f ? "decrease" : "increase";
         var loc = "viewcone-modifier-examine-" + dir;
 
-        var degrees = (int) MathF.Abs(ent.Comp.AngleModifier);
-        args.PushMarkup(Loc.GetString(loc, ("degrees", degrees)));
+        // 1.25 -> 25, 0.6 -> 40
+        var percent = Math.Abs((int) (ent.Comp.AngleModifier * 100f) - 100);
+        args.PushMarkup(Loc.GetString(loc, ("percent", percent)));
     }
 
     private void OnModifyAngle(Entity<ViewconeModifierComponent> ent, ref ModifyViewconeAngleEvent args)

--- a/Resources/Locale/en-US/_Trauma/viewcone/modifier-examine.ftl
+++ b/Resources/Locale/en-US/_Trauma/viewcone/modifier-examine.ftl
@@ -1,2 +1,2 @@
-viewcone-modifier-examine-increase = Wearing this will increase your field of vision's angle by [color=green]{$degrees}[/color] degrees.
-viewcone-modifier-examine-decrease = Wearing this will decrease your field of vision's angle by [color=crimson]{$degrees}[/color] degrees.
+viewcone-modifier-examine-increase = Wearing this will increase your field of vision's angle by [color=green]{$percent}[/color]%.
+viewcone-modifier-examine-decrease = Wearing this will decrease your field of vision's angle by [color=crimson]{$percent}[/color]%.


### PR DESCRIPTION
never updated it when changing it from adding degrees to multiplying

## Media

real helmet
<img width="391" height="181" alt="18:45:33" src="https://github.com/user-attachments/assets/b761ec7a-9955-4887-bb93-86342c1d7aef" />

fake 1.5 helmet
<img width="378" height="128" alt="18:45:47" src="https://github.com/user-attachments/assets/46954760-3565-41c9-8c47-a89060bfd629" />


## Changelog
:cl:
- fix: Fixed helmets having a broken examine for their vision decrease.