### PR TITLE
Hitler Dead (swaps windoor safety wire from true to false)

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
@@ -145,7 +145,7 @@
     animatePanel: false
     openUnlitVisible: true
     # needed so that windoors loop between closing and reopening less often even though they don't crush
-    safety: true
+    safety: false # Trauma - was true # keep this shit false
   - type: NavMapDoor
   - type: DoorBolt
   - type: Electrified


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
swaps windoor safety wire from true to false
Fixes: #3193

## Why / Balance
it was giving me cancer and broke so many airlocks(not the airlock doors)

## Test plan
test the hop airlocks now

## Media
n/a

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Changelog

:cl: TechnicFighter

- remove: Hitler Dead. Windoors aren't cancer anymore