### PR TITLE
fire helmets protect head instead of torso now! 

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
@@ -47,7 +47,7 @@
 
 - type: entity
   abstract: true
-  parent: ClothingHeadBase
+  parent: ClothingHeadHelmetBase
   id: ClothingHeadLightBase
   name: base helmet with light
   categories: [ HideSpawnMenu ]


### PR DESCRIPTION
Changed ClothingHeadHelmetBase parent tag from ClothingHeadBase to ClothingHeadHelmetBase because of an issue where the fire helmet and atmos fire helmet the only two things that use ClothingHeadLightBase both protect the torso instead of the head. 

Tested by spawning in a fire helmet and atmos fire helmet seeing it says head now and made tested it by putting urist in a high pressure chamber and seeing that they last longer than a urist with the standard engie hardsuit, now that the helmet actually works.

Before
<img width="369" height="199" alt="Atmos fire helmet old" src="https://github.com/user-attachments/assets/4cf0dbbc-527b-4c37-8f88-af786d14948e" />


After
<img width="550" height="247" alt="atmos fire helmet fix" src="https://github.com/user-attachments/assets/f06c0d5b-89a5-418a-a2a8-84e03d172458" />

- [x] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.


:cl:
- fix: Fixed atmos fire helmet and fire helmet protecting torso instead of head

