### PR TITLE
target vital parts for martial arts combos

### DIFF
--- a/Resources/Prototypes/_Trauma/MartialArts/armstrong.yml
+++ b/Resources/Prototypes/_Trauma/MartialArts/armstrong.yml
@@ -13,6 +13,7 @@
   - !type:TakeStaminaDamage
     amount: 7
   - !type:HealthChange
+    targetPart: Chest
     damage:
       types:
         Blunt: 5
@@ -32,6 +33,7 @@
   - !type:TakeStaminaDamage
     amount: 12
   - !type:HealthChange
+    targetPart: Chest
     damage:
       types:
         Blunt: 6
@@ -51,6 +53,7 @@
   - !type:TakeStaminaDamage
     amount: 18
   - !type:HealthChange
+    targetPart: Chest
     damage:
       types:
         Blunt: 12
@@ -69,6 +72,7 @@
   - !type:TakeStaminaDamage
     amount: 7
   - !type:HealthChange
+    targetPart: Chest
     damage:
       types:
         Blunt: 6
@@ -81,6 +85,7 @@
   - !type:TakeStaminaDamage
     amount: 13
   - !type:HealthChange
+    targetPart: Chest
     damage:
       types:
         Blunt: 8
@@ -102,6 +107,7 @@
   - !type:TakeStaminaDamage
     amount: 7
   - !type:HealthChange
+    targetPart: Chest
     damage:
       types:
         Blunt: 5
@@ -114,6 +120,7 @@
   - !type:TakeStaminaDamage
     amount: 20
   - !type:HealthChange
+    targetPart: Chest
     damage:
       types:
         Blunt: 18
@@ -141,6 +148,7 @@
   - !type:TakeStaminaDamage
     amount: 25
   - !type:HealthChange
+    targetPart: Chest
     damage:
       types:
         Blunt: 20
@@ -166,6 +174,7 @@
   - !type:TakeStaminaDamage
     amount: 8
   - !type:HealthChange
+    targetPart: Chest
     damage:
       types:
         Blunt: 13
@@ -190,6 +199,7 @@
   - !type:TakeStaminaDamage
     amount: 15
   - !type:HealthChange
+    targetPart: Chest
     damage:
       types:
         Blunt: 17
@@ -214,6 +224,7 @@
   - !type:TakeStaminaDamage
     amount: 17
   - !type:HealthChange
+    targetPart: Chest
     damage:
       types:
         Blunt: 25
@@ -230,6 +241,7 @@
     sound: /Audio/Magic/fireball.ogg
   opponentEffects:
   - !type:HealthChange
+    targetPart: Chest
     damage:
       types:
         Heat: 15
@@ -247,6 +259,7 @@
     sound: /Audio/Magic/fireball.ogg
   opponentEffects:
   - !type:HealthChange
+    targetPart: Chest
     damage:
       types:
         Heat: 17
@@ -264,6 +277,7 @@
     sound: /Audio/Magic/fireball.ogg
   opponentEffects:
   - !type:HealthChange
+    targetPart: Chest
     damage:
       types:
         Heat: 20
@@ -283,6 +297,7 @@
   - !type:TakeStaminaDamage
     amount: -10
   - !type:HealthChange
+    targetPart: Chest
     damage:
       types:
         Blunt: 5
@@ -322,11 +337,13 @@
   - !type:PlaySoundEffect
     sound: /Audio/Weapons/genhit2.ogg
   - !type:HealthChange
+    targetPart: Head
     damage:
       types:
         Blunt: 7
   opponentEffects:
   - !type:HealthChange
+    targetPart: Head
     damage:
       types:
         Blunt: 14
@@ -343,11 +360,13 @@
   - !type:PlaySoundEffect
     sound: /Audio/Weapons/genhit2.ogg
   - !type:HealthChange
+    targetPart: Head
     damage:
       types:
         Blunt: 6
   opponentEffects:
   - !type:HealthChange
+    targetPart: Head
     damage:
       types:
         Blunt: 16
@@ -364,11 +383,13 @@
   - !type:PlaySoundEffect
     sound: /Audio/Weapons/genhit2.ogg
   - !type:HealthChange
