### PR TITLE
tweaked xeno wincon (again)

### DIFF
--- a/Content.Trauma.Server/GameTicking/Rules/Components/XenomorphsRuleComponent.cs
+++ b/Content.Trauma.Server/GameTicking/Rules/Components/XenomorphsRuleComponent.cs
@@ -78,7 +78,7 @@ public sealed partial class XenomorphsRuleComponent : Component
     #region RoundEnd
 
     [DataField]
-    public float XenomorphsShuttleCallPercentage = 0.7f;
+    public float XenomorphsShuttleCallPercentage = 0.5f;
 
     [DataField]
     public TimeSpan ShuttleCallTime = TimeSpan.FromMinutes(5);


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->
70% -> 50%
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
takes way too long for xenos to win, good middleground
## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [ ] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [ ] I have tested this pull request and written instructions on how to test it
- [ ] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
--> 🆑 assripper.

 - tweak: xenomorphs must make up 50% of alive crew to win (decreased from 70%)
