### PR TITLE
split spider melee damage into slash to let them break grilles

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -2836,7 +2836,10 @@
       path: /Audio/Effects/bite.ogg
     damage:
       types:
-        Piercing: 6
+        # <Trauma>
+        Slash: 3
+        Piercing: 3 # was 6, split into slash so it can (slowly) break grilles
+        # </Trauma>
 
 - type: entity
   parent:
@@ -2890,7 +2893,10 @@
         path: /Audio/Effects/bite.ogg
       damage:
         types:
-          Piercing: 8
+          # <Trauma>
+          Slash: 4
+          Piercing: 4 # was 8, split into slash so it can break grilles
+          # </Trauma>
     - type: FootstepModifier
       footstepSoundCollection:
         collection: FootstepClownFast


### PR DESCRIPTION
fixes #3315

can revert this if someone makes bullets pass through them instead of current flat reduction slop

10 hits for regular spider, 8 for clown spider

:cl:
- tweak: Split spider bite damage into half slash half pierce so it can break grilles.