+    targetPart: Head
     damage:
       types:
         Blunt: 4
   opponentEffects:
   - !type:HealthChange
+    targetPart: Head
     damage:
       types:
         Blunt: 18

--- a/Resources/Prototypes/_Trauma/MartialArts/capoeira.yml
+++ b/Resources/Prototypes/_Trauma/MartialArts/capoeira.yml
@@ -13,6 +13,7 @@
   - !type:ModifyParalysis
     time: 1
   - !type:HealthChange
+    targetPart: Chest
     damage:
       types:
         Slash: 5
@@ -29,6 +30,7 @@
     sound: /Audio/Weapons/genhit2.ogg
   opponentEffects:
   - !type:HealthChange
+    targetPart: Chest
     damage:
       types:
         Slash: 15
@@ -45,6 +47,7 @@
     sound: /Audio/Weapons/genhit1.ogg
   opponentEffects:
   - !type:HealthChange
+    targetPart: Chest
     damage:
       types:
         Slash: 10
@@ -66,6 +69,7 @@
     sound: /Audio/Weapons/genhit1.ogg
   opponentEffects:
   - !type:HealthChange
+    targetPart: Chest
     damage:
       types:
         Slash: 25

--- a/Resources/Prototypes/_Trauma/MartialArts/carp.yml
+++ b/Resources/Prototypes/_Trauma/MartialArts/carp.yml
@@ -26,6 +26,7 @@
     - carp-saying-cowabunga
   opponentEffects:
   - !type:HealthChange
+    targetPart: Chest
     damage:
       types:
         Slash: 20
@@ -42,6 +43,7 @@
   - !type:ModifyParalysis
     time: 6
   - !type:HealthChange
+    targetPart: Chest
     damage:
       types:
         Blunt: 10

--- a/Resources/Prototypes/_Trauma/MartialArts/cqc.yml
+++ b/Resources/Prototypes/_Trauma/MartialArts/cqc.yml
@@ -33,6 +33,7 @@
   - !type:TakeStaminaDamage
     amount: 25
   - !type:HealthChange
+    targetPart: Chest
     damage:
       types:
         Blunt: 12
@@ -49,6 +50,7 @@
   - Harm
   opponentEffects:
   - !type:HealthChange
+    targetPart: Chest
     damage:
       types:
         Blunt: 8
@@ -72,6 +74,7 @@
   - !type:TakeStaminaDamage
     amount: 25
   - !type:HealthChange
+    targetPart: Chest
     damage:
       types:
         Blunt: 12
@@ -95,6 +98,7 @@
   - !type:TakeStaminaDamage
     amount: 40
   - !type:HealthChange
+    targetPart: Chest
     damage:
       types:
         Blunt: 20
@@ -189,6 +193,7 @@
   - !type:TakeStaminaDamage
     amount: 20
   - !type:HealthChange
+    targetPart: Chest
     damage:
       types:
         Blunt: 5
@@ -211,6 +216,7 @@
   - !type:TakeStaminaDamage
     amount: 40
   - !type:HealthChange
+    targetPart: Chest
     damage:
       types:
         Blunt: 10
@@ -234,6 +240,7 @@
     effectProto: StatusEffectForcedSleeping
     time: 7
   - !type:HealthChange
+    targetPart: Chest
     damage:
       types:
         Blunt: 30

--- a/Resources/Prototypes/_Trauma/MartialArts/dragonkungfu.yml
+++ b/Resources/Prototypes/_Trauma/MartialArts/dragonkungfu.yml
@@ -26,6 +26,7 @@
   - !type:TakeStaminaDamage
     amount: 25
   - !type:HealthChange
+    targetPart: Chest
     damage:
       types:
         Blunt: 15
@@ -44,6 +45,7 @@
     sound: /Audio/Weapons/genhit1.ogg
   opponentEffects:
   - !type:HealthChange
+    targetPart: Chest
     damage:
       types:
         Blunt: 40

