### PR TITLE
fix ipc inheritance

### DIFF
--- a/Resources/Prototypes/_EinsteinEngines/Body/Species/ipc.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Body/Species/ipc.yml
@@ -306,7 +306,7 @@
 ## Parts
 
 - type: entity
-  parent: [ OrganBaseTorsoSexed, OrganBaseTorso, OrganIPCExternal ]
+  parent: [ OrganIPCExternal, OrganBaseTorsoSexed, OrganBaseTorso ]
   id: OrganIPCTorso
   components:
   - type: BodyPart
@@ -322,7 +322,7 @@
     - IPCPump
 
 - type: entity
-  parent: [ OrganBaseHeadSexed, OrganBaseHeadBald, OrganIPCExternal ]
+  parent: [ OrganIPCExternal, OrganBaseHeadSexed, OrganBaseHeadBald ]
   id: OrganIPCHead
   components:
   - type: BodyPart
@@ -333,41 +333,41 @@
     - Ears
 
 - type: entity
-  parent: [ OrganBaseArmLeft, OrganIPCExternal ]
+  parent: [ OrganIPCExternal, OrganBaseArmLeft ]
   id: OrganIPCArmLeft
 
 - type: entity
-  parent: [  OrganBaseArmRight, OrganIPCExternal ]
+  parent: [ OrganIPCExternal,  OrganBaseArmRight ]
   id: OrganIPCArmRight
 
 - type: entity
-  parent: [  OrganBaseHandLeft, OrganIPCExternal ]
+  parent: [ OrganIPCExternal,  OrganBaseHandLeft ]
   id: OrganIPCHandLeft
 
 - type: entity
-  parent: [  OrganBaseHandRight, OrganIPCExternal ]
+  parent: [ OrganIPCExternal,  OrganBaseHandRight ]
   id: OrganIPCHandRight
 
 - type: entity
-  parent: [  OrganBaseLegLeft, OrganIPCExternal ]
+  parent: [ OrganIPCExternal,  OrganBaseLegLeft ]
   id: OrganIPCLegLeft
 
 - type: entity
-  parent: [  OrganBaseLegRight, OrganIPCExternal ]
+  parent: [ OrganIPCExternal,  OrganBaseLegRight ]
   id: OrganIPCLegRight
 
 - type: entity
-  parent: [  OrganBaseFootLeft, OrganIPCExternal ]
+  parent: [ OrganIPCExternal,  OrganBaseFootLeft ]
   id: OrganIPCFootLeft
 
 - type: entity
-  parent: [  OrganBaseFootRight, OrganIPCExternal ]
+  parent: [ OrganIPCExternal,  OrganBaseFootRight ]
   id: OrganIPCFootRight
 
 ## Organs
 
 - type: entity
-  parent: [ OrganBaseEyes, OrganIPCInternal ]
+  parent: [ OrganIPCInternal,  OrganBaseEyes ]
   id: OrganIPCEyes
   name: robotic eyes
   description: "01001001 00100000 01110011 01100101 01100101 00100000 01111001 01101111 01110101 00100001"
@@ -377,18 +377,18 @@
       group: IPC
 
 - type: entity
-  parent: [ OrganBaseTongue, OrganIPCInternal ]
+  parent: [ OrganIPCInternal,  OrganBaseTongue ]
   id: OrganIPCTongue
   name: vocal modulator
   description: A vocal modulator, used to produce speech.
 
 - type: entity
-  parent: [ OrganBaseEars, OrganIPCInternal ]
+  parent: [ OrganIPCInternal,  OrganBaseEars ]
   id: OrganIPCEars
   name: sonic receptors
 
 - type: entity
-  parent: [ OrganBaseHeart, OrganIPCInternal ]
+  parent: [ OrganIPCInternal,  OrganBaseHeart ]
   id: OrganIPCPump
   name: micro pump
   description: A micro pump, used to circulate coolant.

--- a/Resources/Prototypes/_EinsteinEngines/Body/Species/ipc.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Body/Species/ipc.yml
@@ -258,7 +258,6 @@
 
 - type: entity
   abstract: true
-  parent: OrganBase
   id: OrganIPC
   suffix: IPC
   components:


### PR DESCRIPTION
fixes #3164 

## Media

clanker eliminated
<img width="278" height="373" alt="16:09:04" src="https://github.com/user-attachments/assets/89900e84-a6ad-4ec7-a33f-57b2812dedee" />


parts still real
<img width="406" height="362" alt="16:09:32" src="https://github.com/user-attachments/assets/40d3021a-bcb1-4f13-9799-d0851ba087e9" />


## Changelog
:cl:
- fix: Fixed IPCs not taking ion damage. Set justice to ion.