### PR TITLE
Gargantua Rejuvenate Bugfix

### DIFF
--- a/Resources/Prototypes/_Trauma/Vampires/EntityEffects/gargantua.yml
+++ b/Resources/Prototypes/_Trauma/Vampires/EntityEffects/gargantua.yml
@@ -56,6 +56,8 @@
         Shock: -10
         Cold: -10
         Caustic: -10
+        Radiation: -10
+        Poison: -10
   - !type:AdjustReagentGroup
     amount: -10
     group: Toxins


### PR DESCRIPTION

<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->
Gave gargantua's special rejuvenate radiation and poison healing
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This was changed so it is actually consistent since normal upgraded rejuvenate heals toxins so why would gargantua's special rejuvenate not heal rads/poison
## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Made sure I put the proper damage types
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- fix: Fixed Gargantua's Rejuvenate not healing poison and radiation
-->
