### PR TITLE
Fixed Guidebook descriptions for negative flammability values

### DIFF
--- a/Content.Shared/EntityEffects/Effects/Atmos/FlammableEntityEffect.cs
+++ b/Content.Shared/EntityEffects/Effects/Atmos/FlammableEntityEffect.cs
@@ -29,7 +29,9 @@ public sealed partial class Flammable : EntityEffectBase<Flammable>
     public float FireProtectionPenetration;
 
     public override string EntityEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
-        => Loc.GetString("entity-effect-guidebook-flammable-reaction", ("chance", Probability));
+        => Loc.GetString("entity-effect-guidebook-flammable-reaction",
+            ("chance", Probability),
+            ("direction", Multiplier < 0 ? "decrease" : "increase")); // Trauma - negative multiplier reduces flammability; MultiplierOnExisting's sign is not reflected
 
     public override LogImpact? Impact => LogImpact.Low;
 }

--- a/Resources/Locale/en-US/guidebook/entity-effects/effects.ftl
+++ b/Resources/Locale/en-US/guidebook/entity-effects/effects.ftl
@@ -364,6 +364,7 @@ entity-effect-guidebook-extinguish-reaction =
         *[other] extinguish
     } fire
 
+# Trauma - $direction is set from the Flammable effect's multiplier sign, so negative Flammable reagents read "Decreases flammability"; defaults to increase
 entity-effect-guidebook-flammable-reaction =
     { $chance ->
         [1] { $direction ->

--- a/Resources/Locale/en-US/guidebook/entity-effects/effects.ftl
+++ b/Resources/Locale/en-US/guidebook/entity-effects/effects.ftl
@@ -366,8 +366,14 @@ entity-effect-guidebook-extinguish-reaction =
 
 entity-effect-guidebook-flammable-reaction =
     { $chance ->
-        [1] Increases
-        *[other] increase
+        [1] { $direction ->
+                [decrease] Decreases
+                *[increase] Increases
+            }
+        *[other] { $direction ->
+                [decrease] decrease
+                *[increase] increase
+            }
     } flammability
 
 entity-effect-guidebook-ignite =


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->
Allows the guidebook to display negative flammability values


## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
to allow for my new chemical https://github.com/Trauma-Station/Trauma-Station/pull/3627

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
open the guidebook in game with https://github.com/Trauma-Station/Trauma-Station/pull/3627 and verify that decreased flammability text works as well as previous increased flammability chems like phlog still show the proper text 
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="732" height="517" alt="Suffocatium" src="https://github.com/user-attachments/assets/973f3368-68bb-4c7b-9095-5022676b6c98" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
