### PR TITLE
GABITY!

### DIFF
--- a/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/base.yml
+++ b/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/base.yml
@@ -174,6 +174,8 @@
   id: BaseMobXenomorphAdult
   abstract: true
   components:
+  - type: MovementIgnoreGravity
+    Weightless: false
   - type: FootstepModifier
     footstepSoundCollection:
       collection: FootstepXenomorph

--- a/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/base.yml
+++ b/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/base.yml
@@ -175,7 +175,7 @@
   abstract: true
   components:
   - type: MovementSpeedModifier
-    BaseweightlessAcceleration: 1.6
+    BaseweightlessAcceleration: 1.7
     BaseweightlessFriction: 1
     BaseWeightlessModifier: 1
   - type: FootstepModifier

--- a/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/base.yml
+++ b/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/base.yml
@@ -174,8 +174,10 @@
   id: BaseMobXenomorphAdult
   abstract: true
   components:
-  - type: MovementIgnoreGravity
-    Weightless: false
+  - type: MovementSpeedModifier
+    BaseweightlessAcceleration: 1.6
+    BaseweightlessFriction: 1
+    BaseWeightlessModifier: 1
   - type: FootstepModifier
     footstepSoundCollection:
       collection: FootstepXenomorph


### PR DESCRIPTION
makes xeno not wieghtless when gabity is off :)

<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->
xenos no longer need gravity
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
"https://discord.com/channels/1222953503610110062/1529195789136564376/1529195789136564376" discord suggestion
"ooh grav off well now u cant fight or catch anybody"

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [ ] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [ ] I have tested this pull request and written instructions on how to test it
- [ ] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
--> 🆑 DinoPercent
- tweak: xenomorphs movment acceleration boosted in no gravity :D 👽 

