### PR TITLE
fix soul bound map handling

### DIFF
--- a/Content.Trauma.Shared/Wizard/BindSoul/SharedBindSoulSystem.cs
+++ b/Content.Trauma.Shared/Wizard/BindSoul/SharedBindSoulSystem.cs
@@ -78,8 +78,7 @@ public abstract partial class SharedBindSoulSystem : EntitySystem
 
     private void OnMindGetRemoved(Entity<SoulBoundComponent> ent, ref MindGotRemovedEvent args)
     {
-        if (_net.IsClient || HasComp<MindSwappingComponent>(args.Container) || HasComp<GhostComponent>(args.Container) ||
-            Terminating(args.Container))
+        if (_net.IsClient || HasComp<MindSwappingComponent>(args.Container) || HasComp<GhostComponent>(args.Container))
             return;
 
         var xform = Transform(args.Container);


### PR DESCRIPTION
fixes #3625

genius shit was refusing to save latest map id if you gibbed (the only way to die as a skeleton) so it just never updated :face_holding_back_tears: 

:cl:
- fix: Fixed wizard's bind soul spell not letting you resurrect when it should.