### PR TITLE
Give Ventcrawler and nightvision to some critters

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -519,6 +519,7 @@
   id: MobMothroach
   description: This is the adorable by-product of multiple attempts at genetically mixing mothpeople with cockroaches.
   components:
+  - type: VentCrawler # Trauma
   - type: GhostRole
     prob: 0 # Trauma - was 0.25
     makeSentient: true
@@ -3392,6 +3393,12 @@
   parent: MobCatSpace
   description: Explosive kitten.
   components:
+  # <Trauma>
+  - type: NightVision
+    color: "#808080"
+    activateSound: null
+    deactivateSound: null
+  # </Trauma>
   - type: Sprite
     layers:
     - map: ["enum.DamageStateVisualLayers.Base"]

--- a/Resources/Prototypes/_Goobstation/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Mobs/NPCs/animals.yml
@@ -128,6 +128,10 @@
   parent: MobMothroach
   description: Explosive moth.
   components:
+  - type: NightVision
+    color: "#808080"
+    activateSound: null
+    deactivateSound: null
   - type: Sprite
     sprite: _Goobstation/Mobs/Animals/syndiroach.rsi
   - type: Clothing


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
Buffing syndi mothroach, mothroach and syndi cat

## Why / Balance
syndi mothroach feels like shift without being able to vent crawl, like literally every other syndie ally animal, also giving nightvision to some animals that really should have had em already

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Changelog

:cl: TechnicFighter

- tweak: Mothroaches can now ventcrawl, syndi mothroaches now have night vision, same with syndicats
