### PR TITLE
buff botany produce 5x and let it be recycled

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -198,6 +198,11 @@
   name: tower-cap log
   description: It's better than bad, it's good!
   components:
+  # <Trauma>
+  - type: PhysicalComposition
+    materialComposition:
+      Wood: 500
+  # </Trauma>
   - type: Sprite
     sprite: Objects/Specific/Hydroponics/towercap.rsi
   - type: Item
@@ -209,6 +214,7 @@
   - type: Produce
     seedId: towercap
   - type: Log
+    spawnCount: 5 # Trauma
 
 - type: entity
   parent: ProduceBase
@@ -216,6 +222,11 @@
   name: steel-cap log
   description: Steel doesn't grow on trees! It grows on mushrooms, of course.
   components:
+  # <Trauma>
+  - type: PhysicalComposition
+    materialComposition:
+      Steel: 500 # 5 sheets
+  # </Trauma>
   - type: Sprite
     sprite: Objects/Specific/Hydroponics/steelcap.rsi
   - type: Item
@@ -228,7 +239,7 @@
     seedId: steelcap
   - type: Log
     spawnedPrototype: SheetSteel1
-    spawnCount: 1
+    spawnCount: 5 # Trauma - 5x, steel costs are so hyperinflated
 
 - type: entity
   parent: ProduceBaseRuminant
@@ -1792,6 +1803,11 @@
   id: FoodGlasstle
   description: A fragile crystal plant with lot of spiky thorns.
   components:
+  # <Trauma>
+  - type: PhysicalComposition
+    materialComposition:
+      Glass: 500 # 5 sheets, same as from welding it
+  # </Trauma>
   - type: Item
     size: Small
     sprite: Objects/Specific/Hydroponics/glasstle.rsi
@@ -1817,7 +1833,7 @@
     damageContainer: Inorganic
   - type: ToolRefinable
     refineResult:
-    - id: SheetGlass1
+    - id: SheetGlass5 # Trauma - 5x so its not a total waste of time making it
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -202,6 +202,8 @@
   - type: PhysicalComposition
     materialComposition:
       Wood: 500
+  - type: StaticPrice
+    price: 50
   # </Trauma>
   - type: Sprite
     sprite: Objects/Specific/Hydroponics/towercap.rsi
@@ -226,6 +228,8 @@
   - type: PhysicalComposition
     materialComposition:
       Steel: 500 # 5 sheets
+  - type: StaticPrice
+    price: 75
   # </Trauma>
   - type: Sprite
     sprite: Objects/Specific/Hydroponics/steelcap.rsi

--- a/Resources/Prototypes/_Trauma/Entities/Objects/Materials/Sheets/glass.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Objects/Materials/Sheets/glass.yml
@@ -9,3 +9,13 @@
     state: glass_2
   - type: Stack
     count: 15
+
+- type: entity
+  parent: SheetGlass
+  id: SheetGlass5
+  suffix: 5
+  components:
+  - type: Sprite
+    state: glass_1
+  - type: Stack
+    count: 5


### PR DESCRIPTION
its such a waste of time right now it cant even compare to cargo *ordering mats*, let alone salv mining, even if you max out its yield

:cl:
- tweak: Buffed towercap, steelcap and glasstle. They give 5x as much and can be thrown into a recycler.