### PR TITLE
Modify the SpacePolShuttle now that windoors aren't cancer

### DIFF
--- a/Resources/Maps/_Trauma/Shuttles/SpacePolShuttle.yml
+++ b/Resources/Maps/_Trauma/Shuttles/SpacePolShuttle.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 277.0.0
   forkId: ""
   forkVersion: ""
-  time: 05/29/2026 20:43:29
-  entityCount: 196
+  time: 06/17/2026 20:36:03
+  entityCount: 205
 maps: []
 grids:
 - 1
@@ -26,6 +26,8 @@ entities:
     components:
     - type: MetaData
       name: grid
+    - type: Transform
+      parent: invalid
     - type: MapGrid
       chunks:
         0,0:
@@ -79,16 +81,16 @@ entities:
           - -1,7
           - -1,9
           - -1,10
-          - 0,9
-          - 0,10
-          - 0,8
-          - 0,5
-          - 0,7
-          - 0,4
-          - 0,3
-          - 0,1
-          - 0,6
           - 0,2
+          - 0,6
+          - 0,1
+          - 0,3
+          - 0,4
+          - 0,7
+          - 0,5
+          - 0,8
+          - 0,10
+          - 0,9
           - 1,2
           - 1,3
           - 1,10
@@ -133,11 +135,12 @@ entities:
             0: 47232
             1: 48
           0,1:
-            0: 13247
+            0: 13119
+            2: 128
             1: 32768
           -1,1:
             0: 32959
-            2: 2048
+            3: 2048
             1: 12288
           0,2:
             0: 817
@@ -149,7 +152,8 @@ entities:
             1: 560
             0: 4096
           1,1:
-            0: 17
+            0: 1
+            2: 16
             1: 12800
           -2,0:
             1: 2176
@@ -164,6 +168,11 @@ entities:
         - volume: 2500
           immutable: True
           moles: {}
+        - volume: 2500
+          temperature: 293.14975
+          moles:
+            Oxygen: 20.078888
+            Nitrogen: 75.53487
         - volume: 2500
           temperature: 293.14948
           moles:
@@ -515,6 +524,29 @@ entities:
       rot: 3.141592653589793 rad
       pos: 0.5,9.5
       parent: 1
+- proto: ClosetWallOrange
+  entities:
+  - uid: 203
+    components:
+    - type: Transform
+      pos: 4.5,6.5
+      parent: 1
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 204
+          - 205
 - proto: ClothingBackpackSatchelSmugglerUnanchored
   entities:
   - uid: 64
@@ -537,6 +569,9 @@ entities:
         65:
           position: 1,2
           _rotation: South
+        69:
+          position: 3,0
+          _rotation: South
     - type: ContainerContainer
       containers:
         storagebase: !type:Container
@@ -547,49 +582,100 @@ entities:
           - 68
           - 66
           - 65
+          - 69
     - type: Physics
       canCollide: False
       bodyType: Static
+- proto: ClothingHandsGlovesColorYellow
+  entities:
+  - uid: 192
+    components:
+    - type: Transform
+      parent: 191
+    - type: Physics
+      canCollide: False
+- proto: ClothingOuterWinterColorOrange
+  entities:
+  - uid: 190
+    components:
+    - type: Transform
+      parent: 189
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+      storage: 189
+  - uid: 191
+    components:
+    - type: Transform
+      parent: 189
+    - type: ContainerContainer
+      containers:
+        storagebase: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 192
+          - 193
+          - 194
+        toggleable-clothing: !type:Container
+          showEnts: False
+          occludes: True
+          ents: []
+    - type: Storage
+      storedItems:
+        192:
+          position: 0,0
+          _rotation: South
+        193:
+          position: 1,0
+          _rotation: South
+        194:
+          position: 2,0
+          _rotation: South
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+      storage: 189
 - proto: ComputerComms
   entities:
-  - uid: 69
+  - uid: 70
     components:
     - type: Transform
       pos: -0.5,10.5
       parent: 1
 - proto: ComputerIFFSyndicate
   entities:
-  - uid: 70
+  - uid: 71
     components:
     - type: Transform
       pos: 1.5,10.5
       parent: 1
 - proto: ComputerShuttle
   entities:
-  - uid: 71
+  - uid: 72
     components:
     - type: Transform
       pos: 0.5,10.5
       parent: 1
 - proto: CrowbarRed
   entities:
-  - uid: 73
+  - uid: 75
     components:
     - type: Transform
-      parent: 72
+      parent: 73
     - type: Physics
       canCollide: False
 - proto: CyberPen
   entities:
-  - uid: 74
+  - uid: 76
     components:
     - type: Transform
-      parent: 72
+      parent: 73
     - type: Physics
       canCollide: False
 - proto: GasPipeBend
   entities:
-  - uid: 76
+  - uid: 77
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -597,31 +683,31 @@ entities:
       parent: 1
 - proto: GasPipeStraight
   entities:
-  - uid: 77
+  - uid: 78
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,4.5
       parent: 1
-  - uid: 78
+  - uid: 79
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,4.5
       parent: 1
-  - uid: 79
+  - uid: 80
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,4.5
       parent: 1
-  - uid: 80
+  - uid: 81
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,4.5
       parent: 1
-  - uid: 81
+  - uid: 82
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -629,14 +715,14 @@ entities:
       parent: 1
 - proto: GasPipeTJunction
   entities:
-  - uid: 82
+  - uid: 83
     components:
     - type: Transform
       pos: 0.5,4.5
       parent: 1
 - proto: GasPort
   entities:
-  - uid: 83
+  - uid: 84
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -644,32 +730,32 @@ entities:
       parent: 1
 - proto: GasVentPump
   entities:
