### PR TITLE
restrict mech equipment container to equipment

### DIFF
--- a/Content.Shared/Mech/EntitySystems/SharedMechSystem.Trauma.cs
+++ b/Content.Shared/Mech/EntitySystems/SharedMechSystem.Trauma.cs
@@ -1,62 +1,18 @@
-using Content.Trauma.Common.Mech;
-using Content.Trauma.Common.TileMovement;
-using Content.Shared.Emag.Systems;
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction.Components;
 using Content.Shared.Inventory.VirtualItem;
 using Content.Shared.Mech.Components;
 using Content.Shared.Mech.Equipment.Components;
-using Content.Shared.Weapons.Ranged.Events;
-using Robust.Shared.Containers;
+using Content.Trauma.Common.TileMovement;
 
 namespace Content.Shared.Mech.EntitySystems;
 
 public abstract partial class SharedMechSystem
 {
-    [Dependency] private EmagSystem _emag = default!;
     [Dependency] private SharedHandsSystem _hands = default!;
     [Dependency] private SharedVirtualItemSystem _virtualItem = default!;
     [Dependency] private EntityQuery<TileMovementComponent> _tileQuery = default!;
-
-    private void InitializeTrauma()
-    {
-        SubscribeLocalEvent<MechEquipmentComponent, ShotAttemptedEvent>(OnShotAttempted);
-        SubscribeLocalEvent<MechPilotComponent, EntGotRemovedFromContainerMessage>(OnEntGotRemovedFromContainer);
-        SubscribeLocalEvent<MechComponent, GotEmaggedEvent>(OnEmagged);
-    }
-
-    // TODO: this has no reason to be here
-    private void OnShotAttempted(EntityUid uid, MechEquipmentComponent component, ref ShotAttemptedEvent args)
-    {
-        if ((component.EquipmentOwner is not {} mech ||
-            !HasComp<MechComponent>(mech)))
-        {
-            args.Cancel();
-            return;
-        }
-
-        // TODO: this should not be in an attempt event
-        var ev = new MechGunFiredEvent();
-        RaiseLocalEvent(uid, ref ev);
-    }
-
-    // TODO: this has no reason to be here
-    private void OnEntGotRemovedFromContainer(EntityUid uid, MechPilotComponent component, EntGotRemovedFromContainerMessage args)
-    {
-        // Fixes scram implants or teleports locking the pilot out of being able to move.
-        TryEject(component.Mech, pilot: uid);
-    }
-
-    // TODO: this has no reason to be here
-    private void OnEmagged(EntityUid uid, MechComponent component, ref GotEmaggedEvent args)
-    {
-        if (!component.BreakOnEmag || !_emag.CompareFlag(args.Type, EmagType.Interaction))
-            return;
-        args.Handled = true;
-        component.EquipmentWhitelist = null;
-        Dirty(uid, component);
-    }
 
     private void CopyTileMovement(EntityUid mech, EntityUid pilot)
     {

--- a/Content.Shared/Mech/EntitySystems/SharedMechSystem.cs
+++ b/Content.Shared/Mech/EntitySystems/SharedMechSystem.cs
@@ -63,7 +63,6 @@ public abstract partial class SharedMechSystem : EntitySystem
         SubscribeLocalEvent<MechPilotComponent, CanAttackFromContainerEvent>(OnCanAttackFromContainer);
         SubscribeLocalEvent<MechPilotComponent, AttackAttemptEvent>(OnAttackAttempt);
 
-        InitializeTrauma(); // Trauma
         InitializeRelay();
     }
 

--- a/Content.Trauma.Shared/Mech/TraumaMechSystem.cs
+++ b/Content.Trauma.Shared/Mech/TraumaMechSystem.cs
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Shared.Emag.Systems;
+using Content.Shared.Mech.Components;
+using Content.Shared.Mech.EntitySystems;
+using Content.Shared.Mech.Equipment.Components;
+using Content.Shared.Weapons.Ranged.Events;
+using Content.Trauma.Common.Mech;
+using Robust.Shared.Containers;
+
+namespace Content.Trauma.Shared.Mech;
+
+public sealed partial class TraumaMechSystem : EntitySystem
+{
+    [Dependency] private EmagSystem _emag = default!;
+    [Dependency] private SharedMechSystem _mech = default!;
+    [Dependency] private EntityQuery<MechComponent> _mechQuery = default!;
+    [Dependency] private EntityQuery<MechEquipmentComponent> _equipmentQuery = default!;
+
+    [SubscribeLocalEvent]
+    private void OnShotAttempted(Entity<MechEquipmentComponent> ent, ref ShotAttemptedEvent args)
+    {
+        if (ent.Comp.EquipmentOwner is not {} mech || !_mechQuery.HasComp(mech))
+        {
+            args.Cancel();
+            return;
+        }
+
+        // TODO: this should not be in an attempt event...
+        var ev = new MechGunFiredEvent();
+        RaiseLocalEvent(ent, ref ev);
+    }
+
+    [SubscribeLocalEvent]
+    private void OnEntGotRemovedFromContainer(Entity<MechPilotComponent> ent, ref EntGotRemovedFromContainerMessage args)
+    {
+        // Fixes scram implants or teleports locking the pilot out of being able to move.
+        _mech.TryEject(ent.Comp.Mech, pilot: ent.Owner);
+    }
+
+    [SubscribeLocalEvent]
+    private void OnEmagged(Entity<MechComponent> ent, ref GotEmaggedEvent args)
+    {
+        if (!ent.Comp.BreakOnEmag ||
+            ent.Comp.EquipmentWhitelist == null ||
+            !_emag.CompareFlag(args.Type, EmagType.Interaction))
+            return;
+
+        args.Handled = true;
+        ent.Comp.EquipmentWhitelist = null;
+        Dirty(ent);
+    }
+
+    [SubscribeLocalEvent]
+    private void OnInsertAttempt(Entity<MechComponent> ent, ref ContainerIsInsertingAttemptEvent args)
+    {
+        if (args.Container != ent.Comp.EquipmentContainer ||
+            _equipmentQuery.HasComp(args.EntityUid))
+            return;
+
+        // only equipment can go into the equipment container not bullet casings etc
+        args.Cancel();
+    }
+}


### PR DESCRIPTION
fixes #3651 

it prevents inserting things without the component to the equipment container so random shit like casings cant fill it anymore

## Media
notice how they get ejected not filling it up...

<img width="771" height="466" alt="23:09:56" src="https://github.com/user-attachments/assets/152579f3-4298-4918-b90f-78a820a6a914" />

## Changelog
:cl:
- fix: Fixed killdozer getting filled with casings when you use its mosin.