### PR TITLE
rework dragon fire breath

### DIFF
--- a/Content.Shared/Actions/Components/ActionComponent.Trauma.cs
+++ b/Content.Shared/Actions/Components/ActionComponent.Trauma.cs
@@ -1,0 +1,23 @@
+namespace Content.Shared.Actions.Components;
+
+public sealed partial class ActionComponent
+{
+    /// <summary>
+    /// Raise event on the action entity instead of user/container.
+    /// </summary>
+    [DataField]
+    public bool RaiseOnAction;
+
+    /// <summary>
+    /// If true, ghosts will be granted this action.
+    /// For wizard lich revival stuff.
+    /// </summary>
+    [DataField]
+    public bool AllowGhostAction;
+
+    /// <summary>
+    /// Is this action predicted?
+    /// </summary>
+    [DataField]
+    public bool Predicted = true;
+}

--- a/Content.Shared/Actions/Components/ActionComponent.cs
+++ b/Content.Shared/Actions/Components/ActionComponent.cs
@@ -158,12 +158,6 @@ public sealed partial class ActionComponent : Component
     public EntityUid? AttachedEntity;
 
     /// <summary>
-    /// Trauma - Raise event on the action entity instead of user/container.
-    /// </summary>
-    [DataField]
-    public bool RaiseOnAction;
-
-    /// <summary>
     ///     If true, this will cause the the action event to always be raised directed at the action performer/user instead of the action's container/provider.
     /// </summary>
     [DataField, AutoNetworkedField]
@@ -192,20 +186,6 @@ public sealed partial class ActionComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public SoundSpecifier? Sound;
-
-    /// <summary>
-    ///     Goobstation.
-    ///     If true, ghosts will be granted this action.
-    /// </summary>
-    [DataField]
-    public bool AllowGhostAction;
-
-    /// <summary>
-    ///     Goobstation.
-    ///     Is this action predicted.
-    /// </summary>
-    [DataField]
-    public bool Predicted = true;
 }
 
 [DataRecord, Serializable, NetSerializable]

--- a/Content.Trauma.Shared/Actions/GunActionComponent.cs
+++ b/Content.Trauma.Shared/Actions/GunActionComponent.cs
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Content.Trauma.Shared.Actions;
+
+/// <summary>
+/// Component for a world target action to shoot the action's gun where you used the action.
+/// The action must raise the event on itself and have GunComponent, etc.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class GunActionComponent : Component;

--- a/Content.Trauma.Shared/Actions/GunActionSystem.cs
+++ b/Content.Trauma.Shared/Actions/GunActionSystem.cs
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Shared.Weapons.Ranged.Components;
+using Content.Shared.Weapons.Ranged.Systems;
+
+namespace Content.Trauma.Shared.Actions;
+
+// not to be confused with ActionGunSystem
+public sealed partial class GunActionSystem : EntitySystem
+{
+    [Dependency] private SharedGunSystem _gun = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<GunActionComponent, ActionGunShootEvent>(OnShoot);
+    }
+
+    private void OnShoot(Entity<GunActionComponent> ent, ref ActionGunShootEvent args)
+    {
+        var user = args.Performer;
+        var gun = Comp<GunComponent>(ent);
+        args.Handled = _gun.AttemptShoot(user, (ent, gun), args.Target, args.Entity);
+    }
+}

--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -243,7 +243,7 @@
     rechargeSound:
       path: /Audio/Animals/space_dragon_roar.ogg
   - type: BasicEntityAmmoProvider
-    proto: ProjectileDragonsBreath
+    proto: ProjectileDragonsBreathSpread # Trauma - add Spread
     capacity: 1
     count: 1
   - type: Gun
@@ -318,15 +318,22 @@
     event: !type:DevourActionEvent
 
 - type: entity
-  parent: BaseAction
+  parent: [ BaseAction, DragonsBreathGun ] # Trauma - inherit from the gun too
   id: ActionDragonsBreath
   name: "[color=orange]Dragon's Breath[/color]"
   description: Spew out flames at anyone foolish enough to attack you!
   components:
+  # <Trauma>
+  - type: GunAction
+  # </Trauma>
   - type: Action
+    # <Trauma>
+    raiseOnAction: true # action does the logic instead of the mob
+    useDelay: 5
+    # </Trauma>
     # TODO: actual sprite and iconOn
     icon: { sprite : Objects/Weapons/Guns/Projectiles/magic.rsi, state: fireball }
