### PR TITLE
Adding metal work knowledge for engi roles 

### DIFF
--- a/Resources/Prototypes/_Trauma/Entities/Objects/Specific/BrainChips/engineering.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Objects/Specific/BrainChips/engineering.yml
@@ -16,6 +16,7 @@
       WallsKnowledge: 50
       WindowsKnowledge: 50
       SmokeablesKnowledge: 100 # lol
+      MetalworkingKnowledge: 50
 
 - type: entity
   parent: BaseSkillChip
@@ -34,6 +35,7 @@
       WallsKnowledge: 26
       WindowsKnowledge: 26
       SmokeablesKnowledge: 50
+      MetalworkingKnowledge: 26
 
 - type: entity
   parent: BaseSkillChip
@@ -52,6 +54,7 @@
       WallsKnowledge: 26
       WindowsKnowledge: 26
       SmokeablesKnowledge: 50
+      MetalworkingKnowledge: 26
 
 - type: entity
   parent: BaseSkillChip
@@ -71,3 +74,4 @@
       WallsKnowledge: 10
       WindowsKnowledge: 10
       SmokeablesKnowledge: 50
+      MetalworkingKnowledge: 10

--- a/Resources/Prototypes/_Trauma/Entities/Objects/Specific/BrainChips/engineering.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Objects/Specific/BrainChips/engineering.yml
@@ -16,7 +16,7 @@
       WallsKnowledge: 50
       WindowsKnowledge: 50
       SmokeablesKnowledge: 100 # lol
-      MetalworkingKnowledge: 50
+      MetalworkingKnowledge: 50 # Trauma - original didn't have, no idea why
 
 - type: entity
   parent: BaseSkillChip

--- a/Resources/Prototypes/_Trauma/Entities/Objects/Specific/BrainChips/engineering.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Objects/Specific/BrainChips/engineering.yml
@@ -16,7 +16,7 @@
       WallsKnowledge: 50
       WindowsKnowledge: 50
       SmokeablesKnowledge: 100 # lol
-      MetalworkingKnowledge: 50 # Trauma - original didn't have, no idea why
+      MetalworkingKnowledge: 50
 
 - type: entity
   parent: BaseSkillChip


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->
Adding metal working knowledge to engineering roles 
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It was almost impossible to obtain metalworking knowledge unless you selected it through the skill page pre-round
## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Spawned Urist mchands, injected skill chip, gained metal working knowledge
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Smilez
- tweak: Added metal work knowledge to engi roles