### PR TITLE
fix tray scanner flicker

### DIFF
--- a/Content.Client/SubFloor/SubFloorHideSystem.cs
+++ b/Content.Client/SubFloor/SubFloorHideSystem.cs
@@ -1,6 +1,5 @@
 // <Trauma>
 using Content.Shared.Atmos.Components;
-using Content.Trauma.Common.Sprite;
 // </Trauma>
 using Content.Shared.DrawDepth;
 using Content.Client.UserInterface.Systems.Sandbox;
@@ -13,7 +12,6 @@ namespace Content.Client.SubFloor;
 
 public sealed partial class SubFloorHideSystem : SharedSubFloorHideSystem
 {
-    [Dependency] private CommonSpriteVisibilitySystem _spriteVis = default!; // Trauma
     [Dependency] private SharedAppearanceSystem _appearance = default!;
     [Dependency] private SpriteSystem _sprite = default!;
     [Dependency] private IUserInterfaceManager _ui = default!;
@@ -107,10 +105,7 @@ public sealed partial class SubFloorHideSystem : SharedSubFloorHideSystem
             hasVisibleLayer = true;
         }
 
-        // <Trauma>
-        _spriteVis.UpdateVisibilityModifiers(uid, nameof(SubFloorHideComponent), hasVisibleLayer || revealed ? 1f : 0f);
-        // _sprite.SetVisible((uid, args.Sprite), hasVisibleLayer || revealed);
-        // </Trauma>
+        _sprite.SetVisible((uid, args.Sprite), hasVisibleLayer || revealed);
 
         if (ShowAll)
         {

--- a/Content.Medical.Server/Abductor/AbductorSystem.Console.cs
+++ b/Content.Medical.Server/Abductor/AbductorSystem.Console.cs
@@ -82,7 +82,7 @@ public sealed partial class AbductorSystem : SharedAbductorSystem
         };
         if (!_doAfter.TryStartDoAfter(doAfter))
         {
-            Log.Error("Failed to start attract doafter for {ToPrettyString(target)} by {ToPrettyString(user)} with {ToPrettyString(ent)}!");
+            Log.Error($"Failed to start attract doafter for {ToPrettyString(target)} by {ToPrettyString(user)} with {ToPrettyString(ent)}!");
             return;
         }
 

--- a/Content.Shared/Humanoid/HumanoidProfileSystem.cs
+++ b/Content.Shared/Humanoid/HumanoidProfileSystem.cs
@@ -60,7 +60,7 @@ public sealed partial class HumanoidProfileSystem : EntitySystem
         if (_prototype.TryIndex(species, out var speciesPrototype))
             return Loc.GetString(speciesPrototype.Name);
 
-        Log.Error("Tried to get representation of unknown species: {speciesId}");
+        Log.Error($"Tried to get representation of unknown species: {species}"); // Trauma - fix it being unformatted
         return Loc.GetString("humanoid-appearance-component-unknown-species");
     }
 

--- a/Resources/Prototypes/Accents/word_replacements.yml
+++ b/Resources/Prototypes/Accents/word_replacements.yml
@@ -520,7 +520,7 @@
     liar-word-14: liar-word-replacement-14
     liar-word-14-2: liar-word-replacement-14
     liar-word-15: liar-word-replacement-15
-    liar-word-15-2: liar-word-replacement-15
+    #liar-word-15-2: liar-word-replacement-15 # Trauma - doesnt exist
     liar-word-16: liar-word-replacement-16
     liar-word-16-2: liar-word-replacement-16
     liar-word-17: liar-word-replacement-17


### PR DESCRIPTION
fixes #3080

currently there is no real need for it to use sprite visibility, anchored things are always visible outside your vision cone. its not really doable to begin with because of the sprite alpha animation which was flickering when combined with sprite visibility modifiers

:cl:
- fix: Fixed pipes and cables flickering with t-ray scanner. Engis are no longer on suicide watch.