### PR TITLE
round knowledge mastery numbers

### DIFF
--- a/Content.Trauma.Shared/Knowledge/Systems/SharedKnowledgeSystem.cs
+++ b/Content.Trauma.Shared/Knowledge/Systems/SharedKnowledgeSystem.cs
@@ -651,9 +651,9 @@ public abstract partial class SharedKnowledgeSystem : CommonKnowledgeSystem
         {
             >= 100 => 6, // 6th mastery doesn't exist, but we can use this to say max level
             >= 88 => 5,
-            >= 76 => 4,
-            >= 51 => 3,
-            >= 26 => 2,
+            >= 75 => 4,
+            >= 50 => 3,
+            >= 25 => 2,
             >= 1 => 1,
             _ => 0,
         };
@@ -675,9 +675,9 @@ public abstract partial class SharedKnowledgeSystem : CommonKnowledgeSystem
         {
             >= 6 => 100, // 6th mastery doesn't exist, but we can use this to say max level
             >= 5 => 88,
-            >= 4 => 76,
-            >= 3 => 51,
-            >= 2 => 26,
+            >= 4 => 75,
+            >= 3 => 50,
+            >= 2 => 25,
             >= 1 => 1,
             _ => 0,
         };

--- a/Resources/Prototypes/_Trauma/Entities/Knowledge/books.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Knowledge/books.yml
@@ -141,8 +141,8 @@
     - state: janitor
   - type: KnowledgeGrantOnUse
     skills:
-      ThrowingKnowledge: 26
-      JanitorKnowledge: 26
+      ThrowingKnowledge: 25
+      JanitorKnowledge: 25
     experience:
       ThrowingKnowledge: 3
       JanitorKnowledge: 3
@@ -179,7 +179,7 @@
     - state: fabrication
   - type: KnowledgeGrantOnUse
     skills:
-      FabricationKnowledge: 26
+      FabricationKnowledge: 25
     experience:
       FabricationKnowledge: 4
     doAfter: 2
@@ -215,7 +215,7 @@
     - state: fabrication
   - type: KnowledgeGrantOnUse
     skills:
-      CarvingKnowledge: 26
+      CarvingKnowledge: 25
     experience:
       CarvingKnowledge: 4
     doAfter: 2
@@ -230,7 +230,7 @@
   components:
   - type: KnowledgeGrantOnUse
     skills:
-      MaterialsKnowledge: 26
+      MaterialsKnowledge: 25
     experience:
       MaterialsKnowledge: 5
     doAfter: 2
@@ -246,7 +246,7 @@
   components:
   - type: KnowledgeGrantOnUse
     skills:
-      DoorsKnowledge: 26
+      DoorsKnowledge: 25
     experience:
       DoorsKnowledge: 5
     doAfter: 2
@@ -262,7 +262,7 @@
   components:
   - type: KnowledgeGrantOnUse
     skills:
-      AirlocksKnowledge: 26
+      AirlocksKnowledge: 25
     experience:
       AirlocksKnowledge: 5
     doAfter: 2
@@ -278,7 +278,7 @@
   components:
   - type: KnowledgeGrantOnUse
     skills:
-      ToysKnowledge: 26
+      ToysKnowledge: 25
     experience:
       ToysKnowledge: 5
     doAfter: 2
@@ -294,7 +294,7 @@
   components:
   - type: KnowledgeGrantOnUse
     skills:
-      BananiumKnowledge: 26
+      BananiumKnowledge: 25
     experience:
       BananiumKnowledge: 5
     doAfter: 2
@@ -310,7 +310,7 @@
   components:
   - type: KnowledgeGrantOnUse
     skills:
-      BotsKnowledge: 26
+      BotsKnowledge: 25
     experience:
       BotsKnowledge: 5
     doAfter: 2
@@ -326,7 +326,7 @@
   components:
   - type: KnowledgeGrantOnUse
     skills:
-      FurnitureKnowledge: 26
+      FurnitureKnowledge: 25
     experience:
       FurnitureKnowledge: 5
     doAfter: 2
@@ -342,7 +342,7 @@
   components:
   - type: KnowledgeGrantOnUse
     skills:
-      InfrastructureKnowledge: 26
+      InfrastructureKnowledge: 25
     experience:
       InfrastructureKnowledge: 5
     doAfter: 2
@@ -358,7 +358,7 @@
   components:
   - type: KnowledgeGrantOnUse
     skills:
-      ElectronicsKnowledge: 26
+      ElectronicsKnowledge: 25
     experience:
       ElectronicsKnowledge: 5
     doAfter: 2
@@ -374,7 +374,7 @@
   components:
   - type: KnowledgeGrantOnUse
     skills:
-      WallsKnowledge: 26
+      WallsKnowledge: 25
     experience:
       WallsKnowledge: 5
     doAfter: 2
