### PR TITLE
access scanner ignores admins id

### DIFF
--- a/Content.Trauma.Shared/Access/AccessScannerBlacklistComponent.cs
+++ b/Content.Trauma.Shared/Access/AccessScannerBlacklistComponent.cs
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Content.Trauma.Shared.Access;
+
+/// <summary>
+/// Prevents an ID card from being detected by an <see cref="AccessScannerComponent"/>.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class AccessScannerBlacklistComponent : Component;

--- a/Content.Trauma.Shared/Access/AccessScannerSystem.cs
+++ b/Content.Trauma.Shared/Access/AccessScannerSystem.cs
@@ -69,7 +69,7 @@ public sealed partial class AccessScannerSystem : EntitySystem
                 if (idXform.MapID != map)
                     continue; // cant possibly be there
 
-                if (_blacklistQuery.HasComp(id)))
+                if (_blacklistQuery.HasComp(id))
                     continue; // ignored
 
                 var idCoords = _transform.GetMapCoordinates(idXform);

--- a/Content.Trauma.Shared/Access/AccessScannerSystem.cs
+++ b/Content.Trauma.Shared/Access/AccessScannerSystem.cs
@@ -25,6 +25,7 @@ public sealed partial class AccessScannerSystem : EntitySystem
     [Dependency] private SharedPowerReceiverSystem _power = default!;
     [Dependency] private SharedToolSystem _tool = default!;
     [Dependency] private SharedTransformSystem _transform = default!;
+    [Dependency] private EntityQuery<AccessScannerBlacklistComponent> _blacklistQuery = default!;
 
     private TimeSpan _updateDelay = TimeSpan.FromSeconds(0.2);
     private TimeSpan _nextUpdate;
@@ -67,6 +68,9 @@ public sealed partial class AccessScannerSystem : EntitySystem
             {
                 if (idXform.MapID != map)
                     continue; // cant possibly be there
+
+                if (_blacklistQuery.HasComp(id)))
+                    continue; // ignored
 
                 var idCoords = _transform.GetMapCoordinates(idXform);
                 if ((idCoords.Position - pos).LengthSquared() > range2)

--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -963,6 +963,12 @@
   suffix: Admin
   description: An ID card that gives you access beyond your wildest dreams.
   components:
+  # <Trauma>
+  - type: AccessScannerBlacklist # dont let default aghost get doxxed
+  - type: NanoChatCard
+    notificationsMuted: true
+    listNumber: false
+  # </Trauma>
   - type: Sprite
     sprite: Objects/Misc/id_cards.rsi
     layers:
@@ -990,9 +996,6 @@
     - SyndicateAgent
     - Wizard
     - Xenoborg
-  - type: NanoChatCard # DeltaV
-    notificationsMuted: true
-    listNumber: false
   - type: Tag #  Ignore Chameleon tags
     tags:
     - DoorBumpOpener


### PR DESCRIPTION
fixes #3388

:cl:
ADMIN:
- fix: Fixed access scanners detecting your universal ID cards.