### PR TITLE
made xenomorph larva infection growthstages a flat timer instead of a random chance

### DIFF
--- a/Resources/Prototypes/_White/Body/Organs/infection.yml
+++ b/Resources/Prototypes/_White/Body/Organs/infection.yml
@@ -17,7 +17,8 @@
     price: 2000
   - type: XenomorphInfection
     maxGrowthStage: 6
-    growProb: 0.75
+    growProb: 1.0
+    growTime: 40
     infectedIcons:
       0: XenomorphInfectionIconStageZero
       1: XenomorphInfectionIconStageOne


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->
title
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
it will make xenomorph infection more consistent and alleviate the issue of xenomorphs snowballing too fast
## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [ ] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [ ] I have tested this pull request and written instructions on how to test it
- [ ] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
--> 🆑 assripper.

 - add: xenomorph infection growth has now been changed from a random chance to a flat timer, the larva will always grow every 40 seconds (4 minutes to burst)
