### PR TITLE
CBURN Skill Chip spawn for CBURN, ERT, and Deathsquad ghost role spawns

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/CentComm/cburn.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/cburn.yml
@@ -51,7 +51,9 @@
     - AmbuzolMedipen # Injectors are cooler.
     - AmbuzolMedipen # Injectors are cooler.
     - MedkitCombatFilled # Ah yes, let's send them in with ZERO meds. Good luck!
-    - CburnSpear # SPEAAR
+  inhand:
+  - CburnSpear
+  - SkillChipCBURN # Trauma
 # Goobstation - End - Sol
 
 - type: chameleonOutfit

--- a/Resources/Prototypes/Roles/Jobs/CentComm/deathsquad.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/deathsquad.yml
@@ -53,6 +53,7 @@
     - DeterrentCaseFilled
   inhand:
   - WeaponPulseRifle
+  - SkillChipDeathSquad # Trauma
     # Goobstation End
 
 - type: chameleonOutfit

--- a/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
@@ -122,9 +122,6 @@
   # Goobstation
   - NanotrasenRepresentative
   special:
-  - !type:OrganChipsSpecial
-        chips:
-        - SkillChipCBURN # TODO: better chip
   - !type:AddComponentSpecial
     components:
     - type: BibleUser #Lets them heal with bibles
@@ -232,9 +229,6 @@
   # Goobstation
   - NanotrasenRepresentative
   special: # Goobstation
-  - !type:OrganChipsSpecial
-        chips:
-        - SkillChipCBURN # TODO: better chip
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant, FreedomImplant, BluespaceLifelineImplant, RadioImplantCentcomm, NutrimentPumpImplant, StypticStimulatorImplant, DeathRattleImplantCentcomm ]
   # <Trauma>
@@ -373,9 +367,6 @@
   # Goobstation
   - NanotrasenRepresentative
   special: # Goobstation
-  - !type:OrganChipsSpecial
-            chips:
-            - SkillChipCBURN # TODO: better chip
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant, FreedomImplant, BluespaceLifelineImplant, RadioImplantCentcomm, NutrimentPumpImplant, StypticStimulatorImplant, DeathRattleImplantCentcomm]
   # <Trauma>
@@ -565,9 +556,6 @@
   # Goobstation
   - NanotrasenRepresentative
   special: # Goobstation
-  - !type:OrganChipsSpecial
-    chips:
-    - SkillChipCBURN # TODO: better chip
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant, FreedomImplant, BluespaceLifelineImplant, RadioImplantCentcomm, NutrimentPumpImplant, StypticStimulatorImplant, DeathRattleImplantCentcomm ]
   # <Trauma>
@@ -684,9 +672,6 @@
   # Goobstation
   - NanotrasenRepresentative
   special: # Goobstation
-  - !type:OrganChipsSpecial
-    chips:
-    - SkillChipCBURN # TODO: better chip
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant, FreedomImplant, BluespaceLifelineImplant, RadioImplantCentcomm, NutrimentPumpImplant, StypticStimulatorImplant, DeathRattleImplantCentcomm]
   # <Trauma>

--- a/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
@@ -20,7 +20,7 @@
   special:
   - !type:OrganChipsSpecial
     chips:
-    - SkillChipCaptain # TODO: better chip
+    - SkillChipCBURN # TODO: better chip
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant, FreedomImplant, BluespaceLifelineImplant, RadioImplantCentcomm, NutrimentPumpImplant, StypticStimulatorImplant, DeathRattleImplantCentcomm ]
   # </Trauma>
@@ -75,6 +75,8 @@
     - CrowbarRed
     - ERTSecurityUndeterminedWeapon
     #- MagazineMagnum # Goob
+  inhand:
+  - SkillChipCBURN # Trauma
 
 - type: startingGear
   parent: ERTLeaderGearEVA
@@ -120,6 +122,9 @@
   # Goobstation
   - NanotrasenRepresentative
   special:
+  - !type:OrganChipsSpecial
+        chips:
+        - SkillChipCBURN # TODO: better chip
   - !type:AddComponentSpecial
     components:
     - type: BibleUser #Lets them heal with bibles
@@ -197,6 +202,8 @@
     - Lighter
     - Nullrod # Goobstation
     - ExecutiveIDCard # Goobstation - Executive Access!
