### PR TITLE
make oreproc feed master silo

### DIFF
--- a/Content.Server/Lathe/LatheSystem.cs
+++ b/Content.Server/Lathe/LatheSystem.cs
@@ -246,22 +246,12 @@ namespace Content.Server.Lathe
                 var currentRecipe = _proto.Index(comp.CurrentRecipe.Value);
                 if (currentRecipe.Result is { } resultProto)
                 {
-                    // <Goob> - try output to material storage instead of spawning
-                    var prototype = _proto.Index(resultProto);
-                    if (comp.OutputToStorage && prototype.TryGetComponent<PhysicalCompositionComponent>(out var composition, Factory))
-                    {
-                        _materialStorage.TryChangeMaterialAmount(uid, composition.MaterialComposition);
-                    }
-                    else
-                    {
-                        var result = Spawn(resultProto, Transform(uid).Coordinates);
-                        _stack.TryMergeToContacts(result);
-                        // <Trauma>
-                        var ev = new ProducedByLatheEvent();
-                        RaiseLocalEvent(result, ref ev);
-                        // </Trauma>
-                    }
-                    // </Goob>
+                    var result = Spawn(resultProto, Transform(uid).Coordinates);
+                    _stack.TryMergeToContacts(result);
+                    // <Trauma>
+                    var ev = new ProducedByLatheEvent();
+                    RaiseLocalEvent(result, ref ev);
+                    // </Trauma>
                 }
 
                 if (currentRecipe.ResultReagents is { } resultReagents &&

--- a/Content.Shared/Lathe/LatheComponent.Trauma.cs
+++ b/Content.Shared/Lathe/LatheComponent.Trauma.cs
@@ -8,13 +8,6 @@ namespace Content.Shared.Lathe;
 public sealed partial class LatheComponent
 {
     /// <summary>
-    /// Output to MaterialStorage instead of spawning it.
-    /// Used by ore processors.
-    /// </summary>
-    [DataField]
-    public bool OutputToStorage;
-
-    /// <summary>
     /// The producing sound entity being played.
     /// Used to stop it when producing stops.
     /// </summary>

--- a/Content.Shared/Materials/SharedMaterialStorageSystem.cs
+++ b/Content.Shared/Materials/SharedMaterialStorageSystem.cs
@@ -1,3 +1,6 @@
+// <Trauma>
+using Content.Trauma.Common.Materials;
+// </Trauma>
 using System.Linq;
 using Content.Shared.Interaction;
 using Content.Shared.Interaction.Components;
@@ -342,6 +345,13 @@ public abstract partial class SharedMaterialStorageSystem : EntitySystem
 
         if (!Resolve(toInsert, ref material, ref composition, false))
             return false;
+
+        // <Trauma>
+        var attemptEv = new MaterialStorageInsertAttemptEvent(toInsert, user);
+        RaiseLocalEvent(receiver, ref attemptEv);
+        if (attemptEv.Handled)
+            return !attemptEv.Cancelled;
+        // </Trauma>
 
         if (_whitelistSystem.IsWhitelistFail(storage.Whitelist, toInsert))
             return false;

--- a/Content.Trauma.Common/Materials/MaterialStorageInsertAttemptEvent.cs
+++ b/Content.Trauma.Common/Materials/MaterialStorageInsertAttemptEvent.cs
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Content.Trauma.Common.Materials;
+
+/// <summary>
+/// Raised on a material storage to allow preventing inserting a material item into it.
+/// Handling this event prevents regular insertion logic, cancelled indicates that inserting failed instead of being handled specially.
+/// </summary>
+[ByRefEvent]
+public record struct MaterialStorageInsertAttemptEvent(EntityUid Item, EntityUid User, bool Handled = false, bool Cancelled = false);

--- a/Content.Trauma.Shared/Materials/MasterSiloFeederComponent.cs
+++ b/Content.Trauma.Shared/Materials/MasterSiloFeederComponent.cs
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Content.Trauma.Shared.Materials;
+
+/// <summary>
+/// Tries to distribute inserted materials with the first powered master silo on the same grid as this material storage.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class MasterSiloFeederComponent : Component;

--- a/Content.Trauma.Shared/Materials/MasterSiloSystem.cs
+++ b/Content.Trauma.Shared/Materials/MasterSiloSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.Popups;
 using Content.Shared.Power.EntitySystems;
 using Content.Shared.Stacks;
 using Content.Shared.Whitelist;
+using Content.Trauma.Common.Materials;
 
 namespace Content.Trauma.Shared.Materials;
 
@@ -26,37 +27,58 @@ public sealed partial class MasterSiloSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<MasterSiloComponent, InteractUsingEvent>(OnInteractUsing);
+
+        SubscribeLocalEvent<MasterSiloFeederComponent, MaterialStorageInsertAttemptEvent>(OnFeedAttempt);
     }
 
     private void OnInteractUsing(Entity<MasterSiloComponent> ent, ref InteractUsingEvent args)
     {
-        if (args.Handled)
+        if (args.Handled || !SiloAccepts(ent.Comp, args.Used))
             return;
 
-        var user = args.User;
-        var item = args.Used;
+        args.Handled = TryDistribute(ent, args.Used, args.User);
+    }
+
+    private void OnFeedAttempt(Entity<MasterSiloFeederComponent> ent, ref MaterialStorageInsertAttemptEvent args)
+    {
+        var item = args.Item;
+        if (args.Handled ||
+            Transform(ent).GridUid is not { } grid)
+            return;
+
+        args.Handled = FindValidMasterSilo(grid, item) is { } silo &&
+            SiloAccepts(silo.Comp, item) &&
+            TryDistribute(silo, item, args.User);
+    }
+
+    public bool SiloAccepts(MasterSiloComponent comp, EntityUid item)
+        => _whitelist.CheckBoth(item, comp.Blacklist, comp.Whitelist);
+
+    /// <summary>
+    /// Try to distribute a material item to master silo clients, turning true if it was consumed and distributed.
+    /// </summary>
+    public bool TryDistribute(Entity<MasterSiloComponent> ent, EntityUid item, EntityUid user)
+    {
         if (TerminatingOrDeleted(item) ||
-            !_compositionQuery.TryComp(item, out var composition) ||
-            !_whitelist.CheckBoth(item, ent.Comp.Blacklist, ent.Comp.Whitelist))
-            return;
+            !_compositionQuery.TryComp(item, out var composition))
+            return false;
 
-        args.Handled = true;
         if (!_power.IsPowered(ent.Owner))
         {
             _popup.PopupClient("It isn't powered!", ent, user);
-            return;
+            return false;
         }
 
         if (_net.IsClient)
-            return; // client wont have every silo in pvs range
+            return true; // client wont have every silo in pvs range, but assume it succeeded
 
         if (Transform(ent).GridUid is not { } grid)
-            return; // should always exist if powered...
+            return false; // should always exist if powered...
 
         if (!FindSilosAccepting(grid, (item, composition)))
         {
             _popup.PopupEntity("No powered silos on station!", ent, user);
-            return;
+            return false;
         }
 
         var multiplier = _stackQuery.CompOrNull(item)?.Count ?? 1;
@@ -79,6 +101,19 @@ public sealed partial class MasterSiloSystem : EntitySystem
             }
         }
         _popup.PopupEntity($"Distributed {multiplier} {Name(item)} between {count} material silos", ent, user);