@@ -390,7 +390,7 @@
   components:
   - type: KnowledgeGrantOnUse
     skills:
-      WindowsKnowledge: 26
+      WindowsKnowledge: 25
     experience:
       WindowsKnowledge: 5
     doAfter: 2
@@ -406,7 +406,7 @@
   components:
   - type: KnowledgeGrantOnUse
     skills:
-      SmokeablesKnowledge: 26
+      SmokeablesKnowledge: 25
     experience:
       SmokeablesKnowledge: 5
     doAfter: 2

--- a/Resources/Prototypes/_Trauma/Entities/Knowledge/categories.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Knowledge/categories.yml
@@ -73,7 +73,7 @@
   components:
   - type: Knowledge
     category: Language
-    learnedLevel: 26
+    learnedLevel: 25
     experienceCost: 16
     color: "#ADD8E6"
     costs: null # its currently fucked, have to use traits still :(

--- a/Resources/Prototypes/_Trauma/Entities/Knowledge/crafting.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Knowledge/crafting.yml
@@ -1,9 +1,9 @@
-# Level 0 - 0
-# Level 1 - 1-25
-# Level 2 = 26 - 50
-# Level 3 = 51 - 75
-# Level 4 = 76 - 87
-# Level 5 = 88 - 100
+# Mastery 0 - 0
+# Mastery 1 - 1-24
+# Mastery 2 = 25 - 49
+# Mastery 3 = 50 - 74
+# Mastery 4 = 75 - 87
+# Mastery 5 = 88 - 100
 
 - type: entity
   parent: BaseCraftingKnowledge

--- a/Resources/Prototypes/_Trauma/Entities/Objects/Specific/BrainChips/cargo.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Objects/Specific/BrainChips/cargo.yml
@@ -5,9 +5,9 @@
   components:
   - type: KnowledgeGrantOnWear
     skills:
-      StrengthKnowledge: 26
-      ToughnessKnowledge: 26
-      MeleeKnowledge: 26
+      StrengthKnowledge: 25
+      ToughnessKnowledge: 25
+      MeleeKnowledge: 25
       FurnitureKnowledge: 10 # crates
       # TODO: piloting and probably mech
 
@@ -18,8 +18,8 @@
   components:
   - type: KnowledgeGrantOnWear
     skills:
-      StrengthKnowledge: 26
-      ToughnessKnowledge: 26
+      StrengthKnowledge: 25
+      ToughnessKnowledge: 25
       FurnitureKnowledge: 10
       # TODO: piloting
 
@@ -30,8 +30,8 @@
   components:
   - type: KnowledgeGrantOnWear
     skills:
-      StrengthKnowledge: 26
-      ToughnessKnowledge: 26
-      MeleeKnowledge: 26
-      AthleticsKnowledge: 26
+      StrengthKnowledge: 25
+      ToughnessKnowledge: 25
+      MeleeKnowledge: 25
+      AthleticsKnowledge: 25
       # TODO: (low?) piloting

--- a/Resources/Prototypes/_Trauma/Entities/Objects/Specific/BrainChips/civilian.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Objects/Specific/BrainChips/civilian.yml
@@ -5,7 +5,7 @@
   components:
   - type: KnowledgeGrantOnWear
     skills:
-      FabricationKnowledge: 26
+      FabricationKnowledge: 25
       # evil NT mind control dulling the tiders
       MeleeKnowledge: -5
       ShootingKnowledge: -10
@@ -18,7 +18,7 @@
   - type: KnowledgeGrantOnWear
     skills:
     #fabrication and furniture for alter building
-      LiteracyKnowledge: 26
+      LiteracyKnowledge: 25
       MagicalLiteracyKnowledge: 50
       FurnitureKnowledge: 10
       FabricationKnowledge: 10
@@ -31,8 +31,8 @@
   - type: KnowledgeGrantOnWear
     skills:
       BananiumKnowledge: 50
-      ToysKnowledge: 26
-      FabricationKnowledge: 26
+      ToysKnowledge: 25
+      FabricationKnowledge: 25
 
 - type: entity
   parent: BaseSkillChip
@@ -41,7 +41,7 @@
   components:
   - type: KnowledgeGrantOnWear
     skills:
-      JanitorKnowledge: 26
+      JanitorKnowledge: 25
       MeleeKnowledge: 10 # mop hit hard ye
 
 - type: entity
@@ -62,7 +62,7 @@
   - type: KnowledgeGrantOnWear
     skills:
       LiteracyKnowledge: 50
-      MagicalLiteracyKnowledge: 26
+      MagicalLiteracyKnowledge: 25
       # TODO: kys add every language via code
       LanguageCat: 50
       LanguageDog: 50
