### PR TITLE
made xenomorphs more of a stealth antag

### DIFF
--- a/Content.Trauma.Server/GameTicking/Rules/Components/XenomorphsRuleComponent.cs
+++ b/Content.Trauma.Server/GameTicking/Rules/Components/XenomorphsRuleComponent.cs
@@ -42,7 +42,7 @@ public sealed partial class XenomorphsRuleComponent : Component
         };
 
     [DataField]
-    public SoundSpecifier XenomorphTakeoverSound =
+    public SoundSpecifier? XenomorphTakeoverSound =
         new SoundPathSpecifier("/Audio/_Goobstation/Music/Colonial_Marines_The_Final_Battle.ogg")
         {
             Params = AudioParams.Default

--- a/Content.Trauma.Server/GameTicking/Rules/XenomorphsRuleSystem.cs
+++ b/Content.Trauma.Server/GameTicking/Rules/XenomorphsRuleSystem.cs
@@ -250,7 +250,8 @@ public sealed partial class XenomorphsRuleSystem : GameRuleSystem<XenomorphsRule
                 _chat.DispatchGlobalAnnouncement(Loc.GetString(component.Announcement), component.Sender != null ? Loc.GetString(component.Sender) : null, colorOverride: component.AnnouncementColor);
 
             _sound.StopStationEventMusic(uid, StationEventMusicType.Xenomorph);
-            _sound.DispatchStationEventMusic(uid, component.XenomorphInfestationSound, StationEventMusicType.Xenomorph, component.XenomorphInfestationSound.Params);
+            if (component.XenomorphInfestationSound != null)
+                _sound.DispatchStationEventMusic(uid, component.XenomorphInfestationSound, StationEventMusicType.Xenomorph, component.XenomorphInfestationSound.Params);
         }
 
         CheckRoundEnd(uid, component, gameRule);

--- a/Resources/Prototypes/_White/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_White/GameRules/roundstart.yml
@@ -7,8 +7,8 @@
     objectives:
     - XenomorphSurviveObjective
   - type: XenomorphsRule
-    xenomorphInfestationSound:
-      collection: XenoStart
+    announcement: null
+    xenomorphInfestationSound: null
   - type: MaintsSpawnRule
   - type: AntagSpawner
     prototype: MobXenomorphLarva


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->
disabled the callout announcement for xenomorphs
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
xenos being a stealth antag is a lot funner for the crew as its more scary, and the xenos as they dont have to fight 1800 tiders with toolboxes who shouldnt be trying to fight them, the announcement itself never even existed in ss13 and was only added by whitedream as they dont have a lot of pop. i feel this is also justified as xenos have recieved a lot of nerfs such as being defeated if the queen dies once
## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="600" height="499" alt="image" src="https://github.com/user-attachments/assets/1f5e5bfd-3a3c-4826-85d8-dd329956ebdf" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [ ] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [ ] I have tested this pull request and written instructions on how to test it
- [ ] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
--> 🆑 assripper.

 - tweak: xenomorphs are now more stealthy (e.g their callout announcement is gone)
