### PR TITLE
made chestbursters make people unrevivable instead of gib

### DIFF
--- a/Content.Trauma.Server/Xenomorphs/Larva/XenomorphLarvaSystem.cs
+++ b/Content.Trauma.Server/Xenomorphs/Larva/XenomorphLarvaSystem.cs
@@ -4,7 +4,6 @@ using Content.Server.DoAfter;
 using Content.Server.Ghost.Roles.Components;
 using Content.Server.Jittering;
 using Content.Server.Popups;
-using Content.Goobstation.Shared.Changeling.Components;
 using Content.Trauma.Shared.Xenomorphs;
 using Content.Trauma.Shared.Xenomorphs.Larva;
 using Content.Shared.DoAfter;
@@ -86,7 +85,6 @@ public sealed partial class XenomorphLarvaSystem : EntitySystem
             return;
 
         _container.Remove(uid, container);
-        EnsureComp<AbsorbedComponent>(victim);
         EnsureComp<UnrevivableComponent>(victim);
     }
 }

--- a/Content.Trauma.Server/Xenomorphs/Larva/XenomorphLarvaSystem.cs
+++ b/Content.Trauma.Server/Xenomorphs/Larva/XenomorphLarvaSystem.cs
@@ -4,6 +4,7 @@ using Content.Server.DoAfter;
 using Content.Server.Ghost.Roles.Components;
 using Content.Server.Jittering;
 using Content.Server.Popups;
+using Content.Goobstation.Shared.Changeling.Components;
 using Content.Trauma.Shared.Xenomorphs;
 using Content.Trauma.Shared.Xenomorphs.Larva;
 using Content.Shared.DoAfter;
@@ -84,6 +85,6 @@ public sealed partial class XenomorphLarvaSystem : EntitySystem
             return;
 
         _container.Remove(uid, container);
-        _gibbing.Gib(victim);
+        EnsureComp<AbsorbedComponent>(victim);
     }
 }

--- a/Content.Trauma.Server/Xenomorphs/Larva/XenomorphLarvaSystem.cs
+++ b/Content.Trauma.Server/Xenomorphs/Larva/XenomorphLarvaSystem.cs
@@ -9,6 +9,7 @@ using Content.Trauma.Shared.Xenomorphs;
 using Content.Trauma.Shared.Xenomorphs.Larva;
 using Content.Shared.DoAfter;
 using Content.Shared.Gibbing;
+using Content.Shared.Traits.Assorted;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Mind.Components;
 using Content.Shared.Popups;
@@ -86,5 +87,6 @@ public sealed partial class XenomorphLarvaSystem : EntitySystem
 
         _container.Remove(uid, container);
         EnsureComp<AbsorbedComponent>(victim);
+        EnsureComp<UnrevivableComponent>(victim);
     }
 }

--- a/Resources/Prototypes/_White/Body/Organs/infection.yml
+++ b/Resources/Prototypes/_White/Body/Organs/infection.yml
@@ -102,6 +102,6 @@
         damage:
           types:
             Blunt: 1000
-            Pierce: 1000
+            Piercing: 1000
       - !type:Jitter
         time: 16

--- a/Resources/Prototypes/_White/Body/Organs/infection.yml
+++ b/Resources/Prototypes/_White/Body/Organs/infection.yml
@@ -101,6 +101,7 @@
       - !type:HealthChange
         damage:
           types:
-            Blunt: 40
+            Blunt: 1000
+            Pierce: 1000
       - !type:Jitter
         time: 16


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->
chestbursters now hollow instead of gibbing, highly requested
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
it makes hives look cooler and i guess you can clone people who get chestbursted now
## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="280" height="257" alt="image" src="https://github.com/user-attachments/assets/a7fbd050-a012-4e20-948d-caf91a85f4d2" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [ ] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [ ] I have tested this pull request and written instructions on how to test it
- [ ] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
--> 🆑 assripper.

 - add: chestbursters now make people unrevivable instead of gibbing (you can still clone them)
