### PR TITLE
Judo Safe no longer alert level locked.

### DIFF
--- a/Resources/Prototypes/_Trauma/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/_Trauma/Catalog/Fills/Lockers/security.yml
@@ -142,7 +142,7 @@
     - yellow
 
 - type: entity
-  parent: BaseTraumaGunSafe
+  parent: [ GunSafeBaseSecure, BaseSecurityContraband ] # Reparent to one above BaseTraumaGunSafe to remove access lock bs.
   id: GunSafeJudo
   name: judo safe
   components:
@@ -150,10 +150,6 @@
     containers:
       entity_storage: !type:NestedSelector
         tableId: FillGunSafeJudoT1
-  - type: StationAlertLevelLock
-    lockedAlertLevels:
-    - green
-    - yellow
 
 - type: entity
   parent: BaseTraumaGunSafe


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->
Judo safe is armory access once more.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Baton sidegrade but has positives and negatives of its own. 
Want to keep martial arts rare so leaving the 2 count, AND leaving armory access so you still have to beg warden for it. 

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
open da video

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
[Content.Trauma.Client_4GxgIzLYdK.webm](https://github.com/user-attachments/assets/24a767be-02fb-4297-a013-1a1a2370b4dd)

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Judo Safe no longer has an alert level requirement to unlock, returning to requiring armory access.