### PR TITLE
scroll is made out of paper

### DIFF
--- a/Resources/Prototypes/_Trauma/Entities/Objects/Specific/Enchanting/scrolls.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Objects/Specific/Enchanting/scrolls.yml
@@ -1,6 +1,6 @@
 - type: entity
   abstract: true
-  parent: BaseItem
+  parent: BasePaper
   id: BaseEnchantingScroll
   name: enchanted scroll
   description: A scroll embuded with an enchantment. Could do any number of things.
@@ -15,6 +15,8 @@
       shader: Enchant
   - type: Item
     size: Small
+  - type: Tag
+    tags: [] # no faxing it etc
   - type: GuideHelp
     guides:
     - Enchanting


### PR DESCRIPTION
fixes #2984

:cl:
- tweak: Enchanting scrolls are now made out of paper, i.e. can burn.