+        return true;
+    }
+
+    private Entity<MasterSiloComponent>? FindValidMasterSilo(EntityUid grid, EntityUid item)
+    {
+        var query = EntityQueryEnumerator<MasterSiloComponent, TransformComponent>();
+        while (query.MoveNext(out var uid, out var comp, out var xform))
+        {
+            if (xform.GridUid == grid && _power.IsPowered(uid) && SiloAccepts(comp, item))
+                return (uid, comp);
+        }
+
+        return null;
     }
 
     private bool FindSilosAccepting(EntityUid grid, Entity<PhysicalCompositionComponent> item)

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -744,6 +744,7 @@
     - type: MiningPoints
     - type: MiningPointsLathe
     - type: MaterialStorageMagnetPickup
+      magnetEnabled: true
     - type: MasterSiloFeeder # shitsalv 1984
     # </Trauma>
     - type: Sprite

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -776,7 +776,6 @@
       idleState: icon
       runningState: building
       defaultProductionAmount: 10
-      outputToStorage: true # Goob edit
       staticPacks:
       - OreSmelting
       - RGlassSmelting

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -740,6 +740,12 @@
   name: ore processor
   description: It produces sheets and ingots using ores.
   components:
+    # <Trauma>
+    - type: MiningPoints
+    - type: MiningPointsLathe
+    - type: MaterialStorageMagnetPickup
+    - type: MasterSiloFeeder # shitsalv 1984
+    # </Trauma>
     - type: Sprite
       sprite: Structures/Machines/ore_processor.rsi
       layers:
@@ -774,9 +780,6 @@
       staticPacks:
       - OreSmelting
       - RGlassSmelting
-    - type: MiningPoints # DeltaV - Source of mining points for miners
-    - type: MiningPointsLathe # DeltaV
-    - type: MaterialStorageMagnetPickup # Frontier
 
 - type: entity
   parent: OreProcessor


### PR DESCRIPTION
resolves #3304

it now automatically sends valid materials for master silo (not ore)
should predict fine since usually its very close to the master silo

:cl:
- tweak: Ore processors now distribute materials through the master silo automatically.