-  - uid: 84
+  - uid: 85
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,3.5
       parent: 1
-  - uid: 85
+  - uid: 86
     components:
     - type: Transform
       pos: 3.5,5.5
       parent: 1
 - proto: GeneratorBasic15kW
   entities:
-  - uid: 86
+  - uid: 87
     components:
     - type: Transform
       pos: -2.5,3.5
       parent: 1
-  - uid: 87
+  - uid: 88
     components:
     - type: Transform
       pos: -2.5,5.5
       parent: 1
 - proto: GhostWarpPoint
   entities:
-  - uid: 88
+  - uid: 89
     components:
     - type: MetaData
       name: Fugitive Hunter Shuttle
@@ -679,54 +765,54 @@ entities:
       parent: 1
 - proto: GravityGeneratorMini
   entities:
-  - uid: 89
+  - uid: 90
     components:
     - type: Transform
       pos: -3.5,3.5
       parent: 1
 - proto: Grille
   entities:
-  - uid: 90
-    components:
-    - type: Transform
-      pos: -0.5,0.5
-      parent: 1
   - uid: 91
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,10.5
+      pos: -0.5,0.5
       parent: 1
   - uid: 92
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -1.5,10.5
+      pos: 2.5,10.5
       parent: 1
   - uid: 93
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 5.5,4.5
+      pos: -1.5,10.5
       parent: 1
   - uid: 94
     components:
     - type: Transform
-      pos: 1.5,0.5
+      rot: -1.5707963267948966 rad
+      pos: 5.5,4.5
       parent: 1
   - uid: 95
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,11.5
+      pos: 1.5,0.5
       parent: 1
   - uid: 96
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 0.5,11.5
+      pos: -0.5,11.5
       parent: 1
   - uid: 97
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,11.5
+      parent: 1
+  - uid: 98
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -734,7 +820,7 @@ entities:
       parent: 1
 - proto: GunSafeHunter
   entities:
-  - uid: 98
+  - uid: 99
     components:
     - type: Transform
       anchored: True
@@ -744,7 +830,7 @@ entities:
       bodyType: Static
 - proto: Gyroscope
   entities:
-  - uid: 99
+  - uid: 100
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -760,31 +846,39 @@ entities:
       canCollide: False
 - proto: MedkitBruteFilled
   entities:
-  - uid: 100
+  - uid: 101
     components:
     - type: Transform
       pos: 1.504614,7.6959615
       parent: 1
 - proto: MedkitBurnFilled
   entities:
-  - uid: 101
+  - uid: 102
     components:
     - type: Transform
       pos: 1.520239,7.266274
       parent: 1
 - proto: MedkitFilled
   entities:
-  - uid: 102
+  - uid: 103
     components:
     - type: Transform
       pos: 1.535864,6.8209615
       parent: 1
-- proto: PaperOffice
+- proto: Multitool
   entities:
-  - uid: 75
+  - uid: 194
     components:
     - type: Transform
-      parent: 72
+      parent: 191
+    - type: Physics
+      canCollide: False
+- proto: PaperOffice
+  entities:
+  - uid: 74
+    components:
+    - type: Transform
+      parent: 73
     - type: Paper
       content: >2-
 
@@ -793,59 +887,59 @@ entities:
       canCollide: False
 - proto: PosterContrabandBountyHunters
   entities:
-  - uid: 103
+  - uid: 104
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 1
 - proto: PosterContrabandSyndicateRecruitment
   entities:
-  - uid: 104
+  - uid: 105
     components:
     - type: Transform
       pos: 2.5,2.5
       parent: 1
 - proto: PosterLegitNanotrasenLogo
   entities:
-  - uid: 105
+  - uid: 106
     components:
     - type: Transform
       pos: -1.5,9.5
       parent: 1
 - proto: PosterLegitObey
   entities:
-  - uid: 106
+  - uid: 107
     components:
     - type: Transform
       pos: 4.5,6.5
       parent: 1
 - proto: Poweredlight
   entities:
-  - uid: 107
+  - uid: 108
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,6.5
       parent: 1
-  - uid: 108
+  - uid: 109
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,9.5
       parent: 1
-  - uid: 109
+  - uid: 110
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,2.5
       parent: 1
-  - uid: 110
+  - uid: 111
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,4.5
       parent: 1
-  - uid: 111
+  - uid: 112
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -853,87 +947,87 @@ entities:
       parent: 1
 - proto: ShuttersNormal
   entities:
-  - uid: 112
+  - uid: 113
     components:
     - type: Transform
       pos: -1.5,10.5
       parent: 1
-  - uid: 113
+  - uid: 114
     components:
     - type: Transform
       pos: -0.5,11.5
       parent: 1
-  - uid: 114
+  - uid: 115
     components:
     - type: Transform
       pos: 0.5,11.5
       parent: 1
-  - uid: 115
+  - uid: 116
     components:
     - type: Transform
       pos: 1.5,11.5
       parent: 1
-  - uid: 116
+  - uid: 117
     components:
     - type: Transform
       pos: 2.5,10.5
       parent: 1
-  - uid: 117
+  - uid: 118
     components:
     - type: Transform
       pos: 5.5,4.5
       parent: 1
 - proto: ShuttleWindow
   entities:
-  - uid: 118
+  - uid: 119
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,10.5
       parent: 1
-  - uid: 119
+  - uid: 120
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,11.5
       parent: 1
-  - uid: 120
+  - uid: 121
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,10.5
       parent: 1
-  - uid: 121
+  - uid: 122
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,11.5
       parent: 1
