### PR TITLE
Cosmic cult micropatch

### DIFF
--- a/Content.Trauma.Server/CosmicCult/EntitySystems/CosmicColossusSystem.cs
+++ b/Content.Trauma.Server/CosmicCult/EntitySystems/CosmicColossusSystem.cs
@@ -22,10 +22,10 @@ public sealed partial class CosmicColossusSystem : SharedCosmicColossusSystem
     public override void Initialize()
     {
         base.Initialize();
-        SubscribeLocalEvent<CosmicColossusComponent, ComponentInit>(OnSpawn);
+        SubscribeLocalEvent<CosmicColossusComponent, ComponentStartup>(OnSpawn);
     }
 
-    private void OnSpawn(Entity<CosmicColossusComponent> ent, ref ComponentInit args) // I WANT THIS BIG GUY HURLED TOWARDS THE STATION
+    private void OnSpawn(Entity<CosmicColossusComponent> ent, ref ComponentStartup args) // I WANT THIS BIG GUY HURLED TOWARDS THE STATION
     {
         if (!ent.Comp.Timed) return;
         ent.Comp.DeathTimer = _timing.CurTime + ent.Comp.DeathWait;
@@ -46,6 +46,7 @@ public sealed partial class CosmicColossusSystem : SharedCosmicColossusSystem
         _codeCondition.SetCompleted(ent.Owner, ent.Comp.EffigyObjective); // Ts not predictable
         PredictedSpawnAtPosition(ent.Comp.EffigyPrototype, pos);
         ent.Comp.Timed = false;
+        Dirty(ent, ent.Comp); // Wow what an absolute idiot forgot to add this! Oh, wait, that was me.
     }
 
 }

--- a/Content.Trauma.Shared/CosmicCult/SharedCosmicColossusSystem.cs
+++ b/Content.Trauma.Shared/CosmicCult/SharedCosmicColossusSystem.cs
@@ -248,7 +248,7 @@ public abstract partial class SharedCosmicColossusSystem : EntitySystem
         var xform = Transform(ent);
         outPos = new EntityCoordinates();
 
-        if (xform.GridUid is not {} gridUid || !TryComp<MapGridComponent>(gridUid, out var grid))
+        if (xform.GridUid is not { } gridUid || !TryComp<MapGridComponent>(gridUid, out var grid))
         {
             _popup.PopupClient(Loc.GetString("ghost-role-colossus-effigy-error-grid"), ent, ent);
             return false;


### PR DESCRIPTION
## About the PR
Midround colossus now properly gets yeeted towards the station on spawn.
Fixed midround colossus health being stuck at "bad" (I forgot to dirty the comp, so client didn't detect the effigy being placed, and tried to kill the colossus after 15 minutes even if it was placed)
Compressed Premonition from 22Mb down to just 4, which should hopefully alleviate the humongous lag spike during coscult finale. No significant quality drop because it had an obscenely high resolution before.

## Why / Balance
Bugfixes

## Test plan
addgamerule ColossusSpawn, take the role, notice how you're being thrown at the station.
Place effigy, wait 15 minutes, notice how your health doesn't go to "bad".

## Media
Not needed

## Requirements
- [X] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Changelog
:cl:
- fix: Fixed midround Entropic Colossus spawn being less cool than intended.
- fix: Fixed Entropic Colossus' health indicator sometimes behaving incorrectly.
- fix: Fixed lag spike when cosmic cult finale starts.