### PR TITLE
Remove against wall condition from BaseUtility (should only go on camera)

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/utilities.yml
+++ b/Resources/Prototypes/Recipes/Construction/utilities.yml
@@ -4,9 +4,6 @@
   id: BaseUtility
   category: construction-category-utilities
   placementMode: SnapgridCenter
-  conditions:
-  - !type:AgainstWall
-    offset: 0 # expects a wall to the north when the camera is in its north facing
   # <Trauma>
   theory:
     ElectronicsKnowledge: 0


### PR DESCRIPTION
## About the PR
I removed a condition that required all children of BaseUtility be against wall. Things like disposals, lots of things. Building it is totally broken rn

## Why / Balance
It's a bug from #3715. the upstream hotfix was lost in the merge

## Test plan
I went in the game and placed disposal ghosts confirming I can put them anywhere now

## Media
None

## Requirements
- [X] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Changelog
:cl:
- fix: Fixed disposals and other utility constructions requiring a wall to build.