-  - uid: 122
+  - uid: 123
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,11.5
       parent: 1
-  - uid: 123
+  - uid: 124
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,4.5
       parent: 1
-  - uid: 124
+  - uid: 125
     components:
     - type: Transform
       pos: -0.5,0.5
       parent: 1
-  - uid: 125
+  - uid: 126
     components:
     - type: Transform
       pos: 1.5,0.5
       parent: 1
 - proto: SignalButton
   entities:
-  - uid: 126
+  - uid: 127
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -941,9 +1035,6 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        112:
-        - - Pressed
-          - Toggle
         113:
         - - Pressed
           - Toggle
@@ -959,6 +1050,9 @@ entities:
         117:
         - - Pressed
           - Toggle
+        118:
+        - - Pressed
+          - Toggle
 - proto: SmokeGrenade
   entities:
   - uid: 66
@@ -969,14 +1063,14 @@ entities:
       canCollide: False
 - proto: SpawnPointNukies
   entities:
-  - uid: 127
+  - uid: 128
     components:
     - type: Transform
       pos: 0.5,4.5
       parent: 1
 - proto: SubstationWallBasic
   entities:
-  - uid: 128
+  - uid: 129
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -984,30 +1078,38 @@ entities:
       parent: 1
 - proto: TableReinforced
   entities:
-  - uid: 129
+  - uid: 130
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,9.5
       parent: 1
-  - uid: 130
+  - uid: 131
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,7.5
       parent: 1
-  - uid: 131
+  - uid: 132
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,6.5
       parent: 1
-  - uid: 132
+  - uid: 133
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,5.5
       parent: 1
+- proto: Telecrystal25
+  entities:
+  - uid: 69
+    components:
+    - type: Transform
+      parent: 64
+    - type: Physics
+      canCollide: False
 - proto: ThrowingKnife
   entities:
   - uid: 67
@@ -1024,69 +1126,69 @@ entities:
       canCollide: False
 - proto: Thruster
   entities:
-  - uid: 133
+  - uid: 134
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,1.5
       parent: 1
-  - uid: 134
+  - uid: 135
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,1.5
       parent: 1
-  - uid: 135
+  - uid: 136
     components:
     - type: Transform
       pos: 4.5,7.5
       parent: 1
-  - uid: 136
-    components:
-    - type: Transform
-      pos: 3.5,7.5
-      parent: 1
   - uid: 137
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,1.5
+      pos: 3.5,7.5
       parent: 1
   - uid: 138
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -3.5,1.5
+      pos: -2.5,1.5
       parent: 1
   - uid: 139
     components:
     - type: Transform
-      pos: -3.5,7.5
+      rot: 3.141592653589793 rad
+      pos: -3.5,1.5
       parent: 1
   - uid: 140
     components:
     - type: Transform
-      pos: -2.5,7.5
+      pos: -3.5,7.5
       parent: 1
   - uid: 141
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,9.5
+      pos: -2.5,7.5
       parent: 1
   - uid: 142
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 3.5,8.5
+      pos: 3.5,9.5
       parent: 1
   - uid: 143
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,8.5
+      parent: 1
+  - uid: 144
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,8.5
       parent: 1
-  - uid: 144
+  - uid: 145
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1094,7 +1196,7 @@ entities:
       parent: 1
 - proto: ToiletDirtyWaterFilled
   entities:
-  - uid: 72
+  - uid: 73
     components:
     - type: Transform
       pos: 4.5,5.5
@@ -1106,29 +1208,28 @@ entities:
         stash: !type:ContainerSlot
           showEnts: False
           occludes: True
-          ent: null
+          ent: 76
         disposals: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 74
           - 75
-          - 73
+          - 74
 - proto: ToolboxElectricalTurretFilled
   entities:
-  - uid: 145
+  - uid: 146
     components:
     - type: Transform
       pos: 1.4968015,6.2584615
       parent: 1
-  - uid: 146
+  - uid: 147
     components:
     - type: Transform
       pos: 1.488989,5.8209615
       parent: 1
 - proto: VendingMachineDonut
   entities:
-  - uid: 147
+  - uid: 148
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1136,7 +1237,7 @@ entities:
       parent: 1
 - proto: VendingMachineSecUnlocked
   entities:
-  - uid: 148
+  - uid: 149
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1144,231 +1245,231 @@ entities:
       parent: 1
 - proto: WallShuttle
   entities:
-  - uid: 149
+  - uid: 150
     components:
     - type: Transform
       pos: 2.5,0.5
       parent: 1
