### PR TITLE
fix martial arts combos not being predicted

### DIFF
--- a/Content.Shared/Movement/Pulling/Systems/PullingSystem.Trauma.cs
+++ b/Content.Shared/Movement/Pulling/Systems/PullingSystem.Trauma.cs
@@ -313,19 +313,18 @@ public sealed partial class PullingSystem
         _blocker.UpdateCanMove(pullable);
         _modifierSystem.RefreshMovementSpeedModifiers(puller);
 
-        _popup.PopupEntity(Loc.GetString($"popup-grab-{puller.Comp.GrabStage.ToString().ToLower()}-target",
-                ("puller", Identity.Entity(puller, EntityManager))),
+        var stageKey = puller.Comp.GrabStage.ToString().ToLower();
+        var pullerName = Identity.Entity(puller, EntityManager);
+        var pulledName = Identity.Entity(pullable, EntityManager);
+        _popup.PopupEntity(Loc.GetString($"popup-grab-{stageKey}-target", ("puller", pullerName)),
             pullable,
             pullable,
             popupType);
-        _popup.PopupClient(Loc.GetString($"popup-grab-{puller.Comp.GrabStage.ToString().ToLower()}-self",
-                ("target", Identity.Entity(pullable, EntityManager))),
+        _popup.PopupClient(Loc.GetString($"popup-grab-{stageKey}-self", ("target", pulledName)),
             pullable,
             puller,
             PopupType.Medium);
-        _popup.PopupEntity(Loc.GetString($"popup-grab-{puller.Comp.GrabStage.ToString().ToLower()}-others",
-                ("target", Identity.Entity(pullable, EntityManager)),
-                ("puller", Identity.Entity(puller, EntityManager))),
+        _popup.PopupEntity(Loc.GetString($"popup-grab-{stageKey}-others", ("target", pulledName), ("puller", pullerName)),
             pullable,
             filter,
             true,

--- a/Content.Trauma.Shared/MartialArts/Components/CanPerformComboComponent.cs
+++ b/Content.Trauma.Shared/MartialArts/Components/CanPerformComboComponent.cs
@@ -37,7 +37,7 @@ public sealed partial class CanPerformComboComponent : Component
     /// <summary>
     /// Current combo list.
     /// </summary>
-    [DataField]
+    [ViewVariables]
     public List<ComboPrototype> AllowedCombos = new();
 
     /// <summary>

--- a/Content.Trauma.Shared/MartialArts/MartialArtsSystem.Combos.cs
+++ b/Content.Trauma.Shared/MartialArts/MartialArtsSystem.Combos.cs
@@ -23,17 +23,17 @@ public partial class MartialArtsSystem
 
     private void InitializeCanPerformCombo()
     {
-        SubscribeLocalEvent<CanPerformComboComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<CanPerformComboComponent, ComponentInit>(OnInit);
         SubscribeLocalEvent<CanPerformComboComponent, ComboAttackPerformedEvent>(OnComboAttackPerformed);
     }
 
-    private void OnMapInit(Entity<CanPerformComboComponent> ent, ref MapInitEvent args)
+    private void OnInit(Entity<CanPerformComboComponent> ent, ref ComponentInit args)
     {
+        ent.Comp.AllowedCombos.Clear();
         foreach (var item in ent.Comp.RoundstartCombos)
         {
             ent.Comp.AllowedCombos.Add(_proto.Index(item));
         }
-        Dirty(ent);
     }
 
     private void OnComboAttackPerformed(Entity<CanPerformComboComponent> ent, ref ComboAttackPerformedEvent args)


### PR DESCRIPTION
fixes #3312

client thought there were no combos because it was using mapinit :face_holding_back_tears: 

:cl:
- fix: Fixed martial arts combos not being predicted.