### PR TITLE
change forged katana to have more damage than wound severity

### DIFF
--- a/Resources/Prototypes/_Trauma/Entities/Objects/Specific/Forging/crafts.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Objects/Specific/Forging/crafts.yml
@@ -307,9 +307,9 @@
     #armorPenetration: -0.7 # Currently not working
     damage:
       types:
-        Slash: 5
+        Slash: 15
       woundSeverityMultipliers:
-        Slash: 5
+        Slash: 2
     soundHit:
       path: /Audio/Weapons/bladeslice.ogg
   - type: Tag


### PR DESCRIPTION
base damage/mul is now 15/2 from 5/5
its now more like ninja katana of 20/2

masterwork plasteel katana beheaded a standing urist in 7 hits with no melee skill

## Media

<img width="390" height="97" alt="01:36:44" src="https://github.com/user-attachments/assets/d12fa1f6-e622-46f2-853a-0259bfb82966" />

## Changelog
:cl:
- tweak: Changed forged katanas to have higher base damage and less wound multipliers.