### PR TITLE
fix reinforcements being jobless

### DIFF
--- a/Content.Server/Station/Systems/StationSpawningSystem.cs
+++ b/Content.Server/Station/Systems/StationSpawningSystem.cs
@@ -169,7 +169,7 @@ public sealed partial class StationSpawningSystem : SharedStationSpawningSystem
         return entity.Value;
     }
 
-    private void DoJobSpecials(ProtoId<JobPrototype>? job, EntityUid entity)
+    public void DoJobSpecials(ProtoId<JobPrototype>? job, EntityUid entity) // Trauma - made public
     {
         if (!_prototypeManager.Resolve(job, out JobPrototype? prototype))
             return;

--- a/Content.Trauma.Client/Sprite/SpriteVisibilitySystem.cs
+++ b/Content.Trauma.Client/Sprite/SpriteVisibilitySystem.cs
@@ -27,7 +27,7 @@ public sealed partial class SpriteVisibilitySystem : CommonSpriteVisibilitySyste
 
     public override void UpdateVisibilityModifiers(EntityUid uid, string key, float alpha)
     {
-        if (!_spriteQuery.TryComp(uid, out var comp))
+        if (!_spriteQuery.TryComp(uid, out var comp) || TerminatingOrDeleted(uid))
             return;
 
         if (alpha >= 1f)

--- a/Content.Trauma.Server/Ghost/GhostCharacterSpawnerSystem.cs
+++ b/Content.Trauma.Server/Ghost/GhostCharacterSpawnerSystem.cs
@@ -48,9 +48,12 @@ public sealed partial class GhostCharacterSpawnerSystem : EntitySystem
         _character.AddSpawnedCharacter(user, profile.Name);
         _character.SendData(args.Player);
 
-        var mob = _spawning.SpawnPlayerMob(coords, job: null, profile: profile, station: null);
+        var mob = _spawning.SpawnPlayerMob(coords, job, profile: profile, station: null);
         _transform.AttachToGridOrMap(mob);
         EntityManager.AddComponents(mob, ent.Comp.Components);
+
+        if (ghostRole.JobProto is { } job)
+            _spawning.DoJobSpecials(job, mob);
 
         var ev = new GhostRoleSpawnerUsedEvent(ent, mob);
         RaiseLocalEvent(mob, ev, true);

--- a/Content.Trauma.Server/Ghost/GhostCharacterSpawnerSystem.cs
+++ b/Content.Trauma.Server/Ghost/GhostCharacterSpawnerSystem.cs
@@ -48,7 +48,7 @@ public sealed partial class GhostCharacterSpawnerSystem : EntitySystem
         _character.AddSpawnedCharacter(user, profile.Name);
         _character.SendData(args.Player);
 
-        var mob = _spawning.SpawnPlayerMob(coords, job, profile: profile, station: null);
+        var mob = _spawning.SpawnPlayerMob(coords, null, profile: profile, station: null);
         _transform.AttachToGridOrMap(mob);
         EntityManager.AddComponents(mob, ent.Comp.Components);
 


### PR DESCRIPTION
they do the job specials now
fixes #3214

:cl:
- fix: Fixed reinforcements not having skill chips, being counted as security, being able to enchant, etc.