### PR TITLE
Environmental hazards tweak

### DIFF
--- a/Content.Common/Damage/DamageSpecifier.Trauma.cs
+++ b/Content.Common/Damage/DamageSpecifier.Trauma.cs
@@ -24,6 +24,18 @@ public sealed partial class DamageSpecifier
     [DataField]
     public DamageFlags Flags = DamageFlags.None;
 
+    /// <summary>
+    /// Wounds that are induced by damage types.
+    /// If not stated, use damage type as a wound.
+    /// </summary>
+    [DataField]
+    public Dictionary<ProtoId<DamageTypePrototype>, string> WoundTypeOverrides = new();
+
+    public string GetWoundId(ProtoId<DamageTypePrototype> id)
+    {
+        return WoundTypeOverrides.GetValueOrDefault(id, id);
+    }
+
     public DamageSpecifier(float armorPenetration,
         float partVariation,
         Dictionary<ProtoId<DamageTypePrototype>, FixedPoint2> severityMultipliers)
@@ -42,6 +54,7 @@ public sealed partial class DamageSpecifier
         PartDamageVariation = src.PartDamageVariation;
         WoundSeverityMultipliers = new(src.WoundSeverityMultipliers);
         Flags = src.Flags;
+        WoundTypeOverrides = new(src.WoundTypeOverrides);
     }
 
     /// <summary>

--- a/Content.Goobstation.Common/CCVar/CCVars.Goob.cs
+++ b/Content.Goobstation.Common/CCVar/CCVars.Goob.cs
@@ -423,7 +423,7 @@ public sealed partial class GoobCVars
     /// Applies to Brute and Burn damage
     /// </summary>
     public static readonly CVarDef<float> ExplosionWoundMultiplier =
-        CVarDef.Create("explosion.wounding_multiplier", 8f, CVar.SERVERONLY);
+        CVarDef.Create("explosion.wounding_multiplier", 2f, CVar.SERVERONLY);
 
     #endregion
 

--- a/Content.Medical.Shared/Traumas/Components/TraumaInflicterComponent.cs
+++ b/Content.Medical.Shared/Traumas/Components/TraumaInflicterComponent.cs
@@ -16,6 +16,12 @@ public sealed partial class TraumaInflicterComponent : Component
     public FixedPoint2 SeverityThreshold = 9f;
 
     /// <summary>
+    /// If wound severity difference pre and post wound inflicting is less then this, traumas won't be applied
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 MinTraumaSeverityDelta = 10f;
+
+    /// <summary>
     /// The container where all the traumas are stored
     /// </summary>
     [ViewVariables(VVAccess.ReadOnly)]

--- a/Content.Medical.Shared/Traumas/Systems/TraumaSystem.Process.cs
+++ b/Content.Medical.Shared/Traumas/Systems/TraumaSystem.Process.cs
@@ -296,15 +296,18 @@ public partial class TraumaSystem
         if (!Resolve(target, ref woundable, false))
             return traumaList;
 
