### PR TITLE
remove bad comps from plasmaman

### DIFF
--- a/Resources/Prototypes/Body/species_base.yml
+++ b/Resources/Prototypes/Body/species_base.yml
@@ -226,6 +226,22 @@
     - Bacterial
     - Parasite
   - type: VampireDrainable
+  - type: Destructible # only ashing, gibbing is still handled by torso
+    thresholds:
+    - trigger: !type:DamageTypeTrigger
+        damageType: Heat
+        damage: 1500
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawnInContainer: true
+        spawn:
+          Ash:
+            min: 1
+            max: 1
+      - !type:BurnBodyBehavior
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MeatLaserImpact
   # </Trauma>
   - type: Hunger
   - type: Thirst

--- a/Resources/Prototypes/_EinsteinEngines/Body/Species/plasmaman.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Body/Species/plasmaman.yml
@@ -80,11 +80,21 @@
 - type: entity
   parent:
   - AppearancePlasmaman
-  - BaseSpeciesMobOrganic
+  - BaseSpeciesMob
+  - MobAtmosStandard
+  - MobBloodstream
+  - MobFlammable
   id: MobPlasmaman
   name: Urist McPlasma
   components:
+  # stuff from organic that applies, notably no hunger or thirst
+  - type: Absorbable
+  - type: WraithAbsorbable
+  - type: Scent
   - type: ZombieImmune
+  - type: Blindable
+  - type: FireVisuals
+    alternateState: Standing
   - type: Bloodstream
     bloodlossThreshold: 0
     bleedReductionAmount: 0
@@ -109,8 +119,8 @@
   - type: Speech
     speechVerb: Skeleton
   - type: Vocal
-    wilhelm: "/Audio/_Goobstation/Voice/badtothebone.ogg" # Goobstation
-    wilhelmProbability: 0.1 # Goobstation
+    wilhelm: "/Audio/_Goobstation/Voice/badtothebone.ogg"
+    wilhelmProbability: 0.1
     emoteSounds: UnisexPlasmaman
   - type: Butcherable
     spawned:
@@ -164,12 +174,6 @@
     thresholds:
     - trigger:
         !type:DamageTypeTrigger
-        damageType: Blunt
-        damage: 400
-      behaviors:
-      - !type:GibBehavior
-    - trigger:
-        !type:DamageTypeTrigger
         damageType: Heat
         damage: 1500
       behaviors:
@@ -190,8 +194,6 @@
   - type: TemperatureSpeed
     thresholds:
       243: 0.8
-  - type: Hunger
-    baseDecayRate: 0 # don't get hungry, still able to eat
 
 ## Base
 


### PR DESCRIPTION
fixes #3718

also added ashing threshold for organic mobs it was missing

still has mutatable just no obvious slop

:cl:
- fix: Fixed plasmamen getting thirsty, having fingerprints, etc.
- fix: Fixed plasmamen being able to gib from limb damage instead of torso only.
- fix: Fixed not being able to ash people with extreme heat damage.