### PR TITLE
prevent locker mimic deconstruction

### DIFF
--- a/Resources/Prototypes/_Trauma/Entities/Mobs/NPCs/mimics.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Mobs/NPCs/mimics.yml
@@ -205,6 +205,7 @@
   description: It's a storage unit. Why is it breathing?
   components:
   - type: TriggerOnActivate
+  - type: TriggerOnInteractUsing
   - type: TriggerOnDamage
     threshold: 0
     probability: 0.5


### PR DESCRIPTION
if you try use an item on a hidden locker mimic it activates

fixes #3262 

:cl:
- fix: Fixed being able to instantly kill locker mimics with a screwdriver.