### PR TITLE
increased xeno win condition as they win too fast now and increased their minpop slightly, also made their heat weakness higher

### DIFF
--- a/Content.Trauma.Server/GameTicking/Rules/Components/XenomorphsRuleComponent.cs
+++ b/Content.Trauma.Server/GameTicking/Rules/Components/XenomorphsRuleComponent.cs
@@ -78,7 +78,7 @@ public sealed partial class XenomorphsRuleComponent : Component
     #region RoundEnd
 
     [DataField]
-    public float XenomorphsShuttleCallPercentage = 0.3f;
+    public float XenomorphsShuttleCallPercentage = 0.7f;
 
     [DataField]
     public TimeSpan ShuttleCallTime = TimeSpan.FromMinutes(5);

--- a/Resources/Prototypes/_White/Actions/xenomorph.yml
+++ b/Resources/Prototypes/_White/Actions/xenomorph.yml
@@ -194,7 +194,7 @@
   - type: EntityTargetAction
     event: !type:AcidActionEvent
   - type: PlasmaCostAction
-    plasmaCost: 200
+    plasmaCost: 100
 
 # Jump action
 - type: entity

--- a/Resources/Prototypes/_White/Actions/xenomorph.yml
+++ b/Resources/Prototypes/_White/Actions/xenomorph.yml
@@ -179,7 +179,7 @@
 - type: entity
   id: ActionAcid
   parent: BaseAction
-  name: Corrosive acid (200)
+  name: Corrosive acid (100)
   description: Drench an object in acid, destroying it over time.
   components:
   - type: Action

--- a/Resources/Prototypes/_White/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_White/Damage/modifier_sets.yml
@@ -5,7 +5,7 @@
     Slash: 1.5
     Piercing: 0.80
     Cold: 0
-    Heat: 2.0
+    Heat: 1.5
     Poison: 0
 
 - type: damageModifierSet

--- a/Resources/Prototypes/_White/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_White/Damage/modifier_sets.yml
@@ -5,7 +5,7 @@
     Slash: 1.5
     Piercing: 0.80
     Cold: 0
-    Heat: 1.2
+    Heat: 2.0
     Poison: 0
 
 - type: damageModifierSet

--- a/Resources/Prototypes/_White/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_White/GameRules/roundstart.yml
@@ -22,7 +22,7 @@
   id: XenomorphsInfestationRoundstart
   components:
   - type: GameRule
-    minPlayers: 30
+    minPlayers: 40
   - type: AntagSelection
     antags:
     - !type:FixedAntagCount

--- a/Resources/Prototypes/_White/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_White/GameRules/roundstart.yml
@@ -22,7 +22,7 @@
   id: XenomorphsInfestationRoundstart
   components:
   - type: GameRule
-    minPlayers: 50
+    minPlayers: 30
   - type: AntagSelection
     antags:
     - !type:FixedAntagCount

--- a/Resources/Prototypes/_White/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_White/GameRules/roundstart.yml
@@ -22,7 +22,7 @@
   id: XenomorphsInfestationRoundstart
   components:
   - type: GameRule
-    minPlayers: 30
+    minPlayers: 50
   - type: AntagSelection
     antags:
     - !type:FixedAntagCount


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->
title
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
>roundstart xenos
>they win 13 minutes into the round..
## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [ ] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [ ] I have tested this pull request and written instructions on how to test it
- [ ] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
--> 🆑 assripper.

 - tweak: xenomorph win condition is higher and their minpop to spawn is now 40, aswell as them having more of a weakness to heat damage