--- a/Resources/Prototypes/_Trauma/MartialArts/hellrip.yml
+++ b/Resources/Prototypes/_Trauma/MartialArts/hellrip.yml
@@ -11,6 +11,7 @@
   - !type:ModifyParalysis
     time: 6
   - !type:HealthChange
+    targetPart: Chest
     damage:
       types:
         Slash: 10
@@ -25,6 +26,7 @@
   - Grab
   opponentEffects:
   - !type:HealthChange
+    targetPart: Head
     damage:
       types:
         Slash: 100
@@ -40,6 +42,7 @@
   - !type:TakeStaminaDamage
     amount: 50
   - !type:HealthChange
+    targetPart: Chest
     damage:
       types:
         Slash: 60

--- a/Resources/Prototypes/_Trauma/MartialArts/kravmaga.yml
+++ b/Resources/Prototypes/_Trauma/MartialArts/kravmaga.yml
@@ -74,13 +74,12 @@
     - cqc-slam
   opponentEffects:
   - !type:HealthChange
-    scaling: false
+    targetPart: Chest
     damage:
       types:
         Blunt: 5
     targetPart: Legs
   - !type:ModifyKnockdown
-    scaling: false
     time: 4
     type: Update
   levelRequired: 26
@@ -97,13 +96,12 @@
     - cqc-kick
   opponentEffects:
   - !type:HealthChange
-    scaling: false
+    targetPart: Chest
     damage:
       types:
         Blunt: 5
     targetPart: Head
   - !type:GenericStatusEffect
-    scaling: false
     key: Muted
     component: Muted
     time: 20
@@ -120,16 +118,13 @@
     - cqc-restrain
   opponentEffects:
   - !type:TakeStaminaDamage
-    scaling: false
     amount: 30
   - !type:GenericStatusEffect
-    scaling: false
     key: Stutter
     component: StutteringAccent
     time: 10
     type: Update
   # TODO: status effect
   - !type:BlockedBreathing
-    scaling: false
     time: 10
   levelRequired: 26

--- a/Resources/Prototypes/_Trauma/MartialArts/kravmaga.yml
+++ b/Resources/Prototypes/_Trauma/MartialArts/kravmaga.yml
@@ -74,7 +74,6 @@
     - cqc-slam
   opponentEffects:
   - !type:HealthChange
-    targetPart: Chest
     damage:
       types:
         Blunt: 5
@@ -96,7 +95,6 @@
     - cqc-kick
   opponentEffects:
   - !type:HealthChange
-    targetPart: Chest
     damage:
       types:
         Blunt: 5

--- a/Resources/Prototypes/_Trauma/MartialArts/ninjutsu.yml
+++ b/Resources/Prototypes/_Trauma/MartialArts/ninjutsu.yml
@@ -34,6 +34,7 @@
   - !type:ModifyParalysis
     time: 9
   - !type:HealthChange
+    targetPart: Chest
     damage:
       types:
         Slash: 10
@@ -51,6 +52,7 @@
   - !type:ModifyParalysis
     time: 7
   - !type:HealthChange
+    targetPart: Chest
     damage:
       types:
         Slash: 20

--- a/Resources/Prototypes/_Trauma/MartialArts/spacebear.yml
+++ b/Resources/Prototypes/_Trauma/MartialArts/spacebear.yml
@@ -13,6 +13,7 @@
     - spacebear-bearjaws
   opponentEffects:
   - !type:HealthChange
+    targetPart: Chest
     damage:
       types:
         Piercing: 5
@@ -32,6 +33,7 @@
     - spacebear-pawslam
   opponentEffects:
   - !type:HealthChange
+    targetPart: Chest
     damage:
       types:
         Blunt: 10 # TODO: DOUBLE DAMAGE WHEN KNOCKED DOWN AND GIVE 2S SLOWDOWN
@@ -57,6 +59,7 @@
   - !type:Extinguish # put it out
   opponentEffects:
   - !type:HealthChange
+    targetPart: Chest
     damage:
       types:
         Heat: 10


### PR DESCRIPTION
fixes #3389

most target torso, some target head where it makes sense

:cl:
- fix: Fixed martial arts damage being split up between all limbs.