### PR TITLE
Add health analyzers to borg surgery modules

### DIFF
--- a/Resources/Prototypes/_Shitmed/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -9,7 +9,7 @@
     - state: icon-surgery
   - type: ItemBorgModule
     hands:
-    - item: HandheldHealthAnalyzer #Trauma - Add a health analyzer to borg surgery modules
+    - item: HandheldHealthAnalyzer
     - item: Scalpel
     - item: SawElectric
     - item: Drill
@@ -40,7 +40,7 @@
     - state: icon-advanced-surgery
   - type: ItemBorgModule
     hands:
-    - item: HandheldHealthAnalyzer #Trauma - Add a health analyzer to borg surgery modules
+    - item: HandheldHealthAnalyzer
     - item: EnergyScalpel
     - item: EnergyCautery
     - item: AdvancedRetractor

--- a/Resources/Prototypes/_Shitmed/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -9,6 +9,7 @@
     - state: icon-surgery
   - type: ItemBorgModule
     hands:
+    - item: HandheldHealthAnalyzer #Trauma - Add a health analyzer to borg surgery modules
     - item: Scalpel
     - item: SawElectric
     - item: Drill
@@ -39,6 +40,7 @@
     - state: icon-advanced-surgery
   - type: ItemBorgModule
     hands:
+    - item: HandheldHealthAnalyzer #Trauma - Add a health analyzer to borg surgery modules
     - item: EnergyScalpel
     - item: EnergyCautery
     - item: AdvancedRetractor


### PR DESCRIPTION
## About the PR
Added Health analyzers to surgery modules and advanced surgery modules for borgs 
## Why / Balance
Mediborgs have health analyzers in other modules, but switching between modules closes the UI. If you need to perform surgery on someone you can't have an active scan of the person as a result
## Test plan
Spawned a borg and controlled it, selected Medical chassis, spawned an advanced surgery module and fitted it using another mob, scanned a urist then switched between both surgery modules re-scanning urist each time
## Media
https://github.com/user-attachments/assets/ba1da7a7-6911-4ba2-925e-4acf9aceceae


## Requirements
- [X ] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X ] I have tested this pull request and written instructions on how to test it
- [X ] I have added media to this PR or it does not require an in-game showcase.

## Changelog
:cl: AirBiscuit
- tweak: Put a health analyzer in borg surgery and advanced surgery modules.
