### PR TITLE
new portal tech

### DIFF
--- a/Content.Goobstation.Shared/Teleportation/Components/PocketDimensionComponent.cs
+++ b/Content.Goobstation.Shared/Teleportation/Components/PocketDimensionComponent.cs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-using Content.Systems;
+using Content.Goobstation.Shared.Teleportation.Systems;
 using Robust.Shared.Audio;
 
 namespace Content.Goobstation.Shared.Teleportation.Components;
@@ -9,27 +9,33 @@ namespace Content.Goobstation.Shared.Teleportation.Components;
 /// Creates a map for a pocket dimension on spawn.
 /// When activated by alt verb, spawns a portal to this dimension or closes it.
 /// </summary>
-[RegisterComponent]
-[Access(typeof(PocketDimensionSystem))]
+[RegisterComponent, NetworkedComponent, Access(typeof(PocketDimensionSystem))]
+[AutoGenerateComponentState]
 public sealed partial class PocketDimensionComponent : Component
 {
     /// <summary>
     /// Whether this pocket dimension portal is enabled.
     /// </summary>
-    [ViewVariables]
+    [DataField]
     public bool PortalEnabled = false;
 
     /// <summary>
     /// The portal in the pocket dimension. Created when the entry portal is first opened.
     /// </summary>
-    [ViewVariables]
+    [DataField, AutoNetworkedField]
     public EntityUid? ExitPortal;
 
     /// <summary>
     /// The pocket dimension map. Created when the entry portal is first opened.
     /// </summary>
-    [ViewVariables]
+    [DataField, AutoNetworkedField]
     public EntityUid? PocketDimensionMap;
+
+    /// <summary>
+    /// The first grid found on <see cref="PocketDimensionMap"/>.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public EntityUid? RootGrid;
 
     /// <summary>
     /// Path to the pocket dimension's map file
@@ -41,7 +47,7 @@ public sealed partial class PocketDimensionComponent : Component
     /// The prototype to spawn for the portal spawned in the pocket dimension.
     /// </summary>
     [DataField]
-    public EntProtoId ExitPortalPrototype = "PortalBlue";
+    public EntProtoId ExitPortalPrototype = "DimensionPotExitPortal";
 
     [DataField]
     public SoundSpecifier OpenPortalSound = new SoundPathSpecifier("/Audio/Machines/high_tech_confirm.ogg")

--- a/Content.Goobstation.Shared/Teleportation/Systems/PocketDimensionSystem.cs
+++ b/Content.Goobstation.Shared/Teleportation/Systems/PocketDimensionSystem.cs
@@ -9,6 +9,7 @@ using Robust.Shared.Audio.Systems;
 using Robust.Shared.EntitySerialization.Systems;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
+using Robust.Shared.Timing;
 
 namespace Content.Goobstation.Shared.Teleportation.Systems;
 
@@ -17,6 +18,7 @@ namespace Content.Goobstation.Shared.Teleportation.Systems;
 /// </summary>
 public sealed partial class PocketDimensionSystem : EntitySystem
 {
+    [Dependency] private IGameTiming _timing = default!;
     [Dependency] private SharedAudioSystem _audio = default!;
     [Dependency] private LinkedEntitySystem _link = default!;
     [Dependency] private MapLoaderSystem _mapLoader = default!;

--- a/Content.Goobstation.Shared/Teleportation/Systems/PocketDimensionSystem.cs
+++ b/Content.Goobstation.Shared/Teleportation/Systems/PocketDimensionSystem.cs
@@ -10,7 +10,7 @@ using Robust.Shared.EntitySerialization.Systems;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 
-namespace Content.Systems;
+namespace Content.Goobstation.Shared.Teleportation.Systems;
 
 /// <summary>
 /// This handles pocket dimensions and their portals.
@@ -21,41 +21,38 @@ public sealed partial class PocketDimensionSystem : EntitySystem
     [Dependency] private LinkedEntitySystem _link = default!;
     [Dependency] private MapLoaderSystem _mapLoader = default!;
 
-    /// <inheritdoc/>
-    public override void Initialize()
+    [SubscribeLocalEvent]
+    private void OnShutdown(Entity<PocketDimensionComponent> ent, ref ComponentShutdown args)
     {
-        base.Initialize();
-
-        SubscribeLocalEvent<PocketDimensionComponent, ComponentRemove>(OnRemoved);
-        SubscribeLocalEvent<PocketDimensionComponent, GetVerbsEvent<AlternativeVerb>>(OnGetVerbs);
+        if (ent.Comp.PocketDimensionMap is { } map && Exists(map))
+            PredictedQueueDel(map);
     }
 
-    private void OnRemoved(EntityUid uid, PocketDimensionComponent comp, ComponentRemove args)
+    [SubscribeLocalEvent]
+    private void OnGetVerbs(Entity<PocketDimensionComponent> ent, ref GetVerbsEvent<AlternativeVerb> args)
     {
-        if (!Deleted(comp.PocketDimensionMap))
-            QueueDel(comp.PocketDimensionMap.Value);
-    }
-
-    private void OnGetVerbs(EntityUid uid, PocketDimensionComponent comp, GetVerbsEvent<AlternativeVerb> args)
-    {
-        if (!args.CanAccess || !args.CanInteract || !HasComp<HandsComponent>(args.User))
+        if (!args.CanAccess || !args.CanInteract || !args.CanComplexInteract || args.Hands == null)
             return;
 
-        AlternativeVerb verb = new()
+        var user = args.User;
+        args.Verbs.Add(new()
         {
             Text = Loc.GetString("pocket-dimension-verb-text"),
-            Act = () => HandleActivation(uid, comp, args.User)
-        };
-        args.Verbs.Add(verb);
+            Act = () => HandleActivation(ent, user)
+        });
     }
 
     /// <summary>
     /// Handles toggling the portal to the pocket dimension.
     /// </summary>
-    private void HandleActivation(EntityUid uid, PocketDimensionComponent comp, EntityUid user)
+    private void HandleActivation(Entity<PocketDimensionComponent> ent, EntityUid user)
     {
+        var (uid, comp) = ent;
         if (Deleted(comp.PocketDimensionMap))
         {
+            if (!_timing.IsFirstTimePredicted)
+                return; // dont want to try loading a map 10 times lol
+
             if (!_mapLoader.TryLoadMap(comp.PocketDimensionPath, out var map, out var roots,
                 options: new Robust.Shared.EntitySerialization.DeserializationOptions { InitializeMaps = true }))
             {
@@ -73,28 +70,33 @@ public sealed partial class PocketDimensionSystem : EntitySystem
                 if (!HasComp<MapGridComponent>(root))
                     continue;
 
+                comp.RootGrid = root;
+
                 // spawn the permanent portal into the pocket dimension, now ready to be used
-                var pos = new EntityCoordinates(root, 0, 0);
-                comp.ExitPortal = Spawn(comp.ExitPortalPrototype, pos);
-                EnsureComp<PortalComponent>(comp.ExitPortal!.Value, out var portal);
+                SpawnExitPortal(ent, root);
                 // the TryUnlink cleanup when first trying to create portal will fail without this
-                EnsureComp<LinkedEntityComponent>(uid);
-                portal.CanTeleportToOtherMaps = true;
+                EnsureComp<LinkedEntityComponent>(ent);
 
                 Log.Info($"Created pocket dimension on grid {root} of map {map}");
 
                 // if someone closes your portal you can use the one inside to escape
-                _link.OneWayLink(comp.ExitPortal.Value, uid);
+                _link.OneWayLink(comp.ExitPortal!.Value, uid);
                 foundGrid = true;
                 break;
             }
             if (!foundGrid)
             {
                 Log.Error($"Pocket dimension {comp.PocketDimensionPath} had no grids!");
-                Del(comp.PocketDimensionMap);
+                Del(map);
+                comp.PocketDimensionMap = null;
                 return;
             }
+            Dirty(ent);
         }
+
+        // respawn exit portal if something deleted it
+        if (Deleted(comp.ExitPortal))
+            SpawnExitPortal(ent, comp.RootGrid!.Value);
 
         var dimension = comp.ExitPortal!.Value;
         if (comp.PortalEnabled)
@@ -116,5 +118,13 @@ public sealed partial class PocketDimensionSystem : EntitySystem
             comp.PortalEnabled = true;
             _audio.PlayPvs(comp.OpenPortalSound, uid);
         }
+    }
+
+    private void SpawnExitPortal(Entity<PocketDimensionComponent> ent, EntityUid grid)
+    {
+        var pos = new EntityCoordinates(grid, 0, 0);
+        var portal = PredictedSpawnAtPosition(ent.Comp.ExitPortalPrototype, pos);
+        ent.Comp.ExitPortal = portal;
+        Dirty(ent);
     }
 }