-  - uid: 150
-    components:
-    - type: Transform
-      pos: -1.5,0.5
-      parent: 1
   - uid: 151
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,1.5
+      pos: -1.5,0.5
       parent: 1
   - uid: 152
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 2.5,2.5
+      pos: 2.5,1.5
       parent: 1
   - uid: 153
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 2.5,3.5
+      pos: 2.5,2.5
       parent: 1
   - uid: 154
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 2.5,5.5
+      pos: 2.5,3.5
       parent: 1
   - uid: 155
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 2.5,6.5
+      pos: 2.5,5.5
       parent: 1
   - uid: 156
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 2.5,7.5
+      pos: 2.5,6.5
       parent: 1
   - uid: 157
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 2.5,8.5
+      pos: 2.5,7.5
       parent: 1
   - uid: 158
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 2.5,9.5
+      pos: 2.5,8.5
       parent: 1
   - uid: 159
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -1.5,9.5
+      pos: 2.5,9.5
       parent: 1
   - uid: 160
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -1.5,8.5
+      pos: -1.5,9.5
       parent: 1
   - uid: 161
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -1.5,7.5
+      pos: -1.5,8.5
       parent: 1
   - uid: 162
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -1.5,6.5
+      pos: -1.5,7.5
       parent: 1
   - uid: 163
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -1.5,5.5
+      pos: -1.5,6.5
       parent: 1
   - uid: 164
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -1.5,3.5
+      pos: -1.5,5.5
       parent: 1
   - uid: 165
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -1.5,2.5
+      pos: -1.5,3.5
       parent: 1
   - uid: 166
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -1.5,1.5
+      pos: -1.5,2.5
       parent: 1
   - uid: 167
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -2.5,2.5
+      pos: -1.5,1.5
       parent: 1
   - uid: 168
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -3.5,2.5
+      pos: -2.5,2.5
       parent: 1
   - uid: 169
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -4.5,3.5
+      pos: -3.5,2.5
       parent: 1
   - uid: 170
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -4.5,4.5
+      pos: -4.5,3.5
       parent: 1
   - uid: 171
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -4.5,5.5
+      pos: -4.5,4.5
       parent: 1
   - uid: 172
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -3.5,6.5
+      pos: -4.5,5.5
       parent: 1
   - uid: 173
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -2.5,6.5
+      pos: -3.5,6.5
       parent: 1
   - uid: 174
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 3.5,6.5
+      pos: -2.5,6.5
       parent: 1
   - uid: 175
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 4.5,6.5
+      pos: 3.5,6.5
       parent: 1
   - uid: 176
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 4.5,2.5
+      pos: 4.5,6.5
       parent: 1
   - uid: 177
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 3.5,2.5
+      pos: 4.5,2.5
       parent: 1
   - uid: 178
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 5.5,3.5
+      pos: 3.5,2.5
       parent: 1
   - uid: 179
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 5.5,5.5
+      pos: 5.5,3.5
       parent: 1
   - uid: 180
     components:
     - type: Transform
-      pos: -0.5,8.5
+      rot: -1.5707963267948966 rad
+      pos: 5.5,5.5
       parent: 1
   - uid: 181
+    components:
+    - type: Transform
+      pos: -0.5,8.5
+      parent: 1
+  - uid: 182
     components:
     - type: Transform
       pos: 1.5,8.5
       parent: 1
 - proto: WallShuttleDiagonal
   entities:
-  - uid: 182
+  - uid: 183
     components:
     - type: Transform
       pos: -1.5,11.5
       parent: 1
-  - uid: 183
+  - uid: 184
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,11.5
       parent: 1
-  - uid: 184
+  - uid: 185
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,2.5
       parent: 1
-  - uid: 185
+  - uid: 186
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,6.5
       parent: 1
-  - uid: 186
+  - uid: 187
     components:
     - type: Transform
       pos: -4.5,6.5
       parent: 1
-  - uid: 187
+  - uid: 188
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1376,43 +1477,83 @@ entities:
       parent: 1
 - proto: WardrobePrisonFilled
   entities:
-  - uid: 188
+  - uid: 189
     components:
     - type: Transform
       anchored: True
       pos: 3.5,5.5
       parent: 1
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 190
+          - 191
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
     - type: Physics
       bodyType: Static
 - proto: WeaponCapacitorRecharger
   entities:
-  - uid: 189
+  - uid: 195
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,9.5
       parent: 1
+- proto: WeaponPistolLiberator
+  entities:
+  - uid: 204
+    components:
+    - type: Transform
+      parent: 203
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+      storage: 203
+- proto: WeaponShotgunDevastator
+  entities:
+  - uid: 205
+    components:
+    - type: Transform
+      parent: 203
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+      storage: 203
 - proto: WeaponTurretSyndicate
   entities:
-  - uid: 190
+  - uid: 196
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,7.5
       parent: 1
-  - uid: 191
+  - uid: 197
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,1.5
       parent: 1
-  - uid: 192
+  - uid: 198
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,1.5
       parent: 1
-  - uid: 193
+  - uid: 199
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1420,35 +1561,43 @@ entities:
       parent: 1
 - proto: WindoorSecureSyndicateLocked
   entities:
-  - uid: 194
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,4.5
-      parent: 1
-    - type: DeviceLinkSink
-      invokeCounter: 1
-    - type: DeviceLinkSource
-      linkedPorts:
-        195:
-        - - DoorStatus
-          - DoorBolt
-  - uid: 195
+  - uid: 200
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 1.5,4.5
+      pos: 2.5,4.5
       parent: 1
     - type: DeviceLinkSink
       invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
-        194:
+        201:
         - - DoorStatus
           - DoorBolt
-  - uid: 196
+  - uid: 201
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,4.5
+      parent: 1
+    - type: DeviceLinkSink
+      invokeCounter: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        200:
+        - - DoorStatus
+          - DoorBolt
+  - uid: 202
     components:
     - type: Transform
       pos: 0.5,1.5
       parent: 1
+- proto: Wirecutter
+  entities:
+  - uid: 193
+    components:
+    - type: Transform
+      parent: 191
+    - type: Physics
+      canCollide: False
 ...

--- a/Resources/Maps/_Trauma/Shuttles/SpacePolShuttle.yml
+++ b/Resources/Maps/_Trauma/Shuttles/SpacePolShuttle.yml
@@ -4,7 +4,7 @@ meta:
   engineVersion: 277.0.0
   forkId: ""
   forkVersion: ""
-  time: 06/17/2026 20:36:03
+  time: 06/17/2026 23:15:42
   entityCount: 205
 maps: []
 grids:
@@ -79,16 +79,16 @@ entities:
           - -1,7
           - -1,9
           - -1,10
