### PR TITLE
add brigmedic to sec department

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/Roles/Jobs/departments.yml
@@ -131,6 +131,7 @@
   weight: 20
   roles:
   # <Trauma>
+  - Brigmedic
   - SecurityClown
   # </Trauma>
   - HeadOfSecurity


### PR DESCRIPTION
fixes #3642

:cl:
ADMIN:
- fix: Sec department rolebans now include brigmedic reinforcements.