### PR TITLE
check action blockers in TryStopPull

### DIFF
--- a/Content.Goobstation.Shared/GrabReleaseBind/GrabReleaseBindSystem.cs
+++ b/Content.Goobstation.Shared/GrabReleaseBind/GrabReleaseBindSystem.cs
@@ -13,7 +13,7 @@ namespace Content.Goobstation.Shared.GrabReleaseBind;
 /// </summary>
 public sealed partial class GrabReleaseBindSystem : EntitySystem
 {
-    [Dependency] private PullingSystem _pullingSystem = default!;
+    [Dependency] private PullingSystem _pulling = default!;
 
     /// <inheritdoc/>
     public override void Initialize()
@@ -26,9 +26,9 @@ public sealed partial class GrabReleaseBindSystem : EntitySystem
 
     private void HandleResistGrab(ICommonSession? session)
     {
-        if (session?.AttachedEntity == null || !TryComp<PullableComponent>(session.AttachedEntity, out var pullable))
+        if (session?.AttachedEntity is not { } uid || !TryComp<PullableComponent>(uid, out var pullable))
             return;
 
-        _pullingSystem.TryStopPull(session.AttachedEntity.Value, pullable, session.AttachedEntity.Value);
+        _pulling.TryStopPull(uid, pullable, user: uid);
     }
 }

--- a/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
+++ b/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
@@ -248,7 +248,7 @@ public sealed partial class PullingSystem : EntitySystem
 
     private void OnStopBeingPulledAlert(Entity<PullableComponent> ent, ref StopBeingPulledAlertEvent args)
     {
-        if (args.Handled || !_blocker.CanInteract(ent, null)) // Trauma - check action blockers
+        if (args.Handled)
             return;
 
         args.Handled = TryStopPull(ent, ent, ent);
@@ -731,6 +731,11 @@ public sealed partial class PullingSystem : EntitySystem
 
         if (pullerUidNull == null)
             return true;
+
+        // <Trauma> - check action blockers so you cant break grabs while stunned asleep etc
+        if (user is { } userUid !_blocker.CanInteract(userUid, pullableUid))
+            return false;
+        // </Trauma>
 
         var msg = new AttemptStopPullingEvent(user);
         RaiseLocalEvent(pullableUid, ref msg, true);

--- a/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
+++ b/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
@@ -733,7 +733,7 @@ public sealed partial class PullingSystem : EntitySystem
             return true;
 
         // <Trauma> - check action blockers so you cant break grabs while stunned asleep etc
-        if (user is { } userUid !_blocker.CanInteract(userUid, pullableUid))
+        if (user is { } userUid && !_blocker.CanInteract(userUid, pullableUid))
             return false;
         // </Trauma>
 


### PR DESCRIPTION
fixes #3196

they were previously only checked for the pulling alert, not goobs break grab keybind

:cl:
- fix: Fixed being able to use the break grab keybind while stunned, dead, etc.