### PR TITLE
tweaked xenomorph shove stun

### DIFF
--- a/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/base.yml
+++ b/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/base.yml
@@ -214,7 +214,7 @@
     - FootstepSound
   - type: XenomorphShoveTracker
     shoveThreshold: 1
-    duration: 3
+    knockdownDuration: 3
   - type: MovementAlwaysTouching # Trauma
 
 - type: entity

--- a/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/base.yml
+++ b/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/base.yml
@@ -213,6 +213,8 @@
     - DoorBumpOpener
     - FootstepSound
   - type: XenomorphShoveTracker
+    shoveThreshold: 1
+    duration: 3
   - type: MovementAlwaysTouching # Trauma
 
 - type: entity


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->
it now stuns in one hit but the stun only lasts 3 seconds
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
i never see the shove stun used, people prefer to crit instead of stun as its only one hit extra most of the time and they dont have to deal with restunning the person over and over
## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [ ] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [ ] I have tested this pull request and written instructions on how to test it
- [ ] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
--> 🆑 assripper.

 - tweak: xenomorphs shove stun has been tweaked to stun in one hit, but the stun only lasts for 3 seconds