-          - 0,2
-          - 0,6
-          - 0,1
-          - 0,3
-          - 0,4
-          - 0,7
-          - 0,5
-          - 0,8
-          - 0,10
           - 0,9
+          - 0,10
+          - 0,8
+          - 0,5
+          - 0,7
+          - 0,4
+          - 0,3
+          - 0,1
+          - 0,6
+          - 0,2
           - 1,2
           - 1,3
           - 1,10
@@ -524,7 +524,7 @@ entities:
       parent: 1
 - proto: ClosetWallOrange
   entities:
-  - uid: 203
+  - uid: 64
     components:
     - type: Transform
       pos: 4.5,6.5
@@ -543,11 +543,11 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 204
-          - 205
+          - 65
+          - 66
 - proto: ClothingBackpackSatchelSmugglerUnanchored
   entities:
-  - uid: 64
+  - uid: 67
     components:
     - type: Transform
       anchored: True
@@ -555,19 +555,19 @@ entities:
       parent: 1
     - type: Storage
       storedItems:
-        67:
+        71:
           position: 0,0
           _rotation: South
-        68:
+        72:
           position: 1,0
           _rotation: South
-        66:
+        69:
           position: 0,2
           _rotation: South
-        65:
+        68:
           position: 1,2
           _rotation: South
-        69:
+        70:
           position: 3,0
           _rotation: South
     - type: ContainerContainer
@@ -576,104 +576,104 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 67
-          - 68
-          - 66
-          - 65
+          - 71
+          - 72
           - 69
+          - 68
+          - 70
     - type: Physics
       canCollide: False
       bodyType: Static
 - proto: ClothingHandsGlovesColorYellow
   entities:
-  - uid: 192
+  - uid: 75
     components:
     - type: Transform
-      parent: 191
+      parent: 74
     - type: Physics
       canCollide: False
 - proto: ClothingOuterWinterColorOrange
   entities:
-  - uid: 190
+  - uid: 74
     components:
     - type: Transform
-      parent: 189
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-      storage: 189
-  - uid: 191
-    components:
-    - type: Transform
-      parent: 189
+      parent: 73
     - type: ContainerContainer
       containers:
         storagebase: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 192
-          - 193
-          - 194
+          - 75
+          - 77
+          - 76
         toggleable-clothing: !type:Container
           showEnts: False
           occludes: True
           ents: []
     - type: Storage
       storedItems:
-        192:
+        75:
           position: 0,0
           _rotation: South
-        193:
+        77:
           position: 1,0
           _rotation: South
-        194:
+        76:
           position: 2,0
           _rotation: South
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-      storage: 189
+      storage: 73
+  - uid: 78
+    components:
+    - type: Transform
+      parent: 73
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+      storage: 73
 - proto: ComputerComms
   entities:
-  - uid: 70
+  - uid: 79
     components:
     - type: Transform
       pos: -0.5,10.5
       parent: 1
 - proto: ComputerIFFSyndicate
   entities:
-  - uid: 71
+  - uid: 80
     components:
     - type: Transform
       pos: 1.5,10.5
       parent: 1
 - proto: ComputerShuttle
   entities:
-  - uid: 72
+  - uid: 81
     components:
     - type: Transform
       pos: 0.5,10.5
       parent: 1
 - proto: CrowbarRed
   entities:
-  - uid: 75
+  - uid: 85
     components:
     - type: Transform
-      parent: 73
+      parent: 82
     - type: Physics
       canCollide: False
 - proto: CyberPen
   entities:
-  - uid: 76
+  - uid: 83
     components:
     - type: Transform
-      parent: 73
+      parent: 82
     - type: Physics
       canCollide: False
 - proto: GasPipeBend
   entities:
-  - uid: 77
+  - uid: 86
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -681,31 +681,31 @@ entities:
       parent: 1
 - proto: GasPipeStraight
   entities:
-  - uid: 78
+  - uid: 87
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,4.5
       parent: 1
-  - uid: 79
+  - uid: 88
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,4.5
       parent: 1
-  - uid: 80
+  - uid: 89
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,4.5
       parent: 1
-  - uid: 81
+  - uid: 90
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,4.5
       parent: 1
-  - uid: 82
+  - uid: 91
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -713,14 +713,14 @@ entities:
       parent: 1
 - proto: GasPipeTJunction
   entities:
-  - uid: 83
+  - uid: 92
     components:
     - type: Transform
       pos: 0.5,4.5
       parent: 1
 - proto: GasPort
   entities:
-  - uid: 84
+  - uid: 93
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -728,32 +728,32 @@ entities:
       parent: 1
 - proto: GasVentPump
   entities:
-  - uid: 85
+  - uid: 94
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,3.5
       parent: 1
-  - uid: 86
+  - uid: 95
     components:
     - type: Transform
       pos: 3.5,5.5
       parent: 1
 - proto: GeneratorBasic15kW
   entities:
-  - uid: 87
+  - uid: 96
     components:
     - type: Transform
       pos: -2.5,3.5
       parent: 1
-  - uid: 88
+  - uid: 97
     components:
     - type: Transform
       pos: -2.5,5.5
       parent: 1
 - proto: GhostWarpPoint
   entities:
-  - uid: 89
+  - uid: 98
     components:
     - type: MetaData
       name: Fugitive Hunter Shuttle
@@ -763,54 +763,54 @@ entities:
       parent: 1
 - proto: GravityGeneratorMini
   entities:
-  - uid: 90
+  - uid: 99
     components:
     - type: Transform
       pos: -3.5,3.5
       parent: 1
 - proto: Grille
   entities:
