### PR TITLE
firehelmet fix attempt #2

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
@@ -47,7 +47,7 @@
 
 - type: entity
   abstract: true
-  parent: ClothingHeadBase
+  parent: ClothingHeadHelmetBase
   id: ClothingHeadLightBase
   name: base helmet with light
   categories: [ HideSpawnMenu ]

--- a/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
@@ -47,7 +47,7 @@
 
 - type: entity
   abstract: true
-  parent: ClothingHeadHelmetBase
+  parent: ClothingHeadHelmetBase # Trauma - was ClothingHeadBase
   id: ClothingHeadLightBase
   name: base helmet with light
   categories: [ HideSpawnMenu ]


### PR DESCRIPTION
attempt 2 because I tried merging from my master branch with the exact same change

Changed ClothingHeadHelmetBase parent tag from ClothingHeadBase to ClothingHeadHelmetBase because of an issue where the fire helmet and atmos fire helmet the only two things that use ClothingHeadLightBase both protect the torso instead of the head.

Tested by spawning in a fire helmet and atmos fire helmet seeing it protects head now and tested it by putting a urist in a high pressure chamber and seeing that they last longer than a urist with the standard engie hardsuit, now that the helmet actually works.

- [x] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.

:cl:
- fix: Fixed atmos fire helmet and fire helmet protecting torso instead of head
