### PR TITLE
fix faith/iradomini being able to transform

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/nullrod.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/nullrod.yml
@@ -24,9 +24,6 @@
     - NONE
   - type: DisarmMalus
     malus: 0
-  - type: Tag
-    tags:
-    - Nullrod
 
 - type: entity
   name: Null Rod

--- a/Resources/Prototypes/_Goobstation/tags.yml
+++ b/Resources/Prototypes/_Goobstation/tags.yml
@@ -435,7 +435,7 @@
   id: NukeOpsReinforcementUplink
 
 - type: Tag
-  id: Nullrod
+  id: Nullrod # Allows transforming it into an altar's specific nullrod. Given to the Nullrod entity specifically.
 
 - type: Tag
   id: NunHood

--- a/Resources/Prototypes/_Trauma/Entities/Objects/Weapons/Melee/nullrod.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Objects/Weapons/Melee/nullrod.yml
@@ -44,9 +44,6 @@
   - type: ContainerContainer
     containers:
       ballistic-ammo: !type:Container
-  - type: Tag
-    tags:
-    - Nullrod
   - type: DivineIntervention
   - type: Reflect
     reflectProb: 1
@@ -106,9 +103,6 @@
       path: /Audio/Weapons/Guns/MagIn/pistol_magin.ogg
       params:
         volume: 0.1
-  - type: Tag
-    tags:
-    - Nullrod
   - type: DivineIntervention
   - type: Reflect
     reflectProb: 1


### PR DESCRIPTION
fixes #3290

it was adding the nullrod transformation tag 4 no raisin, removed it from basenullrod too so only actual nullrod gets to transform

:cl:
- fix: Fixed being able to transform faith/iradomini into other nullrods.