-  - uid: 91
+  - uid: 100
     components:
     - type: Transform
       pos: -0.5,0.5
       parent: 1
-  - uid: 92
+  - uid: 101
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,10.5
       parent: 1
-  - uid: 93
+  - uid: 102
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,10.5
       parent: 1
-  - uid: 94
+  - uid: 103
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,4.5
       parent: 1
-  - uid: 95
+  - uid: 104
     components:
     - type: Transform
       pos: 1.5,0.5
       parent: 1
-  - uid: 96
+  - uid: 105
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,11.5
       parent: 1
-  - uid: 97
+  - uid: 106
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,11.5
       parent: 1
-  - uid: 98
+  - uid: 107
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -818,7 +818,7 @@ entities:
       parent: 1
 - proto: GunSafeHunter
   entities:
-  - uid: 99
+  - uid: 108
     components:
     - type: Transform
       anchored: True
@@ -828,7 +828,7 @@ entities:
       bodyType: Static
 - proto: Gyroscope
   entities:
-  - uid: 100
+  - uid: 109
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -836,47 +836,47 @@ entities:
       parent: 1
 - proto: LubeGrenade
   entities:
-  - uid: 65
+  - uid: 68
     components:
     - type: Transform
-      parent: 64
+      parent: 67
     - type: Physics
       canCollide: False
 - proto: MedkitBruteFilled
   entities:
-  - uid: 101
+  - uid: 110
     components:
     - type: Transform
       pos: 1.504614,7.6959615
       parent: 1
 - proto: MedkitBurnFilled
   entities:
-  - uid: 102
+  - uid: 111
     components:
     - type: Transform
       pos: 1.520239,7.266274
       parent: 1
 - proto: MedkitFilled
   entities:
-  - uid: 103
+  - uid: 112
     components:
     - type: Transform
       pos: 1.535864,6.8209615
       parent: 1
 - proto: Multitool
   entities:
-  - uid: 194
+  - uid: 76
     components:
     - type: Transform
-      parent: 191
+      parent: 74
     - type: Physics
       canCollide: False
 - proto: PaperOffice
   entities:
-  - uid: 74
+  - uid: 84
     components:
     - type: Transform
-      parent: 73
+      parent: 82
     - type: Paper
       content: >2-
 
@@ -885,59 +885,59 @@ entities:
       canCollide: False
 - proto: PosterContrabandBountyHunters
   entities:
-  - uid: 104
+  - uid: 113
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 1
 - proto: PosterContrabandSyndicateRecruitment
   entities:
-  - uid: 105
+  - uid: 114
     components:
     - type: Transform
       pos: 2.5,2.5
       parent: 1
 - proto: PosterLegitNanotrasenLogo
   entities:
-  - uid: 106
+  - uid: 115
     components:
     - type: Transform
       pos: -1.5,9.5
       parent: 1
 - proto: PosterLegitObey
   entities:
-  - uid: 107
+  - uid: 116
     components:
     - type: Transform
       pos: 4.5,6.5
       parent: 1
 - proto: Poweredlight
   entities:
-  - uid: 108
+  - uid: 117
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,6.5
       parent: 1
-  - uid: 109
+  - uid: 118
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,9.5
       parent: 1
-  - uid: 110
+  - uid: 119
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,2.5
       parent: 1
-  - uid: 111
+  - uid: 120
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,4.5
       parent: 1
-  - uid: 112
+  - uid: 121
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -945,87 +945,87 @@ entities:
       parent: 1
 - proto: ShuttersNormal
   entities:
-  - uid: 113
+  - uid: 122
     components:
     - type: Transform
       pos: -1.5,10.5
       parent: 1
-  - uid: 114
+  - uid: 123
     components:
     - type: Transform
       pos: -0.5,11.5
       parent: 1
-  - uid: 115
+  - uid: 124
     components:
     - type: Transform
       pos: 0.5,11.5
       parent: 1
-  - uid: 116
+  - uid: 125
     components:
     - type: Transform
       pos: 1.5,11.5
       parent: 1
-  - uid: 117
+  - uid: 126
     components:
     - type: Transform
       pos: 2.5,10.5
       parent: 1
-  - uid: 118
+  - uid: 127
     components:
     - type: Transform
       pos: 5.5,4.5
       parent: 1
 - proto: ShuttleWindow
   entities:
-  - uid: 119
+  - uid: 128
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,10.5
       parent: 1
-  - uid: 120
+  - uid: 129
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,11.5
       parent: 1
-  - uid: 121
+  - uid: 130
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,10.5
       parent: 1
-  - uid: 122
+  - uid: 131
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,11.5
       parent: 1
-  - uid: 123
+  - uid: 132
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,11.5
       parent: 1
-  - uid: 124
+  - uid: 133
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,4.5
       parent: 1
-  - uid: 125
+  - uid: 134
     components:
     - type: Transform
       pos: -0.5,0.5
       parent: 1
-  - uid: 126
+  - uid: 135
     components:
     - type: Transform
       pos: 1.5,0.5
       parent: 1
 - proto: SignalButton
   entities:
-  - uid: 127
+  - uid: 136
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1033,42 +1033,42 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        113:
+        122:
         - - Pressed
           - Toggle
-        114:
+        123:
         - - Pressed
           - Toggle
-        115:
+        124:
         - - Pressed
           - Toggle
-        116:
+        125:
         - - Pressed
           - Toggle
-        117:
+        126:
         - - Pressed
           - Toggle
-        118:
+        127:
         - - Pressed
           - Toggle
 - proto: SmokeGrenade
   entities:
-  - uid: 66
+  - uid: 69
     components:
     - type: Transform
