### PR TITLE
add logic control port for lights

### DIFF
--- a/Content.Shared/Light/Components/PoweredLightComponent.Trauma.cs
+++ b/Content.Shared/Light/Components/PoweredLightComponent.Trauma.cs
@@ -1,0 +1,10 @@
+using Content.Shared.DeviceLinking;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.Light.Components;
+
+public sealed partial class PoweredLightComponent : Component
+{
+    [DataField]
+    public ProtoId<SinkPortPrototype> ControlPort = "Control";
+}

--- a/Content.Shared/Light/EntitySystems/SharedPoweredLightSystem.cs
+++ b/Content.Shared/Light/EntitySystems/SharedPoweredLightSystem.cs
@@ -62,7 +62,8 @@ public abstract partial class SharedPoweredLightSystem : EntitySystem
     private void OnInit(EntityUid uid, PoweredLightComponent light, ComponentInit args)
     {
         light.LightBulbContainer = ContainerSystem.EnsureContainer<ContainerSlot>(uid, LightBulbContainer);
-        _deviceLink.EnsureSinkPorts(uid, light.OnPort, light.OffPort, light.TogglePort);
+        _deviceLink.EnsureSinkPorts(uid, light.OnPort, light.OffPort, light.TogglePort,
+            light.ControlPort); // Trauma
     }
 
     private void OnRemoved(Entity<PoweredLightComponent> light, ref EntRemovedFromContainerMessage args)
@@ -125,6 +126,23 @@ public abstract partial class SharedPoweredLightSystem : EntitySystem
             SetState(ent, true, ent.Comp);
         else if (args.Port == ent.Comp.TogglePort)
             ToggleLight(ent, ent.Comp);
+        // <Trauma> - allow logic signals to set it directly instead of just toggling, no need for edge detector
+        else if (args.Port == ent.Comp.ControlPort)
+        {
+            if (args.Data is not { } data)
+                return; // non-logic signal
+
+            var value = false;
+            if (data.TryGetValue(DeviceNetworkConstants.LogicState, out SignalState state))
+                value = state == SignalState.High;
+            else if (data.TryGetValue("logic_int", out int i))
+                value = i != 0; // so circuits dont have to convert it
+            else
+                return; // unsupported signal (string or something)
+
+            SetState(ent, value, ent.Comp);
+        }
+        // </Trauma>
     }
 
     /// <summary>

--- a/Resources/Locale/en-US/_Trauma/machines/generic.ftl
+++ b/Resources/Locale/en-US/_Trauma/machines/generic.ftl
@@ -1,0 +1,2 @@
+signal-port-name-control = Logic Control
+signal-port-description-control = Sets the device's state to a logic signal, HIGH or LOW for on or off. Pulses are ignored.

--- a/Resources/Locale/en-US/machine-linking/receiver_ports.ftl
+++ b/Resources/Locale/en-US/machine-linking/receiver_ports.ftl
@@ -1,22 +1,3 @@
-# SPDX-FileCopyrightText: 2022 Chris V <HoofedEar@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2022 Leon Friedrich <60421075+ElectroJr@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2022 Rane <60792108+Elijahrane@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2022 fishfish458 <fishfish458>
-# SPDX-FileCopyrightText: 2023 0x6273 <0x40@keemail.me>
-# SPDX-FileCopyrightText: 2023 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 Julian Giebel <juliangiebel@live.de>
-# SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
-# SPDX-FileCopyrightText: 2023 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 deltanedas <@deltanedas:kde.org>
-# SPDX-FileCopyrightText: 2023 metalgearsloth <comedian_vs_clown@hotmail.com>
-# SPDX-FileCopyrightText: 2024 Ed <96445749+TheShuEd@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Saphire Lattice <lattice@saphi.re>
-# SPDX-FileCopyrightText: 2024 deltanedas <39013340+deltanedas@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 Aiden <aiden@djkraz.com>
-#
-# SPDX-License-Identifier: AGPL-3.0-or-later
-
 signal-port-name-autoclose = Autoclose
 signal-port-description-autoclose = Toggles whether the device should automatically close.
 

--- a/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
@@ -122,6 +122,7 @@
     range: 200
   - type: DeviceLinkSink
     ports:
+      - Control # Trauma
       - On
       - Off
       - Toggle
@@ -351,6 +352,7 @@
       burned: burned
   - type: DeviceLinkSink
     ports:
+      - Control # Trauma
       - On
       - Off
       - Toggle

--- a/Resources/Prototypes/Entities/Structures/Lighting/ground_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/ground_lighting.yml
@@ -94,6 +94,7 @@
     range: 200
   - type: DeviceLinkSink
     ports:
+      - Control # Trauma
       - On
       - Off
       - Toggle

--- a/Resources/Prototypes/Entities/Structures/Lighting/strobe_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/strobe_lighting.yml
@@ -118,6 +118,7 @@
       on: base
   - type: DeviceLinkSink
     ports:
+      - Control # Trauma
       - On
       - Off
       - Toggle

--- a/Resources/Prototypes/_Trauma/DeviceLink/sink_ports.yml
+++ b/Resources/Prototypes/_Trauma/DeviceLink/sink_ports.yml
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+- type: sinkPort
+  id: Control
+  name: signal-port-name-control
+  description: signal-port-description-control
+
 # Circuits
 
 - type: sinkPort


### PR DESCRIPTION
so you dont have t use logic gate input visualizer to see a port state, and dont need an edge detector for a light

## Media

<img width="65" height="144" alt="21:04:16" src="https://github.com/user-attachments/assets/3f13bbc5-c7bc-45e2-9e98-a0c32a844277" />

<img width="118" height="168" alt="21:04:12" src="https://github.com/user-attachments/assets/1b6ee90b-d55f-47fc-9b50-672c6c483774" />

<img width="946" height="146" alt="21:04:00" src="https://github.com/user-attachments/assets/41531150-cdfb-4e46-ab62-702af0c95953" />


## Changelog

:cl:
- add: Lights now have a logic control port for setting it on/off with a single signal's value.