### PR TITLE
Tame lottery crate

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/cargo.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/cargo.yml
@@ -106,10 +106,16 @@
   id: LotteryWeaponsEntityTable
   table: !type:GroupSelector
     children:
+    # <Trauma>
+    - id: BoneAxe
+      weight: 0.2
+    - id: WeaponBillyClub
+      weight: 0.2
+    # </Trauma>
     - id: VehicleClowncarAntag # Goob
       weight: 0.01
-    - id: WeaponPulseCarbine
-      weight: 0.01
+    # - id: WeaponPulseCarbine # Trauma
+    #   weight: 0.01
     - id: WeaponRifleAk
       weight: 0.01
     - id: WeaponLauncherPirateCannon
@@ -121,7 +127,7 @@
       weight: 0.1
     - id: Sledgehammer
       weight: 0.1
-    - id: WeaponMeleeToolboxRobust
+    # - id: WeaponMeleeToolboxRobust # Trauma
     - id: ThrowingStar
     - id: WeaponLaserGun
       weight: 0.1


### PR DESCRIPTION
Robust toolbox is 30DPS melee weapon and feels shit to play against
Pulse carbine self explanatory
:cl: Armok
- tweak: replaced pulse carbine and robust toolbox with other weapons in lottery crate
