### PR TITLE
Added harm mode to interactor for auto forging

### DIFF
--- a/Content.Goobstation.Shared/Factory/InteractorComponent.cs
+++ b/Content.Goobstation.Shared/Factory/InteractorComponent.cs
@@ -43,7 +43,7 @@ public sealed partial class InteractorComponent : Component
     public bool UseInHand;
 
     /// <summary>
-    /// If the interactor should act as if it is in harmmode and should hit targets with it's held item.
+    /// If the interactor should act as if it is in harmmode and should hit targets with its held item.
     /// </summary>
     [DataField, AutoNetworkedField]
     public bool HarmMode;

--- a/Content.Goobstation.Shared/Factory/InteractorComponent.cs
+++ b/Content.Goobstation.Shared/Factory/InteractorComponent.cs
@@ -25,6 +25,12 @@ public sealed partial class InteractorComponent : Component
     public ProtoId<SinkPortPrototype> UseInHandPort = "UseInHand";
 
     /// <summary>
+    /// Signal port to toggle or enable/disable <see cref="HarmMode"/>.
+    /// </summary>
+    [DataField]
+    public ProtoId<SinkPortPrototype> HarmModePort = "HarmMode";
+
+    /// <summary>
     /// Whether to use alt interaction, i.e. use the highest priority verb on the target entity.
     /// </summary>
     [DataField, AutoNetworkedField]
@@ -35,6 +41,12 @@ public sealed partial class InteractorComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public bool UseInHand;
+
+    /// <summary>
+    /// If the interactor should act as if it is in harmmode and should hit targets with it's held item.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool HarmMode;
 }
 
 [Serializable, NetSerializable]

--- a/Content.Goobstation.Shared/Factory/RoboticArmSystem.cs
+++ b/Content.Goobstation.Shared/Factory/RoboticArmSystem.cs
@@ -212,7 +212,7 @@ public sealed partial class RoboticArmSystem : EntitySystem
 
         // prevent dropping items on walls etc
         var output = _exclusive.GetOutputSlot(ent);
-        if (output != null && IsOutputBlocked(ent))
+        if (output == null && IsOutputBlocked(ent))
             return false;
 
         var filter = _filter.GetSlot(ent);

--- a/Content.Goobstation.Shared/Factory/SharedInteractorSystem.cs
+++ b/Content.Goobstation.Shared/Factory/SharedInteractorSystem.cs
@@ -202,6 +202,7 @@ public abstract partial class SharedInteractorSystem : EntitySystem
             return false;
 
         // I turn on combat mode manually for the entity because otherwise the melee attack will fail
+        EnsureComp<CombatModeComponent>(ent.Owner);
         var prev = _combatMode.IsInCombatMode(ent.Owner);
         _combatMode.SetInCombatMode(ent.Owner, true);
         var result = _melee.AttemptLightAttack(ent.Owner, tool.Value, meleeWeapon, target);

--- a/Content.Goobstation.Shared/Factory/SharedInteractorSystem.cs
+++ b/Content.Goobstation.Shared/Factory/SharedInteractorSystem.cs
@@ -2,6 +2,7 @@
 
 using Content.Goobstation.Common.DoAfter;
 using Content.Goobstation.Shared.Factory.Filters;
+using Content.Shared.CombatMode;
 using Content.Shared.DeviceLinking;
 using Content.Shared.DeviceLinking.Events;
 using Content.Shared.DoAfter;
@@ -14,6 +15,7 @@ using Content.Shared.Throwing;
 using Content.Shared.Tools;
 using Content.Shared.Tools.Systems;
 using Content.Shared.Verbs;
+using Content.Shared.Weapons.Melee;
 using Robust.Shared.Containers;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
@@ -33,6 +35,8 @@ public abstract partial class SharedInteractorSystem : EntitySystem
     [Dependency] private SharedPopupSystem _popup = default!;
     [Dependency] private SharedToolSystem _tool = default!;
     [Dependency] protected StartableMachineSystem Machine = default!;
+    [Dependency] private SharedCombatModeSystem _combatMode = default!;
+    [Dependency] private SharedMeleeWeaponSystem _melee = default!;
 
     private EntityQuery<ActiveDoAfterComponent> _doAfterQuery;
     private EntityQuery<HandsComponent> _handsQuery;
@@ -187,8 +191,22 @@ public abstract partial class SharedInteractorSystem : EntitySystem
         if (!_hands.TryGetActiveItem(ent.Owner, out var tool))
             return _interaction.InteractHand(ent, target);
 
