### PR TITLE
tweak species skill profiles

### DIFF
--- a/Resources/Prototypes/_Trauma/Entities/Knowledge/Profiles/IPC.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Knowledge/Profiles/IPC.yml
@@ -9,7 +9,7 @@
     AirlocksKnowledge: 1
     ToysKnowledge: 1
     BananiumKnowledge: 0
-    BotsKnowledge: 1 # I AM
+    BotsKnowledge: 2 # I AM
     FurnitureKnowledge: 1
     InfrastructureKnowledge: 1
     ElectronicsKnowledge: 2

--- a/Resources/Prototypes/_Trauma/Entities/Knowledge/Profiles/arachnid.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Knowledge/Profiles/arachnid.yml
@@ -28,7 +28,7 @@
     ChemistryKnowledge: 0
     # Physical Skill
     ThrowingKnowledge: 0
-    AthleticsKnowledge: 1 # Jumping spider larp.
+    AthleticsKnowledge: 2 # Jumping spider larp.
     StrengthKnowledge: 0
     ToughnessKnowledge: 0
     # Combat Skill

--- a/Resources/Prototypes/_Trauma/Entities/Knowledge/Profiles/diona.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Knowledge/Profiles/diona.yml
@@ -39,7 +39,7 @@
     WeaponsKnowledge: 0
     ArmorKnowledge: 0
     MetalworkingKnowledge: 0
-    CarvingKnowledge: 2 # Made of wood, so uh. yeah.
+    CarvingKnowledge: 0
     GunsmithingKnowledge: 0
     MechanicsKnowledge: 0
     TailoringKnowledge: 0

--- a/Resources/Prototypes/_Trauma/Entities/Knowledge/Profiles/dwarf.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Knowledge/Profiles/dwarf.yml
@@ -36,9 +36,9 @@
     ShootingKnowledge: 0
     # Crafting Quality
     FabricationKnowledge: 5
-    WeaponsKnowledge: 0
+    WeaponsKnowledge: 3 # The species that is about industry and crafting shouldn't be outclassed by humans at forging
     ArmorKnowledge: 0
-    MetalworkingKnowledge: 0
+    MetalworkingKnowledge: 5
     CarvingKnowledge: 0
     GunsmithingKnowledge: 0
     MechanicsKnowledge: 0

--- a/Resources/Prototypes/_Trauma/Entities/Knowledge/Profiles/reptilian.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Knowledge/Profiles/reptilian.yml
@@ -39,7 +39,7 @@
     WeaponsKnowledge: 0
     ArmorKnowledge: 0
     MetalworkingKnowledge: 0
-    CarvingKnowledge: 0
+    CarvingKnowledge: 2 # Ashwalkers are like tribal and bone armor is kinda tribal i guess bro
     GunsmithingKnowledge: 0
     MechanicsKnowledge: 0
     TailoringKnowledge: 0


### PR DESCRIPTION
## About the PR
Change species skill profiles

## Why / Balance
humans trump a lot of species in what they are supposed to be good at because 10 point skill buy

Dwarves: significantly buffed forging skills (Why does human cuck dwarves at forging when they are the forge species..)
Lizards: gave lizards average carving skill cus ashwalkers and bone armor is kinda tribal
diona: removed carving knowledge because just cus they're trees doesn't mean they would know how to carve themselves??
arachnids: buffed athletics by 1 point
ipc: buffed bots by 1 point

## Test plan
1. go in game
2. go to character editor
3. look at skills tab

## Media
just look at the yml

## Requirements
- [X] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Changelog
:cl:
- tweak: Buffed skill profiles for a few species, dwarves are actually good at forging.