### PR TITLE
lathe automation supports circuits

### DIFF
--- a/Content.Goobstation.Server/Lathe/LatheAutomationComponent.cs
+++ b/Content.Goobstation.Server/Lathe/LatheAutomationComponent.cs
@@ -6,8 +6,8 @@ using Content.Shared.Research.Prototypes;
 namespace Content.Goobstation.Server.Lathe;
 
 /// <summary>
-/// Lets a lathe produce the last made recipe, controlled by signal port.
-/// The port must be added by something else e.g. AutomationSlots
+/// Lets a lathe produce the last made recipe, controlled by signal ports.
+/// The ports must be added by something else e.g. AutomationSlots
 /// </summary>
 [RegisterComponent, Access(typeof(LatheAutomationSystem))]
 public sealed partial class LatheAutomationComponent : Component
@@ -15,6 +15,21 @@ public sealed partial class LatheAutomationComponent : Component
     [ViewVariables]
     public LatheRecipePrototype? LastRecipe;
 
+    /// <summary>
+    /// How many times to try produce <see cref="LastRecipe"/> when <see cref="PrintPort"/> is invoked.
+    /// </summary>
+    [DataField]
+    public int Quantity = 1;
+
     [DataField]
     public ProtoId<SinkPortPrototype> PrintPort = "LathePrint";
+
+    [DataField]
+    public ProtoId<SinkPortPrototype> SetRecipePort = "LatheSetRecipe";
+
+    [DataField]
+    public ProtoId<SinkPortPrototype> QuantityPort = "LatheQuantity";
+
+    [DataField]
+    public ProtoId<SinkPortPrototype> CurrentRecipePort = "LatheCurrentRecipe";
 }

--- a/Content.Goobstation.Server/Lathe/LatheAutomationComponent.cs
+++ b/Content.Goobstation.Server/Lathe/LatheAutomationComponent.cs
@@ -31,5 +31,5 @@ public sealed partial class LatheAutomationComponent : Component
     public ProtoId<SinkPortPrototype> QuantityPort = "LatheQuantity";
 
     [DataField]
-    public ProtoId<SinkPortPrototype> CurrentRecipePort = "LatheCurrentRecipe";
+    public ProtoId<SourcePortPrototype> CurrentRecipePort = "LatheCurrentRecipe";
 }

--- a/Content.Goobstation.Server/Lathe/LatheAutomationSystem.cs
+++ b/Content.Goobstation.Server/Lathe/LatheAutomationSystem.cs
@@ -1,37 +1,68 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+using Content.Server.DeviceLinking.Systems;
 using Content.Server.Lathe;
 using Content.Shared.DeviceLinking.Events;
+using Content.Shared.DeviceNetwork;
 using Content.Shared.Lathe;
+using Content.Shared.Research.Prototypes;
 
 namespace Content.Goobstation.Server.Lathe;
 
 public sealed partial class LatheAutomationSystem : EntitySystem
 {
     [Dependency] private LatheSystem _lathe = default!;
+    [Dependency] private DeviceLinkSystem _device = default!;
 
-    public override void Initialize()
-    {
-        base.Initialize();
-
-        SubscribeLocalEvent<LatheAutomationComponent, LatheStartPrintingEvent>(OnStartPrinting);
-        SubscribeLocalEvent<LatheAutomationComponent, SignalReceivedEvent>(OnSignalReceived);
-    }
-
+    [SubscribeLocalEvent]
     private void OnStartPrinting(Entity<LatheAutomationComponent> ent, ref LatheStartPrintingEvent args)
     {
-        ent.Comp.LastRecipe = args.Recipe;
+        SetRecipe(ent, args.Recipe);
     }
 
+    [SubscribeLocalEvent]
     private void OnSignalReceived(Entity<LatheAutomationComponent> ent, ref SignalReceivedEvent args)
     {
-        if (args.Port != ent.Comp.PrintPort)
+        if (args.Port == ent.Comp.PrintPort)
+        {
+            if (ent.Comp.LastRecipe is not {} recipe)
+                return;
+
+            _lathe.TryAddToQueue(ent.Owner, recipe, quantity: ent.Comp.Quantity);
+            _lathe.TryStartProducing(ent.Owner); // Won't do anything otherwise
+        }
+        else if (args.Port == ent.Comp.SetRecipePort)
+        {
+            if (args.Data is not { } data ||
+                !data.TryGetValue<string>("logic_string", out var id))
+                return;
+
+            // invalid ids will reset it to null
+            // lathe system checks if the recipe is allowed on this lathe in CanProduce, don't need to check it here
+            ProtoMan.TryIndex<LatheRecipePrototype>(id, out var recipe);
+            SetRecipe(ent, recipe);
+        }
+        else if (args.Port == ent.Comp.QuantityPort)
+        {
+            if (args.Data is not { } data ||
+                !data.TryGetValue<int>("logic_int", out var quantity) ||
+                quantity < 1)
+                return;
+
+            ent.Comp.Quantity = quantity;
+        }
+    }
+
+    private void SetRecipe(Entity<LatheAutomationComponent> ent, LatheRecipePrototype recipe)
+    {
+        if (ent.Comp.LastRecipe == recipe)
             return;
 
-        if (ent.Comp.LastRecipe is not {} recipe)
-            return;
-
-        _lathe.TryAddToQueue(ent.Owner, recipe, quantity: 1);
-        _lathe.TryStartProducing(ent.Owner); // Won't do anything otherwise
+        ent.Comp.LastRecipe = recipe;
+        var payload = new NetworkPayload()
+        {
+            ["logic_string"] = recipe.ID
+        };
+        _device.InvokePort(ent.Owner, ent.Comp.CurrentRecipePort, payload);
     }
 }