-      parent: 64
+      parent: 67
     - type: Physics
       canCollide: False
 - proto: SpawnPointNukies
   entities:
-  - uid: 128
+  - uid: 137
     components:
     - type: Transform
       pos: 0.5,4.5
       parent: 1
 - proto: SubstationWallBasic
   entities:
-  - uid: 129
+  - uid: 138
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1076,25 +1076,25 @@ entities:
       parent: 1
 - proto: TableReinforced
   entities:
-  - uid: 130
+  - uid: 139
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,9.5
       parent: 1
-  - uid: 131
+  - uid: 140
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,7.5
       parent: 1
-  - uid: 132
+  - uid: 141
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,6.5
       parent: 1
-  - uid: 133
+  - uid: 142
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1102,99 +1102,99 @@ entities:
       parent: 1
 - proto: Telecrystal25
   entities:
-  - uid: 69
+  - uid: 70
     components:
     - type: Transform
-      parent: 64
+      parent: 67
     - type: Physics
       canCollide: False
 - proto: ThrowingKnife
   entities:
-  - uid: 67
+  - uid: 71
     components:
     - type: Transform
-      parent: 64
+      parent: 67
     - type: Physics
       canCollide: False
-  - uid: 68
+  - uid: 72
     components:
     - type: Transform
-      parent: 64
+      parent: 67
     - type: Physics
       canCollide: False
 - proto: Thruster
   entities:
-  - uid: 134
+  - uid: 143
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,1.5
       parent: 1
-  - uid: 135
+  - uid: 144
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,1.5
       parent: 1
-  - uid: 136
+  - uid: 145
     components:
     - type: Transform
       pos: 4.5,7.5
       parent: 1
-  - uid: 137
+  - uid: 146
     components:
     - type: Transform
       pos: 3.5,7.5
       parent: 1
-  - uid: 138
+  - uid: 147
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,1.5
       parent: 1
-  - uid: 139
+  - uid: 148
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,1.5
       parent: 1
-  - uid: 140
+  - uid: 149
     components:
     - type: Transform
       pos: -3.5,7.5
       parent: 1
-  - uid: 141
+  - uid: 150
     components:
     - type: Transform
       pos: -2.5,7.5
       parent: 1
-  - uid: 142
+  - uid: 151
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,9.5
       parent: 1
-  - uid: 143
+  - uid: 152
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,8.5
       parent: 1
-  - uid: 144
+  - uid: 153
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,8.5
       parent: 1
-  - uid: 145
+  - uid: 154
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,9.5
       parent: 1
-- proto: ToiletDirtyWaterFilled
+- proto: ToiletEmpty
   entities:
-  - uid: 73
+  - uid: 82
     components:
     - type: Transform
       pos: 4.5,5.5
@@ -1206,28 +1206,32 @@ entities:
         stash: !type:ContainerSlot
           showEnts: False
           occludes: True
-          ent: 76
+          ent: 83
         disposals: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 75
-          - 74
+          - 84
+          - 85
+        solutions: !type:Container
+          showEnts: False
+          occludes: True
+          ents: []
 - proto: ToolboxElectricalTurretFilled
   entities:
-  - uid: 146
+  - uid: 155
     components:
     - type: Transform
       pos: 1.4968015,6.2584615
       parent: 1
-  - uid: 147
+  - uid: 156
     components:
     - type: Transform
       pos: 1.488989,5.8209615
       parent: 1
 - proto: VendingMachineDonut
   entities:
-  - uid: 148
+  - uid: 157
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1235,7 +1239,7 @@ entities:
       parent: 1
 - proto: VendingMachineSecUnlocked
   entities:
-  - uid: 149
+  - uid: 158
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1243,231 +1247,231 @@ entities:
       parent: 1
 - proto: WallShuttle
   entities:
-  - uid: 150
+  - uid: 159
     components:
     - type: Transform
       pos: 2.5,0.5
       parent: 1
-  - uid: 151
-    components:
-    - type: Transform
-      pos: -1.5,0.5
-      parent: 1
-  - uid: 152
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,1.5
-      parent: 1
-  - uid: 153
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,2.5
-      parent: 1
-  - uid: 154
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,3.5
-      parent: 1
-  - uid: 155
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,5.5
-      parent: 1
-  - uid: 156
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,6.5
-      parent: 1
-  - uid: 157
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,7.5
-      parent: 1
-  - uid: 158
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,8.5
-      parent: 1
-  - uid: 159
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,9.5
-      parent: 1
   - uid: 160
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,9.5
+      pos: -1.5,0.5
       parent: 1
   - uid: 161
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -1.5,8.5
+      pos: 2.5,1.5
       parent: 1
   - uid: 162
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -1.5,7.5
+      pos: 2.5,2.5
       parent: 1
   - uid: 163
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -1.5,6.5
+      pos: 2.5,3.5
       parent: 1
   - uid: 164
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -1.5,5.5
+      pos: 2.5,5.5
       parent: 1
   - uid: 165
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -1.5,3.5
+      pos: 2.5,6.5
       parent: 1
   - uid: 166
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -1.5,2.5
+      pos: 2.5,7.5
       parent: 1
   - uid: 167
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -1.5,1.5
+      pos: 2.5,8.5
       parent: 1
   - uid: 168
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -2.5,2.5
+      pos: 2.5,9.5
       parent: 1
   - uid: 169
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -3.5,2.5
+      pos: -1.5,9.5
       parent: 1
   - uid: 170
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -4.5,3.5
+      pos: -1.5,8.5
       parent: 1
   - uid: 171
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -4.5,4.5
+      pos: -1.5,7.5
       parent: 1
   - uid: 172
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -4.5,5.5
+      pos: -1.5,6.5
       parent: 1
   - uid: 173
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -3.5,6.5
+      pos: -1.5,5.5
       parent: 1
   - uid: 174
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -2.5,6.5
+      pos: -1.5,3.5
       parent: 1
   - uid: 175
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 3.5,6.5
+      pos: -1.5,2.5
       parent: 1
   - uid: 176
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 4.5,6.5
+      pos: -1.5,1.5
       parent: 1
   - uid: 177
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 4.5,2.5
+      pos: -2.5,2.5
       parent: 1
   - uid: 178
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 3.5,2.5
+      pos: -3.5,2.5
       parent: 1
   - uid: 179
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 5.5,3.5
+      pos: -4.5,3.5
       parent: 1
   - uid: 180
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 5.5,5.5
+      pos: -4.5,4.5
       parent: 1
   - uid: 181
     components:
     - type: Transform
