### PR TITLE
Clown goblin 1984. No more banana.

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Mobs/NPCs/animals.yml
@@ -889,20 +889,13 @@
       collection: FootstepClown
   - type: CombatMode
   - type: MeleeWeapon
-    attackRate: 1.5 # Trauma - Was 2 - stop being fucking annoying, clown goblin.
+    attackRate: 1.5
     damage:
       types:
         Blunt: 0.5
     soundHit:
       collection: BikeHorn
     animation: WeaponArcFist
-# Trauma - remove honk injection
-#  - type: SolutionManager
-#    solutions:
-#    - SolutionClownSpider
-#  - type: MeleeChemicalInjector
-#    transferAmount: 3
-#    solution: melee
   - type: Vocal
     sounds:
       Male: ClownGoblin

--- a/Resources/Prototypes/_Goobstation/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Mobs/NPCs/animals.yml
@@ -889,19 +889,20 @@
       collection: FootstepClown
   - type: CombatMode
   - type: MeleeWeapon
-    attackRate: 2
+    attackRate: 1.5 # Trauma - Was 2 - stop being fucking annoying, clown goblin.
     damage:
       types:
         Blunt: 0.5
     soundHit:
       collection: BikeHorn
     animation: WeaponArcFist
-  - type: SolutionManager
-    solutions:
-    - SolutionClownSpider
-  - type: MeleeChemicalInjector
-    transferAmount: 3
-    solution: melee
+# Trauma - remove honk injection
+#  - type: SolutionManager
+#    solutions:
+#    - SolutionClownSpider
+#  - type: MeleeChemicalInjector
+#    transferAmount: 3
+#    solution: melee
   - type: Vocal
     sounds:
       Male: ClownGoblin


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->
Clown goblins no longer convert people into fucking bananamen


## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bananamen polymorph breaks a lot of things, mutations, viruses/virus immunity, certain antags. It's a silly joke that has debilitating consequences shouldn't be forced upon you by a pseudo antag designed to cause minor trouble

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Weax
- tweak: Clown Goblins no longer inject Honk
