### PR TITLE
Acid Contact Damage Increase and Foam/Smoke tweaks

### DIFF
--- a/Resources/Prototypes/Reagents/fun.yml
+++ b/Resources/Prototypes/Reagents/fun.yml
@@ -180,7 +180,7 @@
   physicalDesc: reagent-physical-desc-reflective
   flavor: sharp
   color: "#e3fffb"
-  # <Trauma> 
+  # <Trauma>
   tileReactions:
     - !type:SpillTileReaction
   # <Trauma>

--- a/Resources/Prototypes/Reagents/fun.yml
+++ b/Resources/Prototypes/Reagents/fun.yml
@@ -180,7 +180,7 @@
   physicalDesc: reagent-physical-desc-reflective
   flavor: sharp
   color: "#e3fffb"
-  # </Trauma>
+  # <Trauma>
   tileReactions:
   - !type:SpillTileReaction
   # </Trauma>

--- a/Resources/Prototypes/Reagents/fun.yml
+++ b/Resources/Prototypes/Reagents/fun.yml
@@ -180,6 +180,10 @@
   physicalDesc: reagent-physical-desc-reflective
   flavor: sharp
   color: "#e3fffb"
+  # <Trauma> 
+  tileReactions:
+    - !type:SpillTileReaction
+  # <Trauma>
   reactiveEffects:
     Acidic:
       methods: [ Touch ]
@@ -188,7 +192,7 @@
         ignoreResistances: false
         damage:
           types:
-            Slash: 0.25
+            Slash: 0.75 # Trauma - Was 0.25
       - !type:Emote
         emote: Scream
         probability: 0.7

--- a/Resources/Prototypes/Reagents/fun.yml
+++ b/Resources/Prototypes/Reagents/fun.yml
@@ -180,10 +180,10 @@
   physicalDesc: reagent-physical-desc-reflective
   flavor: sharp
   color: "#e3fffb"
-  # <Trauma>
+  # </Trauma>
   tileReactions:
   - !type:SpillTileReaction
-  # <Trauma>
+  # </Trauma>
   reactiveEffects:
     Acidic:
       methods: [ Touch ]

--- a/Resources/Prototypes/Reagents/fun.yml
+++ b/Resources/Prototypes/Reagents/fun.yml
@@ -182,7 +182,7 @@
   color: "#e3fffb"
   # <Trauma>
   tileReactions:
-    - !type:SpillTileReaction
+  - !type:SpillTileReaction
   # <Trauma>
   reactiveEffects:
     Acidic:

--- a/Resources/Prototypes/Reagents/pyrotechnic.yml
+++ b/Resources/Prototypes/Reagents/pyrotechnic.yml
@@ -176,10 +176,10 @@
   meltingPoint: -80.7
   friction: 0.4
   tileReactions:
-  - !type:FlammableTileReaction {}
   # <Trauma>
   - !type:SpillTileReaction
   # <Trauma>
+  - !type:FlammableTileReaction {}
   metabolisms:
     Bloodstream:
       effects:

--- a/Resources/Prototypes/Reagents/pyrotechnic.yml
+++ b/Resources/Prototypes/Reagents/pyrotechnic.yml
@@ -118,6 +118,7 @@
       tags: [ TraumaFire ]
   - !type:FlammableTileReaction
     temperatureMultiplier: 5
+  - !type:SpillTileReaction
   # </Trauma>
   metabolisms:
     Bloodstream:
@@ -176,6 +177,9 @@
   friction: 0.4
   tileReactions:
   - !type:FlammableTileReaction {}
+  # <Trauma>
+  - !type:SpillTileReaction
+  # <Trauma>
   metabolisms:
     Bloodstream:
       effects:

--- a/Resources/Prototypes/Reagents/pyrotechnic.yml
+++ b/Resources/Prototypes/Reagents/pyrotechnic.yml
@@ -176,9 +176,9 @@
   meltingPoint: -80.7
   friction: 0.4
   tileReactions:
-  # <Trauma>
+  # </Trauma>
   - !type:SpillTileReaction
-  # <Trauma>
+  # </Trauma>
   - !type:FlammableTileReaction {}
   metabolisms:
     Bloodstream:

--- a/Resources/Prototypes/Reagents/pyrotechnic.yml
+++ b/Resources/Prototypes/Reagents/pyrotechnic.yml
@@ -176,7 +176,7 @@
   meltingPoint: -80.7
   friction: 0.4
   tileReactions:
-  # </Trauma>
+  # <Trauma>
   - !type:SpillTileReaction
   # </Trauma>
   - !type:FlammableTileReaction {}

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -112,6 +112,10 @@
   color: "#8a9a5b"
   recognizable: true
   physicalDesc: reagent-physical-desc-fuzzy
+  # <Trauma>
+  tileReactions:
+    - !type:SpillTileReaction
+  # <Trauma>
   metabolisms:
     Bloodstream:
       effects:
@@ -146,6 +150,10 @@
   color: "#a1000b"
   boilingPoint: 78.2 # This isn't a real chemical...
   meltingPoint: -19.4
+  # <Trauma> 
+  tileReactions:
+    - !type:SpillTileReaction
+  # <Trauma>
   plantMetabolism:
   - !type:PlantAdjustToxins
     amount: 20
@@ -161,7 +169,7 @@
         ignoreResistances: false
         damage:
           types:
-            Caustic: 0.5
+            Caustic: 1.5 # Trauma - Was 0.5
       - !type:Emote
         emote: Scream
         probability: 0.3
