### PR TITLE
fix holoparasite popup spam

### DIFF
--- a/Content.Shared/Guardian/GuardianSystem.cs
+++ b/Content.Shared/Guardian/GuardianSystem.cs
@@ -153,7 +153,7 @@ public sealed partial class GuardianSystem : EntitySystem
 
     private void OnGuardianAttackAttempt(Entity<GuardianComponent> ent, ref AttackAttemptEvent args)
     {
-        if (args.Cancelled || args.Target != ent.Comp.Host)
+        if (args.Cancelled || args.Target != ent.Comp.Host || ent.Comp.Host == null) // Trauma - add null host check
             return;
 
         _popup.PopupPredictedCursor(Loc.GetString("guardian-attack-host"), ent.Owner, PopupType.LargeCaution);
@@ -267,6 +267,7 @@ public sealed partial class GuardianSystem : EntitySystem
         if (TryComp<GuardianComponent>(guardian, out var guardianComp))
         {
             guardianComp.Host = args.Args.Target.Value;
+            Dirty(guardian, guardianComp); // Trauma - networking for babbies
             _audio.PlayPredicted(ent.Comp.UsedSound,
                 ent.Owner,
                 args.Args.Target);


### PR DESCRIPTION
- dirty it when setting host so client doesnt have null host
- disable the attack prevention if host is null for admin abuse or whatever

fixes #3535 