### PR TITLE
firebomb tweak

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Bombs/firebomb.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Bombs/firebomb.yml
@@ -1,17 +1,3 @@
-# SPDX-FileCopyrightText: 2023 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 deltanedas <39013340+deltanedas@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 deltanedas <@deltanedas:kde.org>
-# SPDX-FileCopyrightText: 2023 liltenhead <104418166+liltenhead@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Aexxie <codyfox.077@gmail.com>
-# SPDX-FileCopyrightText: 2024 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Mr. 27 <45323883+Dutch-VanDerLinde@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 metalgearsloth <comedian_vs_clown@hotmail.com>
-# SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 Armok <155400926+ARMOKS@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
-# SPDX-FileCopyrightText: 2025 Tiniest Shark <head.rebel@yahoo.com>
-#
-# SPDX-License-Identifier: MIT
 # ied crafted from random stuff
 # ideally it would be dynamic and work by actually sparking the solution but that doesnt exist yet :(
 # with that you could make napalm ied instead of welding fuel with no additional complexity
@@ -21,6 +7,12 @@
   name: fire bomb
   description: A weak, improvised incendiary device.
   components:
+  # <Trauma>
+  - type: SpawnOnTrigger
+    keysIn:
+    - timer
+    proto: MolotovFire
+  # </Trauma>
   - type: Sprite
     sprite: Objects/Weapons/Bombs/ied.rsi
     layers:

--- a/Resources/Prototypes/explosion.yml
+++ b/Resources/Prototypes/explosion.yml
@@ -128,7 +128,7 @@
     types:
       Heat: 1
       Blunt: 2
-      Slash: 3 # Goob edit
+      Piercing: 3
   lightColor: Orange
   texturePath: /Textures/Effects/fire.rsi
   fireStates: 3


### PR DESCRIPTION
resolves #3027

- changed slash back to pierce... bruh
- spawns a tile fire like lemon grenade / molotov

it no longer nuggets now, instead its almost all fire wow

:cl:
- tweak: Changed firebomb to create a tile fire and not nugget people.