-    itemIconStyle: BigAction
+    itemIconStyle: NoItem # Trauma - was BigAction, dont show lungs
     priority: 2
   - type: TargetAction
     checkCanAccess: false

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/magic.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/magic.yml
@@ -65,16 +65,11 @@
     temperature: 1000
     ignited: true
   - type: RepeatingTrigger
-    delay: 0.5 # line of fire as well as if it hits something
-  - type: ExplodeOnTrigger
-  - type: Explosive
-    explosionType: FireBomb
-    totalIntensity: 5 # low intensity, the point is to burn attackers not to break open walls, dragons can just eat them
-    intensitySlope: 1
-    maxIntensity: 3
-    canCreateVacuum: false
-    deleteAfterExplosion: false
-    repeatable: true
+    delay: 0.2 # Trauma - was 0.5
+  # <Trauma> - replaced exploding with spawning tile fires
+  - type: SpawnOnTrigger
+    proto: MolotovFire
+  # </Trauma>
   - type: TimedDespawn
     lifetime: 5
 

--- a/Resources/Prototypes/_Shitmed/Body/Species/dragon.yml
+++ b/Resources/Prototypes/_Shitmed/Body/Species/dragon.yml
@@ -104,9 +104,7 @@
   parent: [ OrganAnimalLungs, OrganDragonInternal ]
   id: OrganDragonLungs
   components:
-  - type: OrganComponents
-    onAdd:
-    - type: ActionGun
-      action: ActionDragonsBreath
-      gunProto: DragonsBreathGun
+  - type: OrganActions
+    actions:
+    - ActionDragonsBreath
     # intentionally no BreathingImmunity

--- a/Resources/Prototypes/_Trauma/Entities/Objects/Weapons/Guns/Projectiles/magic.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Objects/Weapons/Guns/Projectiles/magic.yml
@@ -1,0 +1,9 @@
+- type: entity
+  parent: ProjectileDragonsBreath
+  id: ProjectileDragonsBreathSpread
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: ProjectileSpread
+    proto: ProjectileDragonsBreath
+    count: 3
+    spread: 30

--- a/Resources/Prototypes/_Trauma/Genetics/Mutations/fire_breath.yml
+++ b/Resources/Prototypes/_Trauma/Genetics/Mutations/fire_breath.yml
@@ -9,3 +9,22 @@
     difficulty: 12
     rarity: Rare
     locked: true # need to get it via lizard dormant mutation
+  - type: ActionMutation
+    action: ActionFireBreath
+
+- type: entity
+  parent: [ BaseMutationAction, ActionDragonsBreath ]
+  id: ActionFireBreath
+  name: "[color=orange]Breathe Fire[/color]"
+  description: Spew out flames from your lungs!
+  components:
+  - type: BasicEntityAmmoProvider
+    proto: ProjectileDragonsBreath # not a spread just 1 line of fire, funny lizard is weaker than a space dragon
+  - type: EffectAction
+    onPerformed: true
+    effects:
+    - !type:HealthChange
+      targetPart: Chest
+      damage:
+        types:
+          Heat: 4 # spicy


### PR DESCRIPTION
part of #702

- it now actually spews flames in a rough cone not a fucking wizard fireball that gibs people
- implemented the fire breath mutation as a weaker version with only 1 line instead of 3

fire breath does 4 burn damage to you when used :trollface: 

could be rewritten further to do a actual cone with no gaps but that takes effort

## Media

dragons breath

<img width="702" height="541" alt="12:28:11" src="https://github.com/user-attachments/assets/f900e71c-571d-4bee-9ecc-6cc08826d738" />
<img width="752" height="407" alt="12:28:18" src="https://github.com/user-attachments/assets/98c6aff3-0ac9-4904-bdb3-687c16017f42" />


fire breath mutation

<img width="147" height="469" alt="12:27:51" src="https://github.com/user-attachments/assets/8b4fc503-685c-40ed-bf13-5713cca82b71" />


## Changelog
:cl:
- add: Dragons breath is now actual fire instead of wizard's exploding fireball. It spews fire over a wide area, though still stopped by anything it hits.
- add: Implemented Fire Breath mutation as a single-line version of dragons breath.