+  inhand:
+  - SkillChipCBURN # Trauma
 
 - type: chameleonOutfit
   id: ERTChaplainChameleonOutfit
@@ -225,6 +232,9 @@
   # Goobstation
   - NanotrasenRepresentative
   special: # Goobstation
+  - !type:OrganChipsSpecial
+        chips:
+        - SkillChipCBURN # TODO: better chip
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant, FreedomImplant, BluespaceLifelineImplant, RadioImplantCentcomm, NutrimentPumpImplant, StypticStimulatorImplant, DeathRattleImplantCentcomm ]
   # <Trauma>
@@ -315,6 +325,8 @@
     - WeaponPistolMk58
     - MagazinePistol
     - EmergencyMedipen
+  inhand:
+  - SkillChipCBURN # Trauma
 
 - type: startingGear
   parent: ERTEngineerGearEVA
@@ -361,6 +373,9 @@
   # Goobstation
   - NanotrasenRepresentative
   special: # Goobstation
+  - !type:OrganChipsSpecial
+            chips:
+            - SkillChipCBURN # TODO: better chip
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant, FreedomImplant, BluespaceLifelineImplant, RadioImplantCentcomm, NutrimentPumpImplant, StypticStimulatorImplant, DeathRattleImplantCentcomm]
   # <Trauma>
@@ -430,6 +445,8 @@
     - TelescopicShield
     - HoloprojectorSecurity
     - PowerCellHigh
+  inhand:
+  - SkillChipCBURN # Trauma
 
 - type: startingGear
   id: ERTSecurityGearArmedRifle
@@ -445,8 +462,9 @@
     belt: ClothingBeltMilitaryWebbingERT
     pocket2: CombatKnife
     suitstorage: WeaponRifleLecter
+    back: WeaponLaserCannon
   inhand:
-    - WeaponLaserCannon
+    - SkillChipCBURN # Trauma
     - PortableRecharger
   storage:
     belt:
@@ -547,6 +565,9 @@
   # Goobstation
   - NanotrasenRepresentative
   special: # Goobstation
+  - !type:OrganChipsSpecial
+    chips:
+    - SkillChipCBURN # TODO: better chip
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant, FreedomImplant, BluespaceLifelineImplant, RadioImplantCentcomm, NutrimentPumpImplant, StypticStimulatorImplant, DeathRattleImplantCentcomm ]
   # <Trauma>
@@ -589,6 +610,8 @@
     - CartridgeAtropine
     - CartridgeAtropine
     - MedicalBeamGunBattery
+  inhand:
+  - SkillChipCBURN # Trauma
 
 - type: startingGear
   id: ERTMedicalGearEVA
@@ -661,6 +684,9 @@
   # Goobstation
   - NanotrasenRepresentative
   special: # Goobstation
+  - !type:OrganChipsSpecial
+    chips:
+    - SkillChipCBURN # TODO: better chip
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant, FreedomImplant, BluespaceLifelineImplant, RadioImplantCentcomm, NutrimentPumpImplant, StypticStimulatorImplant, DeathRattleImplantCentcomm]
   # <Trauma>
@@ -730,6 +756,8 @@
     - WeaponPistolMk58
     - MagazinePistol
     - EmergencyMedipen
+  inhand:
+  - SkillChipCBURN # Trauma
 
 - type: chameleonOutfit
   id: ERTJanitorChameleonOutfit


### PR DESCRIPTION
## About the PR
All ERT Ghost Roles (ERT, Deathsquad, and CBURN), now spawn in with their respective skill chip in their hand for them to easily insert.

## Why / Balance
All ERT Ghost Roles don't pull from job loadouts meaning they don't get skill chips. Because of this the easiest patch is to just give them the CBURN or Deathsquad skill chip in their hand. Anyone who wishes to redo the ERT entities may do so and remove this later on, but this keeps admins from having to help out ERT auto-spawns every single time they spawn in with 0 skills.

Issue:
CBURN don't have skillchips #3414

## Test plan
Head into an active dev environment and spawn in the CBURN, ERT, or Deathsquad entities to see the skill chips in their hands.

## Media
It acts exact as it sounds, poof and they are in-hand.

## Requirements
- [X] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Changelog
:cl:
- fix: Fixed ERT Skills
