### PR TITLE
remove tile movement trait

### DIFF
--- a/Resources/Locale/en-US/_Goobstation/traits/traits.ftl
+++ b/Resources/Locale/en-US/_Goobstation/traits/traits.ftl
@@ -1,14 +1,3 @@
-# SPDX-FileCopyrightText: 2024 lanse12 <cloudability.ez@gmail.com>
-# SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 Aiden <aiden@djkraz.com>
-# SPDX-FileCopyrightText: 2025 Piras314 <p1r4s@proton.me>
-# SPDX-FileCopyrightText: 2025 Rouge2t7 <81053047+Sarahon@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
-# SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 smudge <138918973+Cerise-Cattowo@users.noreply.github.com>
-#
-# SPDX-License-Identifier: AGPL-3.0-or-later
-
 trait-scottish-name = Scottish accent
 trait-scottish-desc = Your scottish pride is as strong as your accent!
 
@@ -22,8 +11,6 @@ poor-vision-trait-examined = [color=lightblue]{CAPITALIZE(POSS-ADJ($target))} ey
 
 trait-medieval-accent-name = Medieval accent
 trait-medieval-accent-desc = Hark! Thy manner o' speech, 'tis most unusual!
-trait-tile-movement-name = Inner peace
-trait-tile-movement-desc = You are always in touch with your roots. And by your roots, I mean the center of the tile you're standing on.
 
 trait-movement-impaired-name = Movement Impaired
 trait-movement-impaired-desc = You can't quite seem to walk very well without some assistance. Cane included.

--- a/Resources/Prototypes/_Goobstation/Traits/disabilities.yml
+++ b/Resources/Prototypes/_Goobstation/Traits/disabilities.yml
@@ -14,14 +14,6 @@
   - type: LegsParalyzed
 
 - type: trait
-  id: ByondYourPrime
-  name: trait-tile-movement-name
-  description: trait-tile-movement-desc
-  category: Disabilities
-  components:
-  - type: TileMovement
-
-- type: trait
   id: SocialAnxietyTrait
   name: trait-social-anxiety-name
   description: trait-social-anxiety-disc

--- a/Resources/ServerInfo/_Goobstation/Guidebook/Antagonist/DevilClauses.xml
+++ b/Resources/ServerInfo/_Goobstation/Guidebook/Antagonist/DevilClauses.xml
@@ -14,14 +14,6 @@
   - Cuts all damage the contractee takes in half.
   - Increases holy damage taken.
 
-<!-- Disabled, Used by shitters  ## Avarice
-  <Box>
-    [color=#999999][italic]-30 Weight[/italic][/color]
-  </Box>
-
-  - Allows the contractee to devour things whole, just like a dragon.
-  -->
-
   ## Fear of Death
   <Box>
     [color=#999999][italic]-25 Weight[/italic][/color]


### PR DESCRIPTION
- you just straight up move faster
- vehicles are even stronger, it completely removes the clown car crashing downside
- see #3567 lots of systems cant cope with it

still exists from heirophant devil etc

:cl: EN wizards den lizard US west
- remove: Removed the Inner Peace trait.