@@ -213,6 +221,10 @@
   color: "#00ff5f" # Trauma
   boilingPoint: 165
   meltingPoint: -87
+  # <Trauma> 
+  tileReactions:
+    - !type:SpillTileReaction
+  # <Trauma>
   reactiveEffects:
     Acidic:
       methods: [ Touch ]
@@ -221,7 +233,7 @@
         ignoreResistances: false
         damage:
           types:
-            Caustic: 0.3
+            Caustic: 0.9 # Trauma - Was 0.3
       - !type:Emote
         emote: Scream
         probability: 0.2
@@ -255,6 +267,10 @@
   recognizable: true
   boilingPoint: 337.0
   meltingPoint: 10.31
+  # <Trauma> 
+  tileReactions:
+    - !type:SpillTileReaction
+  # <Trauma>
   plantMetabolism:
   - !type:PlantAdjustToxins
     amount: 10
@@ -270,7 +286,7 @@
         ignoreResistances: false
         damage:
           types:
-            Caustic: 0.1
+            Caustic: 0.3 # Trauma - Was 0.1
       - !type:Emote
         emote: Scream
         probability: 0.1

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -150,7 +150,7 @@
   color: "#a1000b"
   boilingPoint: 78.2 # This isn't a real chemical...
   meltingPoint: -19.4
-  # <Trauma> 
+  # <Trauma>
   tileReactions:
     - !type:SpillTileReaction
   # <Trauma>
@@ -221,7 +221,7 @@
   color: "#00ff5f" # Trauma
   boilingPoint: 165
   meltingPoint: -87
-  # <Trauma> 
+  # <Trauma>
   tileReactions:
     - !type:SpillTileReaction
   # <Trauma>
@@ -267,7 +267,7 @@
   recognizable: true
   boilingPoint: 337.0
   meltingPoint: 10.31
-  # <Trauma> 
+  # <Trauma>
   tileReactions:
     - !type:SpillTileReaction
   # <Trauma>

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -114,7 +114,7 @@
   physicalDesc: reagent-physical-desc-fuzzy
   # <Trauma>
   tileReactions:
-    - !type:SpillTileReaction
+  - !type:SpillTileReaction
   # <Trauma>
   metabolisms:
     Bloodstream:
@@ -152,7 +152,7 @@
   meltingPoint: -19.4
   # <Trauma>
   tileReactions:
-    - !type:SpillTileReaction
+  - !type:SpillTileReaction
   # <Trauma>
   plantMetabolism:
   - !type:PlantAdjustToxins
@@ -223,7 +223,7 @@
   meltingPoint: -87
   # <Trauma>
   tileReactions:
-    - !type:SpillTileReaction
+  - !type:SpillTileReaction
   # <Trauma>
   reactiveEffects:
     Acidic:
@@ -269,7 +269,7 @@
   meltingPoint: 10.31
   # <Trauma>
   tileReactions:
-    - !type:SpillTileReaction
+  - !type:SpillTileReaction
   # <Trauma>
   plantMetabolism:
   - !type:PlantAdjustToxins

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -169,7 +169,7 @@
         ignoreResistances: false
         damage:
           types:
-            Caustic: 1.5 # Trauma - Was 0.5
+            Caustic: 1 # Trauma - Was 0.5
       - !type:Emote
         emote: Scream
         probability: 0.3
@@ -233,7 +233,7 @@
         ignoreResistances: false
         damage:
           types:
-            Caustic: 0.9 # Trauma - Was 0.3
+            Caustic: 0.75 # Trauma - Was 0.3
       - !type:Emote
         emote: Scream
         probability: 0.2

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -115,7 +115,7 @@
   # <Trauma>
   tileReactions:
   - !type:SpillTileReaction
-  # <Trauma>
+  # </Trauma>
   metabolisms:
     Bloodstream:
       effects:
@@ -153,7 +153,7 @@
   # <Trauma>
   tileReactions:
   - !type:SpillTileReaction
-  # <Trauma>
+  # </Trauma>
   plantMetabolism:
   - !type:PlantAdjustToxins
     amount: 20
@@ -224,7 +224,7 @@
   # <Trauma>
   tileReactions:
   - !type:SpillTileReaction
-  # <Trauma>
+  # </Trauma>
   reactiveEffects:
     Acidic:
       methods: [ Touch ]
@@ -270,7 +270,7 @@
   # <Trauma>
   tileReactions:
   - !type:SpillTileReaction
-  # <Trauma>
+  # </Trauma>
   plantMetabolism:
   - !type:PlantAdjustToxins
     amount: 10


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->
Made it so most acids, razorium and mold as well as welding fuel and CLF3 now actually are put on the floor when put in foam/smoke
Another thing changed was increasing the damage on most contact acids so for instance polytrinic acid now does 20 caustic damage for 20u instead of 10 caustic damage, With a firefighter tank it does 45 caustic damage for 15u with only 9 of it being vital
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This was changed so you are encouraged to actually use acids to splash people/spray with as well as allowing for more creativity with foam mixes since slipping on razorium does infact cut you 
## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
I went inside my test environment and made sure everything was functioning properly for instance putting the acids/pyrotechnics into a foam and seeing if they properly went onto the ground as well as using a health analyzer to make sure the acids were dealing the intended amount of damage

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Wizard25671
- tweak: Increased the contact damage of most contact chemicals specifically sulfuric acid, fluorosulfuric acid, polytrinic acid, and razorium
- tweak: Tweaked the following chemicals to allow them to spill on the floor from smoke/foam: fluorosulfuric acid, polytrinic acid, razorium, welding fuel, chlorine trifluoride, and mold
