### PR TITLE
fix construction mats duping

### DIFF
--- a/Content.Server/Construction/ConstructionSystem.Initial.cs
+++ b/Content.Server/Construction/ConstructionSystem.Initial.cs
@@ -93,7 +93,7 @@ namespace Content.Server.Construction
 
             var pos = _transformSystem.GetMapCoordinates(user);
 
-            foreach (var near in _lookupSystem.GetEntitiesInRange(pos, 2f, LookupFlags.Contained | LookupFlags.Dynamic | LookupFlags.Sundries | LookupFlags.Approximate))
+            foreach (var near in _lookupSystem.GetEntitiesInRange(pos, 2f, LookupFlags.Dynamic | LookupFlags.Sundries | LookupFlags.Approximate)) // Trauma - removed Contained
             {
                 if (near == user)
                     continue;


### PR DESCRIPTION
fixes #3232

it was including shit like:
- your organs
- your implants
- construction item container, which allowed duping

now itll only include items on the floor, not inside bags on the floor etc

your bag is already checked so who cares

:cl:
- fix: Fixed mrbeast infinite steel giveaway with construction.