### PR TITLE
fix wraith crayon hand

### DIFF
--- a/Content.Goobstation.Shared/Wraith/Systems/BloodCrayonSystem.cs
+++ b/Content.Goobstation.Shared/Wraith/Systems/BloodCrayonSystem.cs
@@ -7,12 +7,19 @@ using Content.Shared.Crayon;
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
+using Content.Shared.Whitelist;
 
 namespace Content.Goobstation.Shared.Wraith.Systems;
+
 public sealed partial class BloodCrayonSystem : EntitySystem
 {
-    [Dependency] private SharedHandsSystem _handsSystem = default!;
+    [Dependency] private SharedHandsSystem _hands = default!;
     [Dependency] private WraithPointsSystem _wpSystem = default!;
+
+    private static readonly EntityWhitelist CrayonWhitelist = new()
+    {
+        Components = ["BloodCrayon"]
+    };
 
     public override void Initialize()
     {
@@ -29,16 +36,17 @@ public sealed partial class BloodCrayonSystem : EntitySystem
 
         if (ent.Comp.BloodCrayon == null)
         {
-            _handsSystem.AddHand(ent.Owner, ent.Comp.HandName, HandLocation.Middle);
+            _hands.AddHand(ent.Owner, ent.Comp.HandName, HandLocation.Middle,
+                emptyRepresentative: ent.Comp.BloodCrayonEntId, whitelist: CrayonWhitelist);
 
             var crayon = PredictedSpawnAtPosition(ent.Comp.BloodCrayonEntId, Transform(ent.Owner).Coordinates);
-            _handsSystem.TryForcePickup(ent.Owner, crayon, ent.Comp.HandName, false);
+            _hands.TryForcePickup(ent.Owner, crayon, ent.Comp.HandName, false);
 
             ent.Comp.BloodCrayon = crayon;
         }
         else
         {
-            _handsSystem.RemoveHand(ent.Owner, ent.Comp.HandName);
+            _hands.RemoveHand(ent.Owner, ent.Comp.HandName);
             PredictedQueueDel(ent.Comp.BloodCrayon);
             ent.Comp.BloodCrayon = null;
         }

--- a/Resources/Prototypes/_Goobstation/Wraith/Objects/crayon.yml
+++ b/Resources/Prototypes/_Goobstation/Wraith/Objects/crayon.yml
@@ -29,3 +29,4 @@
     - Recyclable
     - Trash
   - type: SpaceGarbage
+  - type: Unremoveable # no dropping your magic crayon


### PR DESCRIPTION
fixes #3009
- made crayon unremoveable
- added crayon whitelist to the hand so if you figure out a way to delete it you still cant go wraith esword path

## Media
placeholder, no free hand
<img width="193" height="68" alt="19:37:06" src="https://github.com/user-attachments/assets/48442472-de00-4be4-9881-f0600468ed6d" />


## Changelog
:cl:
- fix: Fixed wraith being able to drop their crayons for a free hand...