### PR TITLE
make armory override key stack based

### DIFF
--- a/Content.Trauma.Shared/Construction/Conditions/StackCountCondition.cs
+++ b/Content.Trauma.Shared/Construction/Conditions/StackCountCondition.cs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Shared.Construction;
+using Content.Shared.Examine;
+using Content.Shared.Stacks;
+
+namespace Content.Trauma.Shared.Construction.Conditions;
+
+/// <summary>
+/// Requires that a stack entity has a certain number of items.
+/// </summary>
+public sealed partial class StackCountCondition : IGraphCondition
+{
+    [DataField(required: true)]
+    public int Count;
+
+    public bool Condition(EntityUid uid, IEntityManager entMan)
+        => entMan.System<SharedStackSystem>().GetCount(uid) == Count;
+
+    public bool DoExamine(ExaminedEvent args)
+    {
+        var entity = args.Examined;
+
+        var entMan = IoCManager.Resolve<IEntityManager>();
+        var stackSys = entMan.System<SharedStackSystem>();
+        var count = stackSys.GetCount(entity);
+        if (count == Count)
+            return false;
+
+        var diff = Math.Abs(count - Count);
+        var word = diff == 1 ? "piece" : "pieces";
+        args.PushMarkup(count < Count
+            ? $"You need {diff} more {word}\n"
+            : $"You need to remove {diff} {word} from it\n");
+        return true;
+    }
+
+    public IEnumerable<ConstructionGuideEntry> GenerateGuideEntry()
+    {
+        yield return new ConstructionGuideEntry()
+        {
+            Localization = "construction-guide-condition-stack-count",
+            Arguments = new (string, object)[]
+            {
+                ("count", Count)
+            }
+        };
+    }
+}

--- a/Resources/Locale/en-US/_Trauma/construction/conditions/stack-count.ftl
+++ b/Resources/Locale/en-US/_Trauma/construction/conditions/stack-count.ftl
@@ -1,0 +1,1 @@
+construction-guide-condition-stack-count = Collect {$count} pieces

--- a/Resources/Locale/en-US/_Trauma/stack/stacks.ftl
+++ b/Resources/Locale/en-US/_Trauma/stack/stacks.ftl
@@ -13,3 +13,4 @@ stack-rev-ball-bearings = ball bearings
 stack-rev-engine-parts = engine parts
 stack-whetstone = whetstone
 stack-drillhead = drill head
+stack-override-key-components = override key components

--- a/Resources/Prototypes/_Trauma/Entities/Objects/Tools/armoryoverridekey.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Objects/Tools/armoryoverridekey.yml
@@ -1,7 +1,21 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 - type: entity
-  parent: [BaseItem, BaseCommandContraband]
+  abstract: true
+  parent: [ BaseItem, BaseCommandContraband ]
+  id: BaseArmoryOverrideItem
+  components:
+  - type: Sprite
+    sprite: _Goobstation/Objects/Misc/ntr_override.rsi
+    state: icon
+  - type: Item
+    sprite: _Goobstation/Objects/Misc/ntr_override.rsi
+    size: Tiny
+  - type: Construction
+    graph: ArmoryOverrideKey
+
+- type: entity
+  parent: BaseArmoryOverrideItem
   id: ArmoryOverrideKey
   name: armory override key
   description: A device for overridding the armory alert level locks in dire situations.
@@ -12,33 +26,20 @@
     whitelist:
       components:
       - StationAlertLevelLock # basically jsut gun safes
-  - type: Sprite
-    sprite: _Goobstation/Objects/Misc/ntr_override.rsi
-    state: icon
-  - type: Item
-    sprite: _Goobstation/Objects/Misc/ntr_override.rsi
-    size: Tiny
   - type: LimitedCharges
     maxCharges: 6
   - type: Construction
-    graph: ArmoryOverrideKey
     node: finished
 
 - type: entity
-  parent: [BaseItem, BaseCommandContraband]
+  parent: BaseArmoryOverrideItem
   id: ArmoryOverrideKeyComponents
   name: armory override key components
   description: Part of the armory override device, keep it close and do not give it away unless its an absolute emergency.
   components:
-  - type: Sprite
-    sprite: _Trauma/Objects/Tools/overridecomponents.rsi
-    state: icon
-  - type: Item
-    size: Tiny
-    sprite: _Trauma/Objects/Tools/overridecomponents.rsi
-  - type: Tag
-    tags:
-    - OverrideKeyComponents
   - type: Construction
-    graph: ArmoryOverrideKey
     node: start
+    defaultTarget: finished
+  - type: Stack
+    count: 1
+    stackType: OverrideKeyComponents

--- a/Resources/Prototypes/_Trauma/Recipes/Crafting/Graphs/other.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Crafting/Graphs/other.yml
@@ -2,7 +2,6 @@
 
 - type: constructionGraph
   id: SheetPaper
-  start: start
   graph:
   - node: start
     edges:
@@ -22,7 +21,6 @@
 
 - type: constructionGraph
   id: PowerArmorStand
-  start: start
   graph:
   - node: start
     entity: RevPowerArmorStand
@@ -38,32 +36,23 @@
 
 - type: constructionGraph
   id: ArmoryOverrideKey
-  start: start
   graph:
   - node: start
     entity: ArmoryOverrideKeyComponents
     edges:
     - to: finished
+      conditions:
+      - !type:StackCountCondition
+        count: 3
       steps:
-      - tag: OverrideKeyComponents
+      - tool: Screwing
         doAfter: 5
-        name: construction-graph-tag-overridekeycomponents
-        icon:
-          sprite: _Trauma/Objects/Tools/overridecomponents.rsi
-          state: icon
-      - tag: OverrideKeyComponents
-        doAfter: 5
-        name: construction-graph-tag-overridekeycomponents
-        icon:
-          sprite: _Trauma/Objects/Tools/overridecomponents.rsi
-          state: icon
 
   - node: finished
     entity: ArmoryOverrideKey
 
 - type: constructionGraph
   id: Bracing
-  start: start
   graph:
   - node: start
     edges:
@@ -81,7 +70,6 @@
 
 - type: constructionGraph
   id: Whetstone
-  start: start
   graph:
   - node: start
     edges:
@@ -125,7 +113,6 @@
 
 - type: constructionGraph
   id: TripWire
-  start: start
   graph:
   - node: start
     edges:
@@ -159,7 +146,6 @@
 
 - type: constructionGraph
   id: PipeBombTrap
-  start: start
   graph:
   - node: start
     edges:

--- a/Resources/Prototypes/_Trauma/Stacks/misc.yml
+++ b/Resources/Prototypes/_Trauma/Stacks/misc.yml
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+- type: stack
+  parent: BaseTinyStack
+  id: OverrideKeyComponents
+  name: stack-override-key-components
+  icon: { sprite: /Textures/_Trauma/Objects/Tools/overridecomponents.rsi, state: icon }
+  spawn: ArmoryOverrideKeyComponents
+  maxCount: 3

--- a/Resources/Prototypes/_Trauma/tags.yml
+++ b/Resources/Prototypes/_Trauma/tags.yml
@@ -165,8 +165,7 @@
 
 ## O ##
 
-- type: Tag
-  id: OverrideKeyComponents # Construction: ArmoryOverrideKey
+# :o nothing
 
 ## P ##
 


### PR DESCRIPTION
fixes #3565 

they now stack up to 3 items, you have to use a screwdriver to turn it into a key

you cant just delete them anymore by adding 2-key stage item to a 1-key one to eat a key

## Media
<img width="376" height="189" alt="14:22:26" src="https://github.com/user-attachments/assets/14c7c402-e4cf-4c7c-ad8c-84bf30c333f8" />
<img width="389" height="212" alt="14:22:14" src="https://github.com/user-attachments/assets/c9cc6e13-8ad0-4639-8f70-dde3edf5c918" />
<img width="254" height="103" alt="14:22:09" src="https://github.com/user-attachments/assets/9924866e-ab59-4efd-920e-16f61bb50d28" />
<img width="395" height="278" alt="14:22:02" src="https://github.com/user-attachments/assets/889f242a-0f0f-4b39-96da-9ecaed4350ff" />


## Changelog
:cl:
- tweak: Armory override key now needs a screwdriver to make