-        var coords = Transform(target).Coordinates;
-        return _interaction.InteractUsing(ent, tool.Value, target, coords);
+        if (!ent.Comp.HarmMode)
+        {
+            var coords = Transform(target).Coordinates;
+            return _interaction.InteractUsing(ent, tool.Value, target, coords);
+        }
+
+        // instead of interacting via the SharedInteractionSystem, attack the target with the held item
+        if (!TryComp<MeleeWeaponComponent>(tool, out var meleeWeapon))
+            return false;
+
+        // I turn on combat mode manually for the entity because otherwise the melee attack will fail
+        var prev = _combatMode.IsInCombatMode(ent.Owner);
+        _combatMode.SetInCombatMode(ent.Owner, true);
+        var result = _melee.AttemptLightAttack(ent.Owner, tool.Value, meleeWeapon, target);
+        _combatMode.SetInCombatMode(ent.Owner, prev);
+        return result;
     }
 
     protected void UpdateAppearance(EntityUid uid)

--- a/Content.Goobstation.Shared/Factory/SharedInteractorSystem.cs
+++ b/Content.Goobstation.Shared/Factory/SharedInteractorSystem.cs
@@ -89,7 +89,8 @@ public abstract partial class SharedInteractorSystem : EntitySystem
         var user = args.User;
         (string, Toggle)[] options = [
             ("alt-interact", () => SetAltInteract(ent, !ent.Comp.AltInteract)),
-            ("use-in-hand", () => SetUseInHand(ent, !ent.Comp.UseInHand))
+            ("use-in-hand", () => SetUseInHand(ent, !ent.Comp.UseInHand)),
+            ("harm-mode", () => SetHarmMode(ent, !ent.Comp.HarmMode))
         ];
         foreach (var (id, toggle) in options)
         {
@@ -130,13 +131,16 @@ public abstract partial class SharedInteractorSystem : EntitySystem
 
     private void OnSignalReceived(Entity<InteractorComponent> ent, ref SignalReceivedEvent args)
     {
-        var alt = args.Port == ent.Comp.AltInteractPort;
-        if (!alt && args.Port != ent.Comp.UseInHandPort)
-            return;
-
         var state = SignalState.Momentary;
         args.Data?.TryGetValue<SignalState>("logic_state", out state);
-        var current = alt ? ent.Comp.AltInteract : ent.Comp.UseInHand;
+        bool current;
+        if (args.Port == ent.Comp.AltInteractPort)
+            current = ent.Comp.AltInteract;
+        else if (args.Port == ent.Comp.UseInHandPort)
+            current = ent.Comp.UseInHand;
+        else
+            current = ent.Comp.HarmMode;
+
         var value = state switch
         {
             SignalState.Momentary => !current,
@@ -144,10 +148,13 @@ public abstract partial class SharedInteractorSystem : EntitySystem
             SignalState.Low => false,
             _ => false
         };
-        if (alt)
+
+        if (args.Port == ent.Comp.AltInteractPort)
             SetAltInteract(ent, value);
-        else
+        else if (args.Port == ent.Comp.UseInHandPort)
             SetUseInHand(ent, value);
+        else
+            SetHarmMode(ent, value);
     }
 
     public bool IsValidTarget(Entity<InteractorComponent> ent, EntityUid target)
@@ -225,6 +232,19 @@ public abstract partial class SharedInteractorSystem : EntitySystem
             return use;
 
         ent.Comp.UseInHand = use;
+        Dirty(ent);
+        return use;
+    }
+
+    /// <summary>
+    /// Set <see cref="InteractorComponent.HarmMode"> and dirty it.
+    /// </summary>
+    public bool SetHarmMode(Entity<InteractorComponent> ent, bool use)
+    {
+        if (ent.Comp.HarmMode == use)
+            return use;
+
+        ent.Comp.HarmMode = use;
         Dirty(ent);
         return use;
     }

--- a/Content.Goobstation.Shared/Factory/SharedInteractorSystem.cs
+++ b/Content.Goobstation.Shared/Factory/SharedInteractorSystem.cs
@@ -142,8 +142,10 @@ public abstract partial class SharedInteractorSystem : EntitySystem
             current = ent.Comp.AltInteract;
         else if (args.Port == ent.Comp.UseInHandPort)
             current = ent.Comp.UseInHand;
-        else
+        else if (args.Port == ent.Comp.HarmModePort)
             current = ent.Comp.HarmMode;
+        else
+            return;
 
         var value = state switch
         {
@@ -157,7 +159,7 @@ public abstract partial class SharedInteractorSystem : EntitySystem
             SetAltInteract(ent, value);
         else if (args.Port == ent.Comp.UseInHandPort)
             SetUseInHand(ent, value);
-        else
+        else if (args.Port == ent.Comp.HarmModePort)
             SetHarmMode(ent, value);
     }
 

--- a/Content.Goobstation.Shared/Factory/SharedInteractorSystem.cs
+++ b/Content.Goobstation.Shared/Factory/SharedInteractorSystem.cs
@@ -204,7 +204,6 @@ public abstract partial class SharedInteractorSystem : EntitySystem
             return false;
 
         // I turn on combat mode manually for the entity because otherwise the melee attack will fail