@@ -115,8 +115,8 @@
   components:
   - type: KnowledgeGrantOnWear
     skills:
-      ToysKnowledge: 26
-      FabricationKnowledge: 26
+      ToysKnowledge: 25
+      FabricationKnowledge: 25
   - type: OrganComponents
     onAdd:
     - type: MimePowers # merci
@@ -130,8 +130,8 @@
   components:
   - type: KnowledgeGrantOnWear
     skills:
-      ToysKnowledge: 26
-      FabricationKnowledge: 26
+      ToysKnowledge: 25
+      FabricationKnowledge: 25
       # TODO: music knowledge if anyone makes that...
 
 - type: entity
@@ -141,8 +141,8 @@
   components:
   - type: KnowledgeGrantOnWear
     skills:
-      LiteracyKnowledge: 26
-      FabricationKnowledge: 26
+      LiteracyKnowledge: 25
+      FabricationKnowledge: 25
 
 - type: entity
   parent: BaseSkillChip
@@ -151,5 +151,5 @@
   components:
   - type: KnowledgeGrantOnWear
     skills:
-      ToysKnowledge: 26
-      FabricationKnowledge: 26
+      ToysKnowledge: 25
+      FabricationKnowledge: 25

--- a/Resources/Prototypes/_Trauma/Entities/Objects/Specific/BrainChips/engineering.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Objects/Specific/BrainChips/engineering.yml
@@ -25,17 +25,17 @@
   components:
   - type: KnowledgeGrantOnWear
     skills:
-      FabricationKnowledge: 26
-      MaterialsKnowledge: 26
-      DoorsKnowledge: 26
+      FabricationKnowledge: 25
+      MaterialsKnowledge: 25
+      DoorsKnowledge: 25
       AirlocksKnowledge: 16
-      FurnitureKnowledge: 26
+      FurnitureKnowledge: 25
       InfrastructureKnowledge: 50
-      ElectronicsKnowledge: 26
-      WallsKnowledge: 26
-      WindowsKnowledge: 26
+      ElectronicsKnowledge: 25
+      WallsKnowledge: 25
+      WindowsKnowledge: 25
       SmokeablesKnowledge: 50
-      MetalworkingKnowledge: 26
+      MetalworkingKnowledge: 25
 
 - type: entity
   parent: BaseSkillChip
@@ -44,17 +44,17 @@
   components:
   - type: KnowledgeGrantOnWear
     skills:
-      FabricationKnowledge: 26
-      MaterialsKnowledge: 26
-      DoorsKnowledge: 26
+      FabricationKnowledge: 25
+      MaterialsKnowledge: 25
+      DoorsKnowledge: 25
       AirlocksKnowledge: 16
-      FurnitureKnowledge: 26
-      InfrastructureKnowledge: 26
-      ElectronicsKnowledge: 26
-      WallsKnowledge: 26
-      WindowsKnowledge: 26
+      FurnitureKnowledge: 25
+      InfrastructureKnowledge: 25
+      ElectronicsKnowledge: 25
+      WallsKnowledge: 25
+      WindowsKnowledge: 25
       SmokeablesKnowledge: 50
-      MetalworkingKnowledge: 26
+      MetalworkingKnowledge: 25
 
 - type: entity
   parent: BaseSkillChip

--- a/Resources/Prototypes/_Trauma/Entities/Objects/Specific/BrainChips/medical.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Objects/Specific/BrainChips/medical.yml
@@ -25,7 +25,7 @@
   - type: KnowledgeGrantOnWear
     skills:
       FirstAidKnowledge: 30
-      SurgeryKnowledge: 26
+      SurgeryKnowledge: 25
 
 - type: entity
   parent: BaseSkillChip
@@ -34,7 +34,7 @@
   components:
   - type: KnowledgeGrantOnWear
     skills:
-      FirstAidKnowledge: 26
+      FirstAidKnowledge: 25
       SurgeryKnowledge: 10
     # TODO: xp boost?
 
@@ -47,7 +47,7 @@
   components:
   - type: KnowledgeGrantOnWear
     skills:
-      FirstAidKnowledge: 26
+      FirstAidKnowledge: 25
 
 - type: entity
   parent: BaseSkillChip
@@ -56,7 +56,7 @@
   components:
   - type: KnowledgeGrantOnWear
     skills:
-      ChemistryKnowledge: 26
+      ChemistryKnowledge: 25
   # TODO: supermatter hallucination thing parity
 
 - type: entity
@@ -66,5 +66,5 @@
   components:
   - type: KnowledgeGrantOnWear
     skills:
-      FirstAidKnowledge: 26
+      FirstAidKnowledge: 25
       # TODO

--- a/Resources/Prototypes/_Trauma/Entities/Objects/Specific/BrainChips/nukies.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Objects/Specific/BrainChips/nukies.yml
@@ -9,15 +9,15 @@
   - type: KnowledgeGrantOnWear
     skills:
       # Nukies are well-trained
