### PR TITLE
Make batong evil

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -45,6 +45,8 @@
     activatedDamage:
       types:
         Blunt: 0
+        Shock: 4
+        Ion: 2
   - type: MeleeWeapon
     wideAnimationRotation: -135
     damage:

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -44,9 +44,10 @@
   - type: ItemToggleMeleeWeapon
     activatedDamage:
       types:
-        Blunt: 0
-        Shock: 4
-        Ion: 2
+      # <Trauma>
+        Blunt: 3
+        Shock: 2
+      # </Trauma>
   - type: MeleeWeapon
     wideAnimationRotation: -135
     damage:


### PR DESCRIPTION
## About the PR
made the stun baton do 2 shock and 3 blunt when turned on

## Why / Balance
sec is evil and this is fucking evil

## Test plan
1. spawn batong
2. turn batong on
3. shitsec urist mchands (or urist mcpositronic)

## Requirements
- [X] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Changelog
:cl:
- add: Added weak damage to the stun mode for the stun baton