-      pos: -0.5,8.5
+      rot: -1.5707963267948966 rad
+      pos: -4.5,5.5
       parent: 1
   - uid: 182
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,6.5
+      parent: 1
+  - uid: 183
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,6.5
+      parent: 1
+  - uid: 184
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,6.5
+      parent: 1
+  - uid: 185
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,6.5
+      parent: 1
+  - uid: 186
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,2.5
+      parent: 1
+  - uid: 187
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 188
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,3.5
+      parent: 1
+  - uid: 189
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,5.5
+      parent: 1
+  - uid: 190
+    components:
+    - type: Transform
+      pos: -0.5,8.5
+      parent: 1
+  - uid: 191
     components:
     - type: Transform
       pos: 1.5,8.5
       parent: 1
 - proto: WallShuttleDiagonal
   entities:
-  - uid: 183
+  - uid: 192
     components:
     - type: Transform
       pos: -1.5,11.5
       parent: 1
-  - uid: 184
+  - uid: 193
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,11.5
       parent: 1
-  - uid: 185
+  - uid: 194
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,2.5
       parent: 1
-  - uid: 186
+  - uid: 195
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,6.5
       parent: 1
-  - uid: 187
+  - uid: 196
     components:
     - type: Transform
       pos: -4.5,6.5
       parent: 1
-  - uid: 188
+  - uid: 197
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1475,7 +1479,7 @@ entities:
       parent: 1
 - proto: WardrobePrisonFilled
   entities:
-  - uid: 189
+  - uid: 73
     components:
     - type: Transform
       anchored: True
@@ -1495,8 +1499,8 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 190
-          - 191
+          - 78
+          - 74
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -1505,7 +1509,7 @@ entities:
       bodyType: Static
 - proto: WeaponCapacitorRecharger
   entities:
-  - uid: 195
+  - uid: 198
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1513,45 +1517,45 @@ entities:
       parent: 1
 - proto: WeaponPistolLiberator
   entities:
-  - uid: 204
+  - uid: 65
     components:
     - type: Transform
-      parent: 203
+      parent: 64
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-      storage: 203
+      storage: 64
 - proto: WeaponShotgunDevastator
   entities:
-  - uid: 205
+  - uid: 66
     components:
     - type: Transform
-      parent: 203
+      parent: 64
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-      storage: 203
+      storage: 64
 - proto: WeaponTurretSyndicate
   entities:
-  - uid: 196
+  - uid: 199
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,7.5
       parent: 1
-  - uid: 197
+  - uid: 200
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,1.5
       parent: 1
-  - uid: 198
+  - uid: 201
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,1.5
       parent: 1
-  - uid: 199
+  - uid: 202
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1559,7 +1563,7 @@ entities:
       parent: 1
 - proto: WindoorSecureSyndicateLocked
   entities:
-  - uid: 200
+  - uid: 203
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1569,10 +1573,10 @@ entities:
       invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
-        201:
+        204:
         - - DoorStatus
           - DoorBolt
-  - uid: 201
+  - uid: 204
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1582,20 +1586,20 @@ entities:
       invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
-        200:
+        203:
         - - DoorStatus
           - DoorBolt
-  - uid: 202
+  - uid: 205
     components:
     - type: Transform
       pos: 0.5,1.5
       parent: 1
 - proto: Wirecutter
   entities:
-  - uid: 193
+  - uid: 77
     components:
     - type: Transform
-      parent: 191
+      parent: 74
     - type: Physics
       canCollide: False
 ...

--- a/Resources/Maps/_Trauma/Shuttles/SpacePolShuttle.yml
+++ b/Resources/Maps/_Trauma/Shuttles/SpacePolShuttle.yml
@@ -26,8 +26,6 @@ entities:
     components:
     - type: MetaData
       name: grid
-    - type: Transform
-      parent: invalid
     - type: MapGrid
       chunks:
         0,0:

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -50,9 +50,6 @@ BoxMagazineMagnumSubMachineGun: BoxMagazineRifle
 # 2025-01-01 Trauma Remove scurret poster
 PosterLegitHelio: null
 
-# 2026-01-05 Actually use the ToiletCisternLoot table.
-ToiletEmpty: ToiletFilled
-
 # 2026-01-07
 GunSafeDisabler: GunSafePhaser
 WeaponDisabler: WeaponLaserSidearm


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
Modify the SpacePolShuttle now that windoors aren't cancer

## Why / Balance
Looks better

## Test plan
run the FugitiveHunterSpawn gamerule and see the shuttle

## Media
it's literally just a few minor things and made the airlock smaller

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Changelog

:cl: TechnicFighter

- tweak: Changed the SpacePolShuttle, now the airlock isn't trash
