### PR TITLE
give fishing ponds collision

### DIFF
--- a/Resources/Prototypes/_Trauma/Entities/Objects/Specific/Fishing/fishingspots.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Objects/Specific/Fishing/fishingspots.yml
@@ -20,16 +20,22 @@
     bodyType: Static
   - type: Fixtures
     fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeAabb
+      fishing:
+        shape: !type:PhysShapeAabb
           bounds: "-0.25,-0.25,0.25,0.25"
         layer:
         - ItemMask
         mask:
         - HighImpassable
-        density: 1000
         hard: false
+      fix1:
+        shape: !type:PhysShapeCircle
+          radius: 0.4
+        density: 1000 # water..?
+        mask:
+        - MachineMask
+        layer:
+        - None
   - type: Solution
     id: tank
     solution:


### PR DESCRIPTION
fixes #3318

## Media

<img width="171" height="143" alt="00:02:13" src="https://github.com/user-attachments/assets/edf5a4c5-603e-4d31-9938-810dfb41b62a" />

## Changelog
:cl:
- fix: Fishing ponds no longer phase through walls.