### PR TITLE
Make Baseball bat smaller

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/baseball_bat.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/baseball_bat.yml
@@ -27,9 +27,10 @@
     distance: 1
     speed: 5
   - type: Item
-    size: Large # Goob - was Normal
+    size: Normal
     shape:
-    - 0,0,1,3 # Goob - 2x4 instead of 1x4
+    - 0,0,3,0
+    storedRotation: 90 # Trauma
     storedSprite:
       state: storage
       sprite: Objects/Weapons/Melee/baseball_bat.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/baseball_bat.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/baseball_bat.yml
@@ -29,7 +29,7 @@
   - type: Item
     size: Normal
     shape:
-    - 0,0,3,0
+    - 0,0,0,3
     storedRotation: 90 # Trauma
     storedSprite:
       state: storage

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/baseball_bat.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/baseball_bat.yml
@@ -30,7 +30,6 @@
     size: Normal
     shape:
     - 0,0,0,3
-    storedRotation: 90 # Trauma
     storedSprite:
       state: storage
       sprite: Objects/Weapons/Melee/baseball_bat.rsi


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
Make Baseball bat smaller, 1x4 instead of 2x4

## Why / Balance
putting it in line with the other bats/batons

## Test plan
put a bat in your inventory

## Media
n/a

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Changelog

:cl: TechnicFighter

- tweak: Tweaked the Baseball Bat, it is now 1x4, and normal size.