-        EnsureComp<CombatModeComponent>(ent.Owner);
         var prev = _combatMode.IsInCombatMode(ent.Owner);
         _combatMode.SetInCombatMode(ent.Owner, true);
         var result = _melee.AttemptLightAttack(ent.Owner, tool.Value, meleeWeapon, target);

--- a/Resources/Locale/en-US/_Goobstation/factory/interactor.ftl
+++ b/Resources/Locale/en-US/_Goobstation/factory/interactor.ftl
@@ -8,7 +8,7 @@ interactor-verb-toggled-use-in-hand = {$enabled ->
     [true]Enabled
     *[false]Disabled
 } use in hand mode.
-interactor-verb-toggle-harm-mode = Toggle Use In Hand Mode
+interactor-verb-toggle-harm-mode = Toggle Harm Mode
 interactor-verb-toggled-harm-mode = {$enabled ->
     [true]Enabled
     *[false]Disabled

--- a/Resources/Locale/en-US/_Goobstation/factory/interactor.ftl
+++ b/Resources/Locale/en-US/_Goobstation/factory/interactor.ftl
@@ -8,5 +8,11 @@ interactor-verb-toggled-use-in-hand = {$enabled ->
     [true]Enabled
     *[false]Disabled
 } use in hand mode.
+interactor-verb-toggle-harm-mode = Toggle Use In Hand Mode
+interactor-verb-toggled-harm-mode = {$enabled ->
+    [true]Enabled
+    *[false]Disabled
+} harm mode.
+
 
 interactor-verb-no-screwdriver = You need a screwdriver

--- a/Resources/Locale/en-US/_Goobstation/machines/automation.ftl
+++ b/Resources/Locale/en-US/_Goobstation/machines/automation.ftl
@@ -98,6 +98,9 @@ signal-port-description-alt-interact = Signal port to toggle alt interact mode, 
 signal-port-name-use-in-hand = Use In Hand Mode
 signal-port-description-use-in-hand = Signal port to toggle use in hand mode, or set it to a HIGH/LOW value. This will ignore targets and use Z or Alt+Z on the held tool.
 
+signal-port-name-harm-mode = Harm Mode
+signal-port-description-harm-mode = Signal port to toggle harm mode, or set it to a HIGH/LOW value. This will hit the target with the held tool like the interactor is in harm mode.
+
 # Autodoc
 
 signal-port-name-automation-slot-autodoc-hand = Item: Autodoc Hand

--- a/Resources/Prototypes/_Goobstation/DeviceLink/sink_ports.yml
+++ b/Resources/Prototypes/_Goobstation/DeviceLink/sink_ports.yml
@@ -111,6 +111,11 @@
   name: signal-port-name-use-in-hand
   description: signal-port-description-use-in-hand
 
+- type: sinkPort
+  id: HarmMode
+  name: signal-port-name-harm-mode
+  description: signal-port-description-harm-mode
+
 # Autodoc
 
 - type: sinkPort

--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/interactor.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/interactor.yml
@@ -95,6 +95,7 @@
   - type: UseDelay
     delay: 0.5 # to avoid tps lag machines
   # Fake interaction stuff
+  - type: CombatMode
   - type: DoAfter
     raiseEndedEvent: true # so Completed can be fired off
   - type: Hands

--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/interactor.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/interactor.yml
@@ -116,6 +116,7 @@
     - AutoStart
     - AltInteract
     - UseInHand
+    - HarmMode
   - type: DeviceLinkSource
     ports:
     - Started


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
Added harm mode to interactor (a machine unlocked by science which can be used to automate item interactions).
When on harm mode the interactor will attack its target with its held item.
This can be used to automate the most tedious parts of forging (hitting things with hammer and breaking bloomeries).

I also fixed a bug with the robotic arm where it would refuse to put things in its output machine.

## Why / Balance
I asked armok on discord about automating forging and he said it was fine.
You can give the interactors weapons and have them attack people to make traps. They respect the hit delays and I think they act as a person with 0 skills. Someone could use this to make a trap but like it is no better than a bunch of incredibly patient players with 0 melee skill. And at most you can have 4 interactors targeting one tile.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
spawn interactor, use screwdriver to toggle harm mode, observe it acts the same as the other mode verbs
attempt to toggle harm mode without screwdriver, observe failure

Place a weapon in the interactor's hand and connect a button to the `Start` port. Toggle on harm mode and put an entity in front of the interactor. You will also need a filter to target the entity because otherwise if there other alternate entities then it could target them instead and produce unexpected results. When the button is toggled, observe the interactor swinging the tool at the target, damaging it. Observe the swinging animation.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
3 minute youtube video of me building an automatic forge and forging some ingots:
https://www.youtube.com/watch?v=u375aAKDstA

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added a harm mode to interactors. Automated forging is now!
