### PR TITLE
makes the adminwho command globally accessible

### DIFF
--- a/Content.Server/Administration/Commands/AdminWhoCommand.cs
+++ b/Content.Server/Administration/Commands/AdminWhoCommand.cs
@@ -7,7 +7,7 @@ using Robust.Shared.Utility;
 
 namespace Content.Server.Administration.Commands;
 
-[AdminCommand(AdminFlags.AdminWho)]
+[AnyCommand]
 public sealed partial class AdminWhoCommand : LocalizedCommands
 {
     [Dependency] private IAfkManager _afkManager = default!;


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
made the adminwho command globally runnable.

## Why / Balance
not sure why this command exists just for admins. 

## Test plan
ran it with two clients, one adminned and one deadminned. ran adminwho on the non-admin client. worked.
## Media
<img width="1919" height="787" alt="Screenshot 2026-07-28 004656" src="https://github.com/user-attachments/assets/816b12b2-372b-4a1b-a881-204f97c38c01" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Changelog
:cl:
- tweak: Allows normal players to run the adminwho command
