### PR TITLE
Fix chudshifts

### DIFF
--- a/Content.Server/Antag/AntagSelectionSystem.API.Assignment.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.API.Assignment.cs
@@ -178,8 +178,10 @@ public sealed partial class AntagSelectionSystem
         if (!_whitelist.CheckBoth(uid, def.Blacklist, def.Whitelist))
             return false;
 
+        /* <Trauma> - station trait that spawns everyone on arrivals exists
         if (_arrivals.IsOnArrivals((uid.Value, null)))
             return false;
+        </Trauma> */
 
         // No ghosts!!!
         if (HasComp<GhostComponent>(uid))


### PR DESCRIPTION
Fixes #3571

Station trait that spawns everyone on arrivals fails the check in antag selection system that checks if people are not on arrivals.

:cl:
- fix: Fixed Late Arrivals station trait preventing antags from rolling.