--- a/Content.Goobstation.Server/Lathe/LatheAutomationSystem.cs
+++ b/Content.Goobstation.Server/Lathe/LatheAutomationSystem.cs
@@ -2,6 +2,7 @@
 
 using Content.Server.DeviceLinking.Systems;
 using Content.Server.Lathe;
+using Content.Shared.DeviceLinking;
 using Content.Shared.DeviceLinking.Events;
 using Content.Shared.DeviceNetwork;
 using Content.Shared.Lathe;

--- a/Content.Goobstation.Server/Lathe/LatheAutomationSystem.cs
+++ b/Content.Goobstation.Server/Lathe/LatheAutomationSystem.cs
@@ -31,7 +31,8 @@ public sealed partial class LatheAutomationSystem : EntitySystem
 
             // ignore low signals
             var state = SignalState.Momentary;
-            if (args.Data?.TryGetValue("logic_state", out state) && state == SignalState.Low)
+            args.Data?.TryGetValue("logic_state", out state);
+            if (state == SignalState.Low)
                 return;
 
             _lathe.TryAddToQueue(ent.Owner, recipe, quantity: ent.Comp.Quantity);

--- a/Content.Goobstation.Server/Lathe/LatheAutomationSystem.cs
+++ b/Content.Goobstation.Server/Lathe/LatheAutomationSystem.cs
@@ -28,6 +28,11 @@ public sealed partial class LatheAutomationSystem : EntitySystem
             if (ent.Comp.LastRecipe is not {} recipe)
                 return;
 
+            // ignore low signals
+            var state = SignalState.Momentary;
+            if (args.Data?.TryGetValue("logic_state", out state) && state == SignalState.Low)
+                return;
+
             _lathe.TryAddToQueue(ent.Owner, recipe, quantity: ent.Comp.Quantity);
             _lathe.TryStartProducing(ent.Owner); // Won't do anything otherwise
         }
@@ -53,7 +58,7 @@ public sealed partial class LatheAutomationSystem : EntitySystem
         }
     }
 
-    private void SetRecipe(Entity<LatheAutomationComponent> ent, LatheRecipePrototype recipe)
+    private void SetRecipe(Entity<LatheAutomationComponent> ent, LatheRecipePrototype? recipe)
     {
         if (ent.Comp.LastRecipe == recipe)
             return;
@@ -61,7 +66,7 @@ public sealed partial class LatheAutomationSystem : EntitySystem
         ent.Comp.LastRecipe = recipe;
         var payload = new NetworkPayload()
         {
-            ["logic_string"] = recipe.ID
+            ["logic_string"] = recipe?.ID ?? string.Empty
         };
         _device.InvokePort(ent.Owner, ent.Comp.CurrentRecipePort, payload);
     }

