### PR TITLE
fix decapoid markings

### DIFF
--- a/Resources/Prototypes/_Imp/Body/Species/decapoid.yml
+++ b/Resources/Prototypes/_Imp/Body/Species/decapoid.yml
@@ -1,6 +1,13 @@
 - type: markingsGroup
   id: Decapoid
+  onlyGroupWhitelisted: true
   limits:
+    enum.HumanoidVisualLayers.Hair:
+      limit: 0
+      required: false
+    enum.HumanoidVisualLayers.FacialHair:
+      limit: 0
+      required: false
     enum.HumanoidVisualLayers.Eyes:
       limit: 1
       required: true


### PR DESCRIPTION
fixes #3078

:cl:
- fix: Fixed decapoids being able to use more markings than they should.