-      MeleeKnowledge: 51
-      ShootingKnowledge: 51
-      StrengthKnowledge: 51
-      ToughnessKnowledge: 51
-      AthleticsKnowledge: 51
-      WeaponsKnowledge: 51
-      ThrowingKnowledge: 26
-      FirstAidKnowledge: 26
-      WallsKnowledge: 26
-      InfrastructureKnowledge: 26
-      ElectronicsKnowledge: 26
-      FabricationKnowledge: 26
+      MeleeKnowledge: 50
+      ShootingKnowledge: 50
+      StrengthKnowledge: 50
+      ToughnessKnowledge: 50
+      AthleticsKnowledge: 50
+      WeaponsKnowledge: 50
+      ThrowingKnowledge: 25
+      FirstAidKnowledge: 25
+      WallsKnowledge: 25
+      InfrastructureKnowledge: 25
+      ElectronicsKnowledge: 25
+      FabricationKnowledge: 25

--- a/Resources/Prototypes/_Trauma/Entities/Objects/Specific/BrainChips/science.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Objects/Specific/BrainChips/science.yml
@@ -18,8 +18,8 @@
   components:
   - type: KnowledgeGrantOnWear
     skills:
-      ElectronicsKnowledge: 26
-      ScienceKnowledge: 26
+      ElectronicsKnowledge: 25
+      ScienceKnowledge: 25
       # TODO: more??
 
 - type: entity
@@ -29,7 +29,7 @@
   components:
   - type: KnowledgeGrantOnWear
     skills:
-      ElectronicsKnowledge: 26
+      ElectronicsKnowledge: 25
       ScienceKnowledge: 50
       BotsKnowledge: 20 # not as good as robo
 
@@ -52,6 +52,6 @@
   - type: KnowledgeGrantOnWear
     skills:
       ElectronicsKnowledge: 50
-      ScienceKnowledge: 26
+      ScienceKnowledge: 25
       BotsKnowledge: 50
       # TODO: goida mech skill

--- a/Resources/Prototypes/_Trauma/Entities/Objects/Specific/BrainChips/security.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Objects/Specific/BrainChips/security.yml
@@ -16,8 +16,8 @@
   - type: KnowledgeGrantOnWear
     skills:
       FirstAidKnowledge: 50
-      SurgeryKnowledge: 26
-      ShootingKnowledge: 26
+      SurgeryKnowledge: 25
+      ShootingKnowledge: 25
 
 - type: entity
   parent: BaseSkillChip
@@ -26,7 +26,7 @@
   components:
   - type: KnowledgeGrantOnWear
     skills:
-      MeleeKnowledge: 26
+      MeleeKnowledge: 25
       ShootingKnowledge: 50
       # TODO: something for detecting
 
@@ -48,8 +48,8 @@
   components:
   - type: KnowledgeGrantOnWear
     skills:
-      MeleeKnowledge: 26
-      ShootingKnowledge: 26
+      MeleeKnowledge: 25
+      ShootingKnowledge: 25
 
 - type: entity
   parent: BaseSkillChip
@@ -61,5 +61,5 @@
       MeleeKnowledge: 50
       ShootingKnowledge: 50
       WeaponsKnowledge: 50
-      FirstAidKnowledge: 26 # Brigmedic isn't real
+      FirstAidKnowledge: 25 # Brigmedic isn't real
       SurgeryKnowledge: 20

--- a/Resources/Prototypes/_Trauma/Entities/Objects/Specific/BrainChips/service.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Objects/Specific/BrainChips/service.yml
@@ -14,8 +14,8 @@
   components:
   - type: KnowledgeGrantOnWear
     skills:
-      MeleeKnowledge: 26
-      ShootingKnowledge: 26
+      MeleeKnowledge: 25
+      ShootingKnowledge: 25
 
 - type: entity
   parent: BaseSkillChip
@@ -24,7 +24,7 @@
   components:
   - type: KnowledgeGrantOnWear
     skills:
-      FabricationKnowledge: 26
+      FabricationKnowledge: 25
       SmokeablesKnowledge: 50
 
 - type: entity
@@ -36,7 +36,7 @@
     skills:
       MartialArtCQCChef: 1 # work your way up chuddy
       MeleeKnowledge: 10
-      CookingKnowledge: 26
+      CookingKnowledge: 25
       LanguageSpaceItalian: 100 # born and raised
 
 - type: entity


### PR DESCRIPTION
50 is advanced instead of 51
25 vs 26
75 vs 76

its just better

fixes #3129 

:cl:
- tweak: Changed knowledge mastery levels to be 25/50/75 instead of 26/51/76, so chaplain now has advanced magical literacy.