-        if (severity > 10 && woundInflicter.Comp.AllowedTraumas.Contains(TraumaType.BoneDamage) &&
+        if (severity < woundInflicter.Comp.MinTraumaSeverityDelta)
+            return traumaList;
+
+        if (woundInflicter.Comp.AllowedTraumas.Contains(TraumaType.BoneDamage) &&
             RandomBoneTraumaChance((target, woundable), woundInflicter))
             traumaList.Add(TraumaType.BoneDamage);
 
-        if (severity > 10 && woundInflicter.Comp.AllowedTraumas.Contains(TraumaType.Dismemberment) &&
+        if (woundInflicter.Comp.AllowedTraumas.Contains(TraumaType.Dismemberment) &&
             RandomDismembermentTraumaChance((target, woundable), woundInflicter))
             traumaList.Add(TraumaType.Dismemberment);
 
-        if (severity > 15 && woundInflicter.Comp.AllowedTraumas.Contains(TraumaType.OrganDamage) &&
+        if (woundInflicter.Comp.AllowedTraumas.Contains(TraumaType.OrganDamage) &&
             RandomOrganTraumaChance((target, woundable), woundInflicter))
             traumaList.Add(TraumaType.OrganDamage);
 
@@ -475,8 +478,7 @@ public partial class TraumaSystem
             _part.GetPartType(target.Owner) is not {} partType ||
             // can't dismember the root part
             !target.Comp.CanRemove ||
-            target.Comp.ParentWoundable is not {} parent ||
-            target.Comp.WoundableSeverity != WoundableSeverity.Mangled) // has to be mangled before possibly dismembering
+            target.Comp.ParentWoundable == null)
             return false;
 
         var deduction = GetTraumaChanceDeduction(

--- a/Content.Medical.Shared/Wounds/Systems/WoundSystem.Wounding.cs
+++ b/Content.Medical.Shared/Wounds/Systems/WoundSystem.Wounding.cs
@@ -218,11 +218,12 @@ public sealed partial class WoundSystem
                     continue;
 
                 TryInduceWound(uid,
-                    damageType,
+                    args.Damage.GetWoundId(damageType),
                     damageValue *
                     args.Damage.WoundSeverityMultipliers.GetValueOrDefault(damageType, 1),
                     out _,
-                    component);
+                    component,
+                    damageType: damageType);
             }
         }
 
@@ -294,7 +295,8 @@ public sealed partial class WoundSystem
         FixedPoint2 severity,
         [NotNullWhen(true)] out Entity<WoundComponent>? woundInduced,
         WoundableComponent? woundable = null,
-        ProtoId<DamageGroupPrototype>? damageGroup = null)
+        ProtoId<DamageGroupPrototype>? damageGroup = null,
+        string? damageType = null)
     {
         woundInduced = null;
         if (severity == FixedPoint2.Zero || !Resolve(uid, ref woundable))
@@ -303,9 +305,10 @@ public sealed partial class WoundSystem
         if (TryContinueWound(uid, woundId, severity, out woundInduced, woundable))
             return true;
 
+        damageType ??= woundId;
         var protoId = damageGroup?.Id ??
             (from @group in ProtoMan.EnumeratePrototypes<DamageGroupPrototype>()
-                where @group.DamageTypes.Contains(woundId)
+                where @group.DamageTypes.Contains(damageType)
                 select @group).FirstOrDefault()?.ID;
 
         var wound = protoId != null && TryCreateWound(
@@ -804,7 +807,7 @@ public sealed partial class WoundSystem
             wound,
             bodySeverity - (total - old),
             bodySeverity);
-        RaiseLocalEvent(body, ref ev);
+        RaiseLocalEvent(body, ref bodyEv);
     }
 
     private void DropWoundableOrgans(EntityUid woundable, WoundableComponent? woundableComp)

--- a/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
@@ -2,6 +2,7 @@
 using Content.Goobstation.Common.Atmos;
 using Content.Medical.Common.Targeting;
 using Content.Shared.Atmos.Components;
+using Content.Shared.Body;
 using Content.Trauma.Common.Wizard;
 // </Trauma>
 using System.Diagnostics.CodeAnalysis;
@@ -24,6 +25,7 @@ namespace Content.Server.Atmos.EntitySystems
         // <Trauma>
         [Dependency] private CommonSpellbladeSystem _spellblade = default!;
         [Dependency] private SharedContainerSystem _container = default!;
+        [Dependency] private BodySystem _body = default!;
         // </Trauma>
         [Dependency] private AtmosphereSystem _atmosphereSystem = default!;
         [Dependency] private DamageableSystem _damageableSystem = default!;