--- a/Content.Shared/Teleportation/Systems/SharedPortalSystem.cs
+++ b/Content.Shared/Teleportation/Systems/SharedPortalSystem.cs
@@ -1,5 +1,8 @@
+// <Trauma>
+using Content.Goobstation.Common.BlockTeleport;
+using Content.Trauma.Common.Teleportation;
+// </Trauma>
 using System.Linq;
-using Content.Goobstation.Common.BlockTeleport; // Goob
 using Content.Shared.Ghost;
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Movement.Pulling.Systems;
@@ -235,12 +238,12 @@ public abstract partial class SharedPortalSystem : EntitySystem
             return;
         }
 
-        // Goobstation start
-        var ev = new TeleportAttemptEvent(false);
-        RaiseLocalEvent(subject, ref ev);
-        if (ev.Cancelled)
+        // <Trauma>
+        var attemptEv = new TeleportAttemptEvent(false);
+        RaiseLocalEvent(subject, ref attemptEv);
+        if (attemptEv.Cancelled)
             return;
-        // Goobstation end
+        // </Trauma>
 
         var arrivalSound = CompOrNull<PortalComponent>(targetEntity)?.ArrivalSound ?? ent.Comp.ArrivalSound;
         var departureSound = ent.Comp.DepartureSound;
