### PR TITLE
nerf grille health

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Walls/grille.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/grille.yml
@@ -74,7 +74,7 @@
               acts: ["Destruction"]
         - trigger:
             !type:DamageTrigger
-            damage: 100
+            damage: 30 # Trauma - was 100, way too tanky (window has 50 hp lol)
           behaviors:
             - !type:ChangeConstructionNodeBehavior
               node: grilleBroken


### PR DESCRIPTION
100 to 30
for reference window was only 50 hp, 2 fucking rods shouldnt be stronger than it, its a flimsy mesh

:cl:
- tweak: Nerfed grilles health to 30, down from 100.