### PR TITLE
mapping is so easy its slop

### DIFF
--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -10,20 +10,20 @@
   - MachineMaterialSilo # for main departments
   - MachineMasterMaterialSilo # for cargo to easily distribute mats to department silos
   maps:
-  #- Atlas needs SpawnPointExtraAiCore mapped
-  - Amber
+  - Atlas
+  #- Amber # needs SpawnPointExtraAiCore mapped
   - Bagel
   - Box
-  - Cluster
+  #- Cluster # SpawnPointExtraAiCore
   - Fland
   #- Loop # needs full area coverage
   - Marathon
   - Meta
   - Oasis
-  - Omega
+  #- Omega # SpawnPointExtraAiCore
   - Origin
   #- Saltern # DEATH TO SALTERN
-  - Packed
+  #- Packed # SpawnPointExtraAiCore
   #- Barratry
   - Kettle
   #- Submarine

--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -10,7 +10,7 @@
   - MachineMaterialSilo # for main departments
   - MachineMasterMaterialSilo # for cargo to easily distribute mats to department silos
   maps:
-  - Atlas
+  #- Atlas # SpawnPointExtraAiCore
   #- Amber # needs SpawnPointExtraAiCore mapped
   - Bagel
   - Box

--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -6,10 +6,11 @@
   - AreaMaints # for ambience and maints spawn rules
   - AreaHallway # for carp migration
   requiredEntities:
+  - SpawnPointExtraAiCore # for maps with AI (almost all of them) to work with triumvirate station trait
   - MachineMaterialSilo # for main departments
   - MachineMasterMaterialSilo # for cargo to easily distribute mats to department silos
   maps:
-  - Atlas
+  #- Atlas needs SpawnPointExtraAiCore mapped
   - Amber
   - Bagel
   - Box
@@ -32,5 +33,5 @@
   - Cog
   - Reach
   #- Serpentcrest
-  - Nume
+  #- Nume # slop
   - Freighter

--- a/Resources/Prototypes/_Trauma/Maps/reach.yml
+++ b/Resources/Prototypes/_Trauma/Maps/reach.yml
@@ -8,6 +8,7 @@
   maxPlayers: 10
   ignoredRequiredEntities:
   - MachineMasterMaterialSilo # 1 department silo can probably cover the whole ship be real
+  - SpawnPointExtraAiCore # no AI core
   stations:
     Reach:
       stationProto: StandardNanotrasenStation


### PR DESCRIPTION
triumvirate marker is now required for pooled maps, no more lowpop maps
killed nume too its dead

:cl:
- remove: Derotated nume station, it was abandoned and needs a lot of work.
- remove: Derotated atlas, amber, cluster, omega and packed temporarily.