@@ -256,6 +259,10 @@ public abstract partial class SharedPortalSystem : EntitySystem
         LogTeleport(ent, subject, Transform(subject).Coordinates, target);
 
         _transform.SetCoordinates(subject, target);
+        // <Trauma>
+        var ev = new PortalTeleportedEvent(ent, targetEntity);
+        RaiseLocalEvent(subject, ref ev);
+        // </Trauma>
 
         if (!playSound)
             return;

--- a/Content.Trauma.Common/Teleportation/PortalTeleportedEvent.cs
+++ b/Content.Trauma.Common/Teleportation/PortalTeleportedEvent.cs
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Content.Trauma.Common.Teleportation;
+
+/// <summary>
+/// Event raised on an entity after it goes through a portal and is teleported to either a destination portal or random position if that's null.
+/// </summary>
+[ByRefEvent]
+public record struct PortalTeleportedEvent(EntityUid Source, EntityUid? Dest);

--- a/Content.Trauma.Shared/Teleportation/PortalTransitEffectsComponent.cs
+++ b/Content.Trauma.Shared/Teleportation/PortalTransitEffectsComponent.cs
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Shared.EntityEffects;
+
+namespace Content.Trauma.Shared.Teleportation;
+
+/// <summary>
+/// Applies entity effects after going through a portal.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class PortalTransitEffectsComponent : Component
+{
+    /// <summary>
+    /// Effects applied to this entity.
+    /// </summary>
+    [DataField]
+    public EntityEffect[]? Effects;
+
+    /// <summary>
+    /// Effects applied to the portal it entered through.
+    /// </summary>
+    [DataField]
+    public EntityEffect[]? SourceEffects;
+
+    /// <summary>
+    /// Effects applied to the portal it left from.
+    /// </summary>
+    [DataField]
+    public EntityEffect[]? DestEffects;
+}

--- a/Content.Trauma.Shared/Teleportation/PortalTransitEffectsSystem.cs
+++ b/Content.Trauma.Shared/Teleportation/PortalTransitEffectsSystem.cs
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Shared.EntityEffects;
+using Content.Trauma.Common.Teleportation;
+
+namespace Content.Trauma.Shared.Teleportation;
+
+public sealed partial class PortalTransitEffectsSystem : EntitySystem
+{
+    [Dependency] private SharedEntityEffectsSystem _effects = default!;
+
+    [SubscribeLocalEvent]
+    private void OnPortalTeleported(Entity<PortalTransitEffectsComponent> ent, ref PortalTeleportedEvent args)
+    {
+        if (ent.Comp.Effects is { } effects)
+            _effects.ApplyEffects(ent, effects);
+        if (ent.Comp.SourceEffects is { } srcEffects)
+            _effects.ApplyEffects(args.Source, srcEffects);
+        if (ent.Comp.DestEffects is { } destEffects && args.Dest is { } dest)
+            _effects.ApplyEffects(dest, destEffects);
+    }
+}

