### PR TITLE
Fix bloomeries inheriting off wrong parent

### DIFF
--- a/Resources/Prototypes/_Trauma/Entities/Structures/Specific/bloomery.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Structures/Specific/bloomery.yml
@@ -174,7 +174,7 @@
 # Lit
 
 - type: entity
-  parent: BaseBloomery
+  parent: BaseBloomeryLit
   id: BloomeryLitBrass
   suffix: Brass
   description: Loaded with brass, give it some time to burn and it will be ready.
@@ -195,7 +195,7 @@
     node: bloomerybrasslit
 
 - type: entity
-  parent: BaseBloomery
+  parent: BaseBloomeryLit
   id: BloomeryLitSteel
   suffix: Steel
   description: Loaded with steel, give it some time to burn and it will be ready.
@@ -216,7 +216,7 @@
     node: bloomerysteellit
 
 - type: entity
-  parent: BaseBloomery
+  parent: BaseBloomeryLit
   id: BloomeryLitPlasteel
   name: lit bloomery
   description: Loaded with plasteel, give it some time to burn and it will be ready.


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
Lit bloomeries had the wrong parent so they would never break themselves
## Why / Balance
Fix

## Test plan
I didn't bother testing this is a simple YAML parent oversight



## Requirements
- [X] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [ ] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: SPCR
- fix: Fixed bloomeries no longer damaging themselves
