### PR TITLE
fix replays randomly not being saved

### DIFF
--- a/Content.Trauma.Server/Program.cs
+++ b/Content.Trauma.Server/Program.cs
@@ -8,6 +8,8 @@ internal static class Program
 {
     public static void Main(string[] args)
     {
+        // c# doing this randomly breaks replay saving, linux doesnt need file locking
+        AppContext.SetSwitch("System.IO.DisableFileLocking", true);
         ContentStart.Start(args);
     }
 }


### PR DESCRIPTION
disable SafeFileHandle shitcode that does a user level locking thing for no fucking reason, it was just stopping replays from being saved
poshel nahui bill gates

:cl:
- fix: Probably fixed replays randomly not getting saved because of microslop's shitcode