--- a/Resources/Prototypes/_Goobstation/Body/Organs/misc.yml
+++ b/Resources/Prototypes/_Goobstation/Body/Organs/misc.yml
@@ -10,6 +10,7 @@
     - state: icon
     scale: 0.5, 0.5
   - type: UnremoveableOrgan # fuck sec chuds
+  - type: Cybernetics # zap
 
 - type: entity
   parent: OrganSyndicateHeart
@@ -17,7 +18,6 @@
   name: Sandevistan
   description: Illegal cyberware that replaces the user's heart and allows them to greatly increase their speed for the cost of the endurance.
   components:
-  - type: Cybernetics
   - type: Sprite
     sprite: _Goobstation/Objects/Misc/sandevistan.rsi
   - type: OrganActions

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Materials/materials.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Materials/materials.yml
@@ -30,6 +30,23 @@
     radius:
       min: 2
       max: 5
+  # interferes with bluespace portals. does nothing inside containers etc for simplicity and not being annoying
+  - type: PortalTransitEffects
+    effects:
+    - !type:Explosion
+      explosionType: Cryo
+      maxIntensity: 3
+      intensityPerUnit: 6
+    - !type:Delete
+      queued: true
+    sourceEffects: &portalEffects
+    - !type:Delete
+      conditions:
+      - !type:WhitelistCondition
+        blacklist:
+          components:
+          - PocketDimension # dont delete the dimension pot one
+    destEffects: *portalEffects
   - type: Tag
     tags:
     - Ore

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Syndicate/dimension_pot.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Syndicate/dimension_pot.yml
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 - type: entity
-  id: DimensionPot
   parent: PottedPlantBase
+  id: DimensionPot
   suffix: Dimension
+  categories: [ DoNotMap ]
   components:
   - type: Sprite
     layers:
@@ -69,3 +70,11 @@
         layer:
         - WallLayer
         hard: false
+
+- type: entity
+  parent: PortalBlue
+  id: DimensionPotExitPortal
+  suffix: Dimension pot exit
+  components:
+  - type: Portal
+    canTeleportToOtherMaps: true # or else you cant leave

--- a/Resources/Prototypes/_Goobstation/SpaceWhales/whale.yml
+++ b/Resources/Prototypes/_Goobstation/SpaceWhales/whale.yml
@@ -55,7 +55,7 @@
     spacing: 1
     prototype: SpaceWhaleSegment
   - type: MovementSpeedModifier
-    baseSprintSpeed: 40
+    baseSprintSpeed: 70
     baseWalkSpeed: 11
     baseWeightlessFriction: 4
     weightlessFriction: 4
@@ -141,6 +141,12 @@
         Slash: 45
         Structural: 800 #lol
   - type: NoRotateOnMove
+  - type: PortalTransitEffects # its like an apple getting cored
+    effects:
+    - !type:HealthChange
+      damage:
+        types:
+          Slash: 4000
 
 - type: entity
   parent: [MobSpaceLeviathanSegmentBase, FlyingMobBase]

--- a/Resources/Prototypes/_Goobstation/SpaceWhales/whale.yml
+++ b/Resources/Prototypes/_Goobstation/SpaceWhales/whale.yml
@@ -176,7 +176,7 @@
   suffix: despawns
   components:
   - type: TimedDespawn
-    lifetime: 190 # to further prevent shitters from abusing it if something came up
+    lifetime: 110 # to further prevent shitters from abusing it if something came up
 
 - type: entity
   id: SpaceLeviathanMobCaller


### PR DESCRIPTION
- space whales going through a portal gibs them because its like an apple being cored, its 3x the width of the portal... this can easily be added for other huge things in the future too
- increased space whale top speed so its harder to edge it with a syringe gun... probably still possible with enough luck
- bluespace crystals thrown into a portal now explode and destroy the portals. dimensional pot will still exist but you are trapped inside and have to wait for someone to reopen the pot or have some other way to teleport out like fultons
- made dimensional pot better predicted and more robust

also fixes #3645

:cl:
- tweak: Bluespace crystals now violently react with bluespace portals.
- tweak: Space whales now move faster and are gibbed if they go through a portal.