@@ -279,7 +281,7 @@ namespace Content.Server.Atmos.EntitySystems
                 if (pressure <= Atmospherics.HazardLowPressure)
                 {
                     // Deal damage and ignore resistances. Resistance to pressure damage should be done via pressure protection gear.
-                    _damageableSystem.TryChangeDamage(uid, barotrauma.Damage * Atmospherics.LowPressureDamage, true, false, targetPart: TargetBodyPart.All); // Shitmed Change
+                    _damageableSystem.TryChangeDamage(uid, barotrauma.Damage * Atmospherics.LowPressureDamage * _body.GetVitalBodyPartRatio(uid), true, false, targetPart: TargetBodyPart.All); // Shitmed Change
 
                     if (!barotrauma.TakingDamage)
                     {
@@ -294,7 +296,7 @@ namespace Content.Server.Atmos.EntitySystems
                     var damageScale = MathF.Min(((pressure / Atmospherics.HazardHighPressure) - 1) * Atmospherics.PressureDamageCoefficient, Atmospherics.MaxHighPressureDamage);
 
                     // Deal damage and ignore resistances. Resistance to pressure damage should be done via pressure protection gear.
-                    _damageableSystem.TryChangeDamage(uid, barotrauma.Damage * damageScale, true, false, targetPart: TargetBodyPart.All); // Shitmed Change
+                    _damageableSystem.TryChangeDamage(uid, barotrauma.Damage * damageScale * _body.GetVitalBodyPartRatio(uid), true, false, targetPart: TargetBodyPart.All); // Shitmed Change
 
                     if (!barotrauma.TakingDamage)
                     {

--- a/Content.Shared/CCVar/CCVars.Playtest.cs
+++ b/Content.Shared/CCVar/CCVars.Playtest.cs
@@ -75,7 +75,7 @@ public sealed partial class CCVars
         /// </summary>
         [CVarControl(AdminFlags.VarEdit)]
         public static readonly CVarDef<float> PlaytestExplosionDamageModifier =
-            CVarDef.Create("playtest.explosion_damage_modifier", 0.5f, CVar.SERVER | CVar.REPLICATED); // Gppb edit
+            CVarDef.Create("playtest.explosion_damage_modifier", 0.3f, CVar.SERVER | CVar.REPLICATED); // Trauma - was 1
 
         /// <summary>
         ///     Scales the damage dealt to mobs in the game (i.e. entities with MobStateComponent).

--- a/Content.Shared/CCVar/CCVars.Playtest.cs
+++ b/Content.Shared/CCVar/CCVars.Playtest.cs
@@ -75,7 +75,7 @@ public sealed partial class CCVars
         /// </summary>
         [CVarControl(AdminFlags.VarEdit)]
         public static readonly CVarDef<float> PlaytestExplosionDamageModifier =
-            CVarDef.Create("playtest.explosion_damage_modifier", 0.3f, CVar.SERVER | CVar.REPLICATED); // Trauma - was 1
+            CVarDef.Create("playtest.explosion_damage_modifier", 1f, CVar.SERVER | CVar.REPLICATED);
 
         /// <summary>
         ///     Scales the damage dealt to mobs in the game (i.e. entities with MobStateComponent).

--- a/Resources/ConfigPresets/_Trauma/trauma.toml
+++ b/Resources/ConfigPresets/_Trauma/trauma.toml
@@ -23,3 +23,6 @@ high_log_playtime = 2 # this kills the raider
 [afk]
 time = 1500 # 25m
 confirm_timeout = 90 # 1.5m
+
+[playtest]
+explosion_damage_modifier = 0.3

--- a/Resources/Prototypes/Body/Species/moth.yml
+++ b/Resources/Prototypes/Body/Species/moth.yml
@@ -192,7 +192,7 @@
   - type: Flammable
     damage:
       types:
-        Heat: 0.25 # Trauma, was 2.5
+        Heat: 0.5 # Trauma, was 2.5 - 0.2x multiplier to compensate for limb damage
   - type: Temperature
     currentTemperature: 310.15
     specificHeat: 46

--- a/Resources/Prototypes/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/base.yml
@@ -239,7 +239,7 @@
     canResistFire: true
     damage: #per second, scales with number of fire 'stacks'
       types:
-        Heat: 0.1 # Trauma, 10% fire damage to fix issues with limb damage, was 1.5
+        Heat: 0.3 # Trauma, was 1.5 - 0.2x multiplier to compensate for limb damage
   - type: FireVisuals
     sprite: Mobs/Effects/onfire.rsi
     normalState: Generic_mob_burning

--- a/Resources/Prototypes/_Goobstation/explosions.yml
+++ b/Resources/Prototypes/_Goobstation/explosions.yml
@@ -7,7 +7,13 @@
       Radiation: 5
       Heat: 4
       Blunt: 3
+      Piercing: 3
       Slash: 3
+    woundTypeOverrides: &woundoverrides
+      Heat: Burns
+      Blunt: Fracture
+      Slash: Laceration
+      Piercing: Puncture
   tileBreakChance: [0, 0.5, 1]
   tileBreakIntensity: [0, 10, 30]
   tileBreakRerollReduction: 20
@@ -22,6 +28,7 @@
     types:
       Heat: 3
       Blunt: 5
+    woundTypeOverrides: *woundoverrides
   tileBreakChance: [0, 0.5, 1]
   tileBreakIntensity: [0, 10, 30]
   tileBreakRerollReduction: 20
@@ -64,7 +71,8 @@
     types:
       Heat: 1
       Blunt: 2
-      Slash: 3
+      Piercing: 3
+    woundTypeOverrides: *woundoverrides
   lightColor: Orange
   texturePath: /Textures/Effects/fire.rsi
   fireStates: 6
@@ -76,8 +84,10 @@
     types:
       Heat: 4
       Blunt: 7
+      Piercing: 4
       Slash: 4
       Holy: 10
+    woundTypeOverrides: *woundoverrides
   tileBreakChance: [0, 0.5, 1]
   tileBreakIntensity: [0, 10, 30]
   tileBreakRerollReduction: 20
@@ -102,7 +112,9 @@
     types:
       Heat: 3
       Blunt: 2
+      Piercing: 2
       Slash: 2
+    woundTypeOverrides: *woundoverrides
   lightColor: Orange
   texturePath: /Textures/Effects/fire.rsi
   fireStates: 8

--- a/Resources/Prototypes/_Shitmed/Entities/Surgery/wounds.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Surgery/wounds.yml
@@ -42,6 +42,21 @@
       BoneDamage: 1
 
 - type: entity
+  parent: Blunt
+  id: Fracture
+  name: fracture
+  components:
+  - type: TraumaInflicter
+    minTraumaSeverityDelta: 0
+    traumasChances:
+      Dismemberment: -1.5
+      OrganDamage: 0.2
+      BoneDamage: 0.9
+      VeinsDamage: 0
+    mangledMultipliers:
+      BoneDamage: 1.2
+
+- type: entity
   id: Piercing
   parent: WoundBase
   components:
@@ -73,6 +88,24 @@
   - type: BleedInflicter
     severityThreshold: 9
     scalingSpeed: 0.5
+
+- type: entity
+  parent: Piercing
+  id: Puncture
+  name: puncture
+  components:
+  - type: TraumaInflicter
+    minTraumaSeverityDelta: 0
+    traumasChances:
+      Dismemberment: -1.5
+      OrganDamage: 0.12
+      BoneDamage: 0.2
+      VeinsDamage: -0.2
+    mangledMultipliers:
+      BoneDamage: 0.2
+  - type: BleedInflicter
+    severityThreshold: 0
+    scalingSpeed: 0.8
 
 - type: entity
   parent: Piercing
@@ -138,6 +171,23 @@
     scalingSpeed: 1.7
 
 - type: entity
+  parent: Slash
+  id: Laceration
+  name: laceration
+  components:
+  - type: TraumaInflicter
+    minTraumaSeverityDelta: 0
+    traumasChances:
+      Dismemberment: 0.35
+      OrganDamage: 0
+      BoneDamage: 0
+      VeinsDamage: 0.4
+    mangledMultipliers:
+      BoneDamage: 0.3
+  - type: BleedInflicter
+    scalingSpeed: 2
+
+- type: entity
   id: Heat
   parent: WoundBase
   components:
@@ -163,6 +213,19 @@
       VeinsDamage: 0.34
   - type: BleedRemover
     severityThreshold: 3
+
+- type: entity
+  parent: Heat
+  id: Burns
+  name: burns
+  components:
+  - type: TraumaInflicter
+    minTraumaSeverityDelta: 0
+    traumasChances:
+      Dismemberment: 0
+      OrganDamage: -0.1
+      BoneDamage: -0.16
+      VeinsDamage: 0.45
 
 - type: entity
   id: Ion

--- a/Resources/Prototypes/_Trauma/Entities/Objects/Weapons/Melee/improv.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Objects/Weapons/Melee/improv.yml
@@ -290,8 +290,8 @@
     initialBeepDelay: 0
     beepSound: /Audio/Effects/lightburn.ogg
   - type: RandomTimerTrigger
-    min: 3
-    max: 5
+    min: 5
+    max: 8
   - type: ExplodeOnTrigger
     keysIn:
     - timer

--- a/Resources/Prototypes/_Trauma/Recipes/Reactions/single_reagent.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Reactions/single_reagent.yml
@@ -11,12 +11,12 @@
   products:
     Ash: 0.1
   effects:
-    - !type:Explosion
-      explosionType: DemolitionCharge #Better at breaking walls and stuff
-      maxIntensity: 50
-      intensityPerUnit: 7 # RDX's RE factor is 1.6 of tnt
-      intensitySlope: 20 # more controlled explosion
-      maxTotalIntensity: 700
+  - !type:Explosion
+    explosionType: DemolitionCharge #Better at breaking walls and stuff
+    maxIntensity: 15
+    intensityPerUnit: 1 # RDX's RE factor is 1.6 of tnt
+    intensitySlope: 3 # more controlled explosion
+    maxTotalIntensity: 100
 
 - type: reaction
   id: AmmoniumNitrateDecomposition
@@ -51,12 +51,12 @@
   products:
     Ash: 0.1
   effects:
-    - !type:Explosion
-      explosionType: DemolitionCharge #ANFO is used in mining
-      maxIntensity: 12
-      intensityPerUnit: 3 # you need a lot of it for a large explosion
-      intensitySlope: 1
-      maxTotalIntensity: 3000 # max explosion requires 5000 units which is A LOT
+  - !type:Explosion
+    explosionType: DemolitionCharge #ANFO is used in mining
+    maxIntensity: 15
+    intensityPerUnit: 1 # you need a lot of it for a large explosion
+    intensitySlope: 1
+    maxTotalIntensity: 100
 
 - type: reaction
   id: VinegarDecomposition
@@ -79,9 +79,9 @@
   products:
     Ash: 0.1
   effects:
-    - !type:Explosion
-      explosionType: HardBomb # very high detonation velocity
-      maxIntensity: 20
-      intensityPerUnit: 3 # Lower because hardbomb
-      intensitySlope: 2 # very high detonation velocity
-      maxTotalIntensity: 3000 # very high detonation velocity # this sounds horrifying, but we'll just have to see whether it should be tweaked - Speebro
+  - !type:Explosion
+    explosionType: HardBomb # very high detonation velocity
+    maxIntensity: 8
+    intensityPerUnit: 1 # Lower because hardbomb
+    intensitySlope: 0.5 # very high detonation velocity
+    maxTotalIntensity: 100

--- a/Resources/Prototypes/explosion.yml
+++ b/Resources/Prototypes/explosion.yml
@@ -4,7 +4,15 @@
     types:
       Heat: 5
       Blunt: 5
-      Slash: 5 # Goob edit
+      Piercing: 5
+    # <Trauma>
+      Slash: 5
+    woundTypeOverrides: &woundoverrides
+      Heat: Burns
+      Blunt: Fracture
+      Slash: Laceration
+      Piercing: Puncture
+    # </Trauma>
   tileBreakChance: [0, 0.5, 1]
   tileBreakIntensity: [0, 10, 30]
   tileBreakRerollReduction: 20
@@ -19,8 +27,12 @@
     types:
       Heat: 3
       Blunt: 3
-      Slash: 3 # Goob edit
+      Piercing: 3
       Structural: 50
+    # <Trauma>
+      Slash: 3
+    woundTypeOverrides: *woundoverrides
+    # </Trauma>
   tileBreakChance: [ 0, 0.5, 1 ]
   tileBreakIntensity: [ 0, 10, 30 ]
   tileBreakRerollReduction: 20
@@ -35,8 +47,12 @@
     types:
       Heat: 6
       Blunt: 6
-      Slash: 6 # Goob edit
+      Piercing: 6
       Structural: 20
+    # <Trauma>
+      Slash: 6
+    woundTypeOverrides: *woundoverrides
+    # </Trauma>
   tileBreakChance: [ 0, 0.5, 1 ]
   tileBreakIntensity: [ 1, 10, 15 ]
   tileBreakRerollReduction: 30
@@ -53,7 +69,11 @@
       Radiation: 5
       Heat: 4
       Blunt: 3
-      Slash: 3 # Goob edit
+      Piercing: 3
+    # <Trauma>
+      Slash: 3
+    woundTypeOverrides: *woundoverrides
+    # </Trauma>
   lightColor: Green
   fireColor: Green
   texturePath: /Textures/Effects/fire_greyscale.rsi
@@ -66,6 +86,7 @@
       Cold: 5
       Blunt: 2
       Structural: 20
+    woundTypeOverrides: *woundoverrides # Trauma
   tileBreakChance: [0]
   tileBreakIntensity: [0]
   lightColor: Blue
@@ -77,9 +98,13 @@
   id: Minibomb
   damagePerIntensity:
     types:
-      Heat: 8 # Goob edit
-      Blunt: 14 # Goob edit
-      Slash: 8 # Goob edit
+    # <Trauma>
+      Heat: 4
+      Blunt: 32
+      Piercing: 4
+      Slash: 4
+    woundTypeOverrides: *woundoverrides
+    # </Trauma>
   tileBreakChance: [0, 0.5, 1]
   tileBreakIntensity: [0, 10, 30]
   tileBreakRerollReduction: 20
@@ -92,10 +117,14 @@
   id: PowerSink
   damagePerIntensity:
     types:
-      Heat: 24 # Goob edit
-      Blunt: 24 # Goob edit
-      Slash: 24 # Goob edit
+    # <Trauma>
+      Heat: 24
+      Blunt: 24
+      Piercing: 24
       Structural: 30
+      Slash: 24
+    woundTypeOverrides: *woundoverrides
+    # </Trauma>
   tileBreakChance: [ 0, 0.5, 1 ]
   tileBreakIntensity: [ 1, 5, 10 ]
   tileBreakRerollReduction: 3
@@ -109,10 +138,14 @@
   id: HardBomb
   damagePerIntensity:
     types:
-      Heat: 30 # Goob edit
-      Blunt: 30 # Goob edit
-      Slash: 12 # Goob edit
+    # <Trauma>
+      Heat: 30
+      Blunt: 30
+      Piercing: 12
       Structural: 40
+      Slash: 12
+    woundTypeOverrides: *woundoverrides
+    # </Trauma>
   tileBreakChance: [ 0, 0.5, 1 ]
   tileBreakIntensity: [ 0, 10, 30 ]
   tileBreakRerollReduction: 10
@@ -129,6 +162,7 @@
       Heat: 1
       Blunt: 2
       Piercing: 3
+    woundTypeOverrides: *woundoverrides # Trauma
   lightColor: Orange
   texturePath: /Textures/Effects/fire.rsi
   fireStates: 3


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->

Buffed fires since they did basically nothing. Fire should be scary, but not too scary. Now it's 20% of upstream values to account for limbs.
Barotrauma now takes into accound your vital/non vital limb ratio, making it scarier. Space should be deadly.
Explosions tweaked significantly. Added new option for wounds to ignore woundable severity before applying traumas, explosions now use "upgraded" wounds that have this value set to 0, basically delimbing for explosives is more consistent now. Also removed mangled requirement for dismemberment, otherwise it wouldn't work. Also made explosions deal full brute damage, compensating by tuning down global multipliers for explosions. Basically, you can survive pipe bomb now! And you have a chance of not losing any limbs. Octogen and similar slop nerfed significantly, no reason for crew to have access to instagib chems.
Firebomb and pipe bomb spears were given higher timer to explode, should be more room to remove spear in combat.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Explosions too strong, fire and spacing too weak.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

Tested in devenv by exploding things. Explosions do work.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Aviu
- tweak: Fire and barotrauma buffed, explosions nerfed.