### PR TITLE
sling and wraith spawning tweaks

### DIFF
--- a/Resources/Prototypes/_Trauma/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Trauma/GameRules/roundstart.yml
@@ -88,12 +88,8 @@
     minPlayers: 30
   - type: AntagSelection
     antags:
-    - !type:LinearAntagCount
+    - !type:FixedAntagCount
       proto: Shadowling
-      range:
-        min: 1
-        max: 1
-      playerRatio: 25
 
 - type: entity
   parent: TraitorReinforcement

--- a/Resources/Prototypes/_Trauma/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Trauma/GameRules/roundstart.yml
@@ -14,7 +14,7 @@
     - id: ShadowlingRoundstart
       prob: 0.02
     - id: WraithRoundstart
-      prob: 0.02
+      prob: 0.1
 
 - type: entity
   parent: BaseGameRule
@@ -92,7 +92,7 @@
       proto: Shadowling
       range:
         min: 1
-        max: 3
+        max: 1
       playerRatio: 25
 
 - type: entity


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->
Made roundstart wraith more common, made shadowlings spawn w/ a max of one. 
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Shadowlings ascend if one of them ascend, and it's straight up not fun for players when there's more than one sling. I've seen people leave over rounds with more than one sling, and i think making it have a max of one spawned means its less of a danger. I made wraith more common because it almost never spawned.
## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
two lines were changed
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Graves

- tweak: Shadowlings now only spawn alone.
- tweak: Wraiths are now more common roundstart.