### PR TITLE
Plasmaman no longer becomes thirsty

### DIFF
--- a/Resources/Prototypes/_EinsteinEngines/Body/Species/plasmaman.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Body/Species/plasmaman.yml
@@ -192,6 +192,8 @@
       243: 0.8
   - type: Hunger
     baseDecayRate: 0 # don't get hungry, still able to eat
+  - type: Thirst
+    baseDecayRate: 0
 
 ## Base
 


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->

Added a ThirstComponent override to MobPlasmaman

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Fixes: #3718

preferably should just remove both of the components(hunger+thirst), like normal skeleton, but is inherited from BaseSpeciesMobOrganic, not sure if that should be changed.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

Observing the PlasmaMan's CurrentThirst field in VV, and ThirstDecay

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Plasmaman no longer suffers from thirst

