### PR TITLE
bible heals critical targets

### DIFF
--- a/Content.Shared/Bible/BibleSystem.cs
+++ b/Content.Shared/Bible/BibleSystem.cs
@@ -95,7 +95,7 @@ public sealed partial class BibleSystem : EntitySystem
         if (!TryComp<UseDelayComponent>(ent, out var useDelay) || _delay.IsDelayed((ent, useDelay)))
             return;
 
-        if (args.Target == null || args.Target == args.User || !_mobState.IsAlive(args.Target.Value))
+        if (args.Target == null || args.Target == args.User || _mobState.IsDead(args.Target.Value)) // Trauma - was IsAlive bible heals crit targets now
             return;
 
         // <Trauma>


### PR DESCRIPTION

 Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md
 NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
## About the PR
bible can heal targets while alive and crit

## Why / Balance
chaplain regardless of nullrod (reinforcements don't get one) can still instantly prove useful via battlefield stabilizing + we have softcrit so why not

## Test plan

dev environment heal a crit urist

## Media

https://github.com/user-attachments/assets/4d7c997f-11a8-4959-b068-a9afdbd44350



## Requirements
- [x] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
-  [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Bible healing can now be used to save the critically injured.