--- a/Content.Trauma.Server/Circuits/CircuitSystem.cs
+++ b/Content.Trauma.Server/Circuits/CircuitSystem.cs
@@ -35,6 +35,19 @@ public sealed partial class CircuitSystem : EntitySystem
         var query = EntityQueryEnumerator<ActiveCircuitComponent, CircuitComponent>();
         while (query.MoveNext(out var uid, out _, out var comp))
         {
+            // change any momentary pulses back to low since theyve been processed
+            for (var i = 0; i < comp.Inputs.Count; i++)
+            {
+                if (comp.Inputs[i] != Pulse.Instance)
+                    continue;
+
+                comp.Inputs[i] = False.Instance;
+                foreach (var input in comp.LinkedInputs[i])
+                {
+                    ValueChanged(comp, input, False.Instance);
+                }
+            }
+
             var changed = comp.Changed;
             if (changed.Count == 0)
                 return;
@@ -54,19 +67,6 @@ public sealed partial class CircuitSystem : EntitySystem
                 foreach (var output in gate.LinkedOutputs)
                 {
                     ValueChanged(comp, output, gate.Output);
-                }
-            }
-
-            // change any momentary pulses back to low since theyve been processed
-            for (var i = 0; i < comp.Inputs.Count; i++)
-            {
-                if (comp.Inputs[i] is not Pulse p)
-                    continue;
-
-                comp.Inputs[i] = False.Instance;
-                foreach (var input in comp.LinkedInputs[i])
-                {
-                    ValueChanged(comp, input, False.Instance);
                 }
             }
         }

--- a/Resources/Locale/en-US/_Trauma/machines/lathe.ftl
+++ b/Resources/Locale/en-US/_Trauma/machines/lathe.ftl
@@ -1,0 +1,8 @@
+signal-port-name-lathe-set-recipe = Set lathe recipe
+signal-port-description-lathe-set-recipe = Circuit port to set the current lathe recipe to a recipe prototype ID as a string.
+
+signal-port-name-lathe-current-recipe = Lathe recipe
+signal-port-description-lathe-current-recipe = Circuit port invoked with the current recipe prototype ID string, which will be used by automation.
+
+signal-port-name-lathe-quantity = Item quantity
+signal-port-description-lathe-quantity = Circuit port to set the next production count as an integer. Starts out as 1, lower values are ignored.

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -15,6 +15,10 @@
     - !type:AutomatedPorts
       sinks:
       - LathePrint
+      - LatheSetRecipe
+      - LatheQuantity
+      sources:
+      - LatheCurrentRecipe
   - type: LatheAutomation
   - type: DeviceNetwork
     deviceNetId: Wireless

--- a/Resources/Prototypes/_Trauma/DeviceLink/sink_ports.yml
+++ b/Resources/Prototypes/_Trauma/DeviceLink/sink_ports.yml
@@ -46,3 +46,16 @@
   id: Circuit8
   name: signal-port-name-circuit-8
   description: signal-port-description-circuit-input
+
+# Lathe
+
+
+- type: sinkPort
+  id: LatheSetRecipe
+  name: signal-port-name-lathe-set-recipe
+  description: signal-port-description-lathe-set-recipe
+
+- type: sinkPort
+  id: LatheQuantity
+  name: signal-port-name-lathe-quantity
+  description: signal-port-description-lathe-quantity

--- a/Resources/Prototypes/_Trauma/DeviceLink/source_ports.yml
+++ b/Resources/Prototypes/_Trauma/DeviceLink/source_ports.yml
@@ -87,3 +87,10 @@
   id: AccessJob
   name: signal-port-name-access-job
   description: signal-port-description-access-job
+
+# Lathe
+
+- type: sourcePort
+  id: LatheCurrentRecipe
+  name: signal-port-name-lathe-current-recipe
+  description: signal-port-description-lathe-current-recipe


### PR DESCRIPTION
- you can now change the recipe and production quantity via circuit ports
- current recipe is sent so you can find it out ingame without having to rtfsc for protoids (when debugging is added :trollface:)

## Media
<img width="610" height="190" alt="21:02:17" src="https://github.com/user-attachments/assets/3468483e-8a71-4644-a3af-841dae21144d" />


## Changelog
:cl:
- tweak: Lathes can now have their recipe and quantity changed by circuits.
- fix: Fixed circuits not handling pulse signals properly.