### PR TITLE
add robo and genetics skillchips to rd chip box

### DIFF
--- a/Resources/Prototypes/_Trauma/Catalog/Fills/Boxes/heads.yml
+++ b/Resources/Prototypes/_Trauma/Catalog/Fills/Boxes/heads.yml
@@ -65,9 +65,11 @@
         children:
         - id: SkillChipResearchDirector
         - id: SkillChipScientist
-          amount: 3
+          amount: 2
+        - id: SkillChipGeneticist
+        - id: SkillChipRoboticist
         - id: SkillChipResearchAssistant
-          amount: 3
+          amount: 2
 
 - type: entity
   parent: BoxSkillChipsBase


### PR DESCRIPTION
they were missing

:cl:
- fix: Fixed RD not getting roboticist and geneticist skillchips in their locker.