### PR TITLE
add cvar for disabling skills

### DIFF
--- a/Content.Client/Construction/UI/ConstructionMenu.xaml.cs
+++ b/Content.Client/Construction/UI/ConstructionMenu.xaml.cs
@@ -51,7 +51,7 @@ namespace Content.Client.Construction.UI
 
         void ClearRecipeInfo();
         void SetRecipeInfo(string name, string description, EntityPrototype? targetPrototype, bool isItem, bool isFavorite,
-            bool understands, ConstructionPrototype proto); // Trauma
+            bool understands, bool useSkills, ConstructionPrototype proto); // Trauma
         void ResetPlacement();
         void TrySelectCategory(int categoryId);
         void TrySelectListViewButton(ProtoId<ConstructionPrototype> constructionProtoId);
@@ -185,12 +185,14 @@ namespace Content.Client.Construction.UI
             bool isFavorite,
             // <Trauma>
             bool understands,
+            bool useSkills,
             ConstructionPrototype proto)
             // </Trauma>
         {
             // <Trauma> - disable button if you lack the theory, show the requirements
             BuildButton.Disabled = !understands;
-            AddSkillRequirements(proto);
+            if (useSkills)
+                AddSkillRequirements(proto);
             // </Trauma>
             BuildButton.Text = Loc.GetString(isItem ? "construction-menu-place-ghost" : "construction-menu-craft");
             TargetName.SetMessage(name);

--- a/Content.Client/Construction/UI/ConstructionMenuPresenter.cs
+++ b/Content.Client/Construction/UI/ConstructionMenuPresenter.cs
@@ -249,6 +249,7 @@ namespace Content.Client.Construction.UI
                 !_favoritedRecipes.Contains(prototype),
                 // <Trauma>
                 CanUnderstand(prototype),
+                _useSkills,
                 prototype);
                 // </Trauma>
 
@@ -783,7 +784,7 @@ namespace Content.Client.Construction.UI
                 // <Trauma> - update recipes whenever opening the window
                 if (_playerManager.LocalEntity is { } player)
                 {
-                    _useSkills = _constructionSystem!.IsKnowledgeHolder(player);
+                    _useSkills = _constructionSystem!.UsesKnowledge(player);
                     _skills = _knowledge.GetSkillMasteries(player);
                 }
                 // </Trauma>

--- a/Content.Goobstation.Client/Factory/UI/ConstructorBUI.cs
+++ b/Content.Goobstation.Client/Factory/UI/ConstructorBUI.cs
@@ -5,13 +5,16 @@ using Content.Client.Construction.UI;
 using Content.Goobstation.Shared.Factory;
 using Content.Shared.Construction.Prototypes;
 using Content.Shared.Whitelist;
+using Content.Trauma.Common.CCVar;
 using Content.Trauma.Common.Knowledge.Systems;
+using Robust.Shared.Configuration;
 using System.Linq;
 
 namespace Content.Goobstation.Client.Factory.UI;
 
 public sealed partial class ConstructorBUI : BoundUserInterface
 {
+    [Dependency] private IConfigurationManager _cfg = default!;
     [Dependency] private IPrototypeManager _proto = default!;
     private readonly CommonKnowledgeSystem _knowledge = default!;
     private readonly ConstructionSystem _construction;
@@ -38,6 +41,8 @@ public sealed partial class ConstructorBUI : BoundUserInterface
     {
         base.Open();
 
+        var skillsEnabled = _cfg.GetCVar(TraumaCVars.SkillsEnabled);
+
         // god BLESS whoever made construction ui for having it so decoupled <3
         _menu = this.CreateWindow<ConstructionMenu>();
         PopulateCategories();
@@ -54,6 +59,7 @@ public sealed partial class ConstructorBUI : BoundUserInterface
                 _menu.SetRecipeInfo(proto.Name ?? ent.Name, proto.Description ?? ent.Description, ent,
                     proto.Type != ConstructionType.Item, true, // TODO: favourites
                     true,
+                    skillsEnabled,
                     proto);
 
                 GenerateStepList(proto);
@@ -122,7 +128,7 @@ public sealed partial class ConstructorBUI : BoundUserInterface
 
         _recipes.Clear();
         var skills = _knowledge.GetSkillMasteries(user);
-        var useKnowledge = _construction.IsKnowledgeHolder(user);
+        var useKnowledge = _construction.UsesKnowledge(user);
         // FUCK YOU, copy pasta
         bool CanUnderstand(ConstructionPrototype recipe)
         {

--- a/Content.Shared/Construction/SharedConstructionSystem.Trauma.cs
+++ b/Content.Shared/Construction/SharedConstructionSystem.Trauma.cs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+using Content.Trauma.Common.CCVar;
 using Content.Trauma.Common.Knowledge.Components;
+using Robust.Shared.Configuration;
 
 namespace Content.Shared.Construction;
 
@@ -9,14 +11,24 @@ namespace Content.Shared.Construction;
 /// </summary>
 public abstract partial class SharedConstructionSystem
 {
+    [Dependency] private IConfigurationManager _cfg = default!;
+    [Dependency] private EntityQuery<KnowledgeHolderComponent> _knowledgeQuery = default!;
+
+    private bool _skillsEnabled;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        Subs.CVar(_cfg, TraumaCVars.SkillsEnabled, x => _skillsEnabled = x, true);
+    }
+
     public virtual bool ChangeNode(EntityUid uid, EntityUid? userUid, string id, bool performActions = true)
         => false;
 
     /// <summary>
-    /// Just exists for construction client shitcode
+    /// Whether knowledge should be used for a given user.
     /// </summary>
-    public bool IsKnowledgeHolder(EntityUid user)
-    {
-        return HasComp<KnowledgeHolderComponent>(user);
-    }
+    public bool UsesKnowledge(EntityUid user)
+        => _skillsEnabled && _knowledgeQuery.HasComp(user);
 }

--- a/Content.Shared/EntityEffects/Effects/Damage/EvenHealthChangeEntityEffectSystem.cs
+++ b/Content.Shared/EntityEffects/Effects/Damage/EvenHealthChangeEntityEffectSystem.cs
@@ -24,7 +24,7 @@ public sealed partial class EvenHealthChangeEntityEffectSystem : EntityEffectSys
     {
         foreach (var (group, amount) in args.Effect.Damage)
         {
-            // <Goob>
+            // <Trauma> - pass healing to HealEvenly, modify it with temperature if set to
             var healing = amount * args.Scale;
             if (args.Effect.ScaleByTemperature is {} scaleTemp)
             {
@@ -32,9 +32,11 @@ public sealed partial class EvenHealthChangeEntityEffectSystem : EntityEffectSys
                     return; // condition stays the same so this is actually a good return in loop
 
                 healing *= scaleTemp.GetEfficiencyMultiplier(temp.CurrentTemperature, args.Scale, false);
+                if (healing >= 0)
+                    continue; // efficiency multiplier was 0? skip
             }
             _damageable.HealEvenly(entity.AsNullable(), healing, group);
-            // </Goob>
+            // </Trauma>
         }
     }
 }

--- a/Content.Trauma.Common/CCVar/TraumaCVars.Skills.cs
+++ b/Content.Trauma.Common/CCVar/TraumaCVars.Skills.cs
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Robust.Shared.Configuration;
+
+namespace Content.Trauma.Common.CCVar;
+
+public sealed partial class TraumaCVars
+{
+    /// <summary>
+    /// Enables effects of knowledge.
+    /// When disabled only languages and martial arts will do anything, their levels will be irrelevant.
+    /// </summary>
+    public static readonly CVarDef<bool> SkillsEnabled =
+        CVarDef.Create("trauma.skills_enabled", true, CVar.SERVER | CVar.REPLICATED);
+
+    /// <summary>
+    /// Enables gaining XP and skills during rounds.
+    /// Character starting skills are not affected by this.
+    /// </summary>
+    public static readonly CVarDef<bool> SkillGain =
+        CVarDef.Create("trauma.skill_gain", true, CVar.SERVER | CVar.REPLICATED);
+
+    /// <summary>
+    /// Client setting to hide all skill-related popups.
+    /// </summary>
+    public static readonly CVarDef<bool> SkillPopups =
+        CVarDef.Create("trauma.skill_popups", true, CVar.CLIENTONLY | CVar.ARCHIVE);
+}

--- a/Content.Trauma.Common/CCVar/TraumaCVars.cs
+++ b/Content.Trauma.Common/CCVar/TraumaCVars.cs
@@ -72,19 +72,6 @@ public sealed partial class TraumaCVars
 
     #region Skills
 
-    /// <summary>
-    /// Enables gaining XP and skills during rounds.
-    /// Character starting skills are not affected by this.
-    /// </summary>
-    public static readonly CVarDef<bool> SkillGain =
-        CVarDef.Create("trauma.skill_gain", true, CVar.SERVER | CVar.REPLICATED);
-
-    /// <summary>
-    /// Client setting to hide all skill-related popups.
-    /// </summary>
-    public static readonly CVarDef<bool> SkillPopups =
-        CVarDef.Create("trauma.skill_popups", true, CVar.CLIENTONLY | CVar.ARCHIVE);
-
     #endregion
 
     #region Chat

--- a/Content.Trauma.Shared/Knowledge/Quality/QualitySystem.cs
+++ b/Content.Trauma.Shared/Knowledge/Quality/QualitySystem.cs
@@ -285,13 +285,17 @@ public sealed partial class QualitySystem : EntitySystem
             return;
         }
 
-        var (knowledgeToUse, lowestId, lowestDelta, skillDelta) = FindLowestDelta(brain, ent.Comp.LevelDeltas);
+        var rand = SharedRandomExtensions.PredictedRandom(_timing, GetNetEntity(ent));
+        var roll = rand.Next(1, 100);
+        var modifier = 100 - roll * 2; // 99 to -100 if skills are disabled, purely random
+        if (_knowledge.SkillsEnabled)
+        {
+            var (knowledgeToUse, lowestId, lowestDelta, skillDelta) = FindLowestDelta(brain, ent.Comp.LevelDeltas);
+            var added = _knowledge.GetKnowledge(brain, knowledgeToUse)?.Comp.NetLevel ?? -1;
+            modifier = added + lowestDelta * 15 + ent.Comp.Quality + ent.Comp.QualityModifiers - roll;
+        }
 
-        var added = _knowledge.GetKnowledge(brain, knowledgeToUse)?.Comp.NetLevel ?? -1;
-
-        var roll = SharedRandomExtensions.PredictedRandom(_timing, GetNetEntity(ent)).Next(1, 100);
-
-        ent.Comp.Quality = (added + lowestDelta * 15 + ent.Comp.Quality + ent.Comp.QualityModifiers - roll) switch
+        ent.Comp.Quality = modifier switch
         {
             >= 88 => 5,
             >= 44 => 4,

--- a/Content.Trauma.Shared/Knowledge/Systems/ConstructionKnowledgeSystem.cs
+++ b/Content.Trauma.Shared/Knowledge/Systems/ConstructionKnowledgeSystem.cs
@@ -22,18 +22,10 @@ public sealed partial class ConstructionKnowledgeSystem : EntitySystem
 
     private static readonly ProtoId<QualityPrototype> BaseQuality = "BaseQuality";
 
-    public override void Initialize()
-    {
-        base.Initialize();
-
-        SubscribeLocalEvent<KnowledgeHolderComponent, ConstructAttemptEvent>(OnConstructAttempt);
-        SubscribeLocalEvent<KnowledgeHolderComponent, ConstructedEvent>(OnConstructed);
-        SubscribeLocalEvent<KnowledgeHolderComponent, ForgingCompletedEvent>(OnForgingCompleted);
-    }
-
+    [SubscribeLocalEvent]
     private void OnConstructAttempt(Entity<KnowledgeHolderComponent> ent, ref ConstructAttemptEvent args)
     {
-        if (args.Cancelled || !ProtoMan.Resolve<ConstructionPrototype>(args.Prototype, out var proto))
+        if (args.Cancelled || !_knowledge.SkillsEnabled || !ProtoMan.Resolve<ConstructionPrototype>(args.Prototype, out var proto))
             return;
 
         if (_knowledge.GetContainer(ent) is not { } brain)
@@ -62,12 +54,11 @@ public sealed partial class ConstructionKnowledgeSystem : EntitySystem
         }
     }
 
+    [SubscribeLocalEvent]
     private void OnConstructed(Entity<KnowledgeHolderComponent> ent, ref ConstructedEvent args)
     {
         if (!ProtoMan.Resolve<ConstructionPrototype>(args.Prototype, out var proto))
             return;
-
-        // TODO: grant xp when building shit
 
         // combines practical and theory knowledge together
         var levelDeltas = new Dictionary<EntProtoId, int>();
@@ -103,9 +94,9 @@ public sealed partial class ConstructionKnowledgeSystem : EntitySystem
         _quality.RollQuality((item, quality), ent);
     }
 
+    [SubscribeLocalEvent]
     private void OnForgingCompleted(Entity<KnowledgeHolderComponent> ent, ref ForgingCompletedEvent args)
     {
-        // TODO: grant xp from forging
         var item = args.Target;
         if (EnsureComp<QualityComponent>(item, out var quality))
             return;

--- a/Content.Trauma.Shared/Knowledge/Systems/SharedKnowledgeSystem.cs
+++ b/Content.Trauma.Shared/Knowledge/Systems/SharedKnowledgeSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.Body;
 using Content.Shared.Mind.Components;
 using Content.Shared.Polymorph;
 using Content.Shared.Random.Helpers;
+using Content.Shared.Whitelist;
 using Content.Trauma.Common.CCVar;
 using Content.Trauma.Common.Knowledge;
 using Content.Trauma.Common.Knowledge.Components;
@@ -26,6 +27,7 @@ namespace Content.Trauma.Shared.Knowledge.Systems;
 /// </summary>
 public abstract partial class SharedKnowledgeSystem : CommonKnowledgeSystem
 {
+    [Dependency] private EntityWhitelistSystem _whitelist = default!;
     [Dependency] protected IConfigurationManager _cfg = default!;
     [Dependency] protected IGameTiming _timing = default!;
     [Dependency] private INetManager _net = default!;
@@ -49,7 +51,19 @@ public abstract partial class SharedKnowledgeSystem : CommonKnowledgeSystem
         "Expert",
         "Master"
     ];
+    /// <summary>
+    /// When knowledge is disabled only these skills can be added.
+    /// </summary>
+    public static readonly EntityWhitelist DisabledSkillWhitelist = new()
+    {
+        Components =
+        [
+            "LanguageKnowledge",
+            "MartialArtsKnowledge"
+        ]
+    };
 
+    public bool SkillsEnabled;
     private bool _skillGain;
     private TimeSpan _nextUpdate;
     private TimeSpan _updateDelay = TimeSpan.FromSeconds(1);
@@ -64,6 +78,7 @@ public abstract partial class SharedKnowledgeSystem : CommonKnowledgeSystem
         InitializeLanguage();
         InitializeOnWear();
 
+        Subs.CVar(_cfg, TraumaCVars.SkillsEnabled, x => SkillsEnabled = x, true);
         Subs.CVar(_cfg, TraumaCVars.SkillGain, x => _skillGain = x, true);
 
         LoadSkillPrototypes();
@@ -373,6 +388,9 @@ public abstract partial class SharedKnowledgeSystem : CommonKnowledgeSystem
     /// </returns>
     public Entity<KnowledgeComponent>? EnsureKnowledge(Entity<KnowledgeContainerComponent> ent, [ForbidLiteral] EntProtoId id, int level = 0, bool popup = true)
     {
+        if (!SkillsEnabled && _whitelist.IsWhitelistFail(DisabledSkillWhitelist, id))
+            return null; // no crafting etc skills when disabled
+
         if (GetKnowledge(ent, id) is { } existing)
         {
             if (existing.Comp.LearnedLevel < level)

--- a/Content.Trauma.Shared/Weapons/Classes/WeaponClassSystem.cs
+++ b/Content.Trauma.Shared/Weapons/Classes/WeaponClassSystem.cs
@@ -25,7 +25,7 @@ public sealed partial class WeaponClassSystem : EntitySystem
 
     private void OnExamined(Entity<WeaponClassComponent> ent, ref ExaminedEvent args)
     {
-        if (!args.IsInDetailsRange || !ent.Comp.Examinable)
+        if (!_knowledge.SkillsEnabled || !args.IsInDetailsRange || !ent.Comp.Examinable)
             return;
 
         var name = ProtoMan.Index(ent.Comp.Class).Name;
@@ -34,6 +34,9 @@ public sealed partial class WeaponClassSystem : EntitySystem
 
     private void OnGetMeleeDamage(Entity<WeaponClassComponent> ent, ref GetMeleeDamageEvent args)
     {
+        if (!_knowledge.SkillsEnabled)
+            return;
+
         var proto = ProtoMan.Index(ent.Comp.Class);
         var level = GetSkillLevel(proto, args.User);
         args.Damage *= proto.MeleeDamage.GetCurve(level);
@@ -42,7 +45,7 @@ public sealed partial class WeaponClassSystem : EntitySystem
     // TODO: reduce aiming time instead of spread slop
     private void OnGetRecoilModifiers(Entity<WeaponClassComponent> ent, ref GetRecoilModifiersEvent args)
     {
-        if (args.User == ent.Owner)
+        if (args.User == ent.Owner || !_knowledge.SkillsEnabled)
             return; // no actual user welp
 
         var proto = ProtoMan.Index(ent.Comp.Class);

--- a/Resources/Prototypes/_Goobstation/Wraith/Curses/curses.yml
+++ b/Resources/Prototypes/_Goobstation/Wraith/Curses/curses.yml
@@ -121,9 +121,10 @@
       showInChat: true
     - !type:SpawnEntity
       entity: PuddleBloodSmall
-    - !type:EvenHealthChange
+    - !type:HealthChange
       damage:
-        Brute: 10
+        types:
+          Slash: 10
 #    - !type:PlaySoundBehavior This causes the ProtoID to be invalid for some reason
 #     sound:
 #      collection: Flesh_Tear

--- a/Resources/Prototypes/_Lavaland/Reagents/medicine.yml
+++ b/Resources/Prototypes/_Lavaland/Reagents/medicine.yml
@@ -84,16 +84,19 @@
           Burn: -6
           Airloss: -6
       # Improper pressure effects below
-      - !type:EvenHealthChange
+      - !type:HealthChange
         conditions:
         - !type:PressureCondition
           inverted: true
           min: 0
           max: 50
         damage:
-          Toxin: 1
-          Brute: 1
-          Airloss: 1
+          types:
+            Poison: 0.5
+            Radiation: 0.5
+            Blunt: 0.5
+            Slash: 0.5
+            Asphyxiation: 1
       - !type:Emote
         conditions:
         - !type:PressureCondition # five billion pressure conditions :joel:
@@ -144,10 +147,12 @@
         amount: -1
       - !type:ModifyBloodLevel
         amount: 1
-      - !type:EvenHealthChange # Overdose can cause blood to clot in the veins
+      - !type:HealthChange # Overdose can cause blood to clot in the veins
         conditions:
         - !type:ReagentCondition
           reagent: SerakaExtract
           min: 8
         damage:
-          Airloss: 7
+          types:
+            Asphyxiation: 3.5
+            Bloodloss: 3.5

--- a/Resources/Prototypes/_Trauma/Recipes/Construction/revbuildings.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Construction/revbuildings.yml
@@ -2,10 +2,20 @@
 
 - type: construction
   abstract: true
+  id: BaseRev
+  category: construction-category-antagonist
+  entityWhitelist: # if skills are disabled, prevents randoms making rev shit
+    components:
+    - Revolutionary
+  theory:
+    RevolutionaryKnowledge: 0
+
+- type: construction
+  abstract: true
+  parent: BaseRev
   id: BaseRevMachine
   graph: RevMachine
   placementMode: SnapgridCenter
-  category: construction-category-antagonist
   objectType: Structure
   canBuildInImpassable: false
   conditions:

--- a/Resources/Prototypes/_Trauma/Recipes/Crafting/other.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Crafting/other.yml
@@ -9,10 +9,10 @@
   useQuality: false
 
 - type: construction
+  parent: BaseRev
   id: PowerArmorStand
   graph: PowerArmorStand
   targetNode: PowerArmorStand
-  category: construction-category-antagonist
   objectType: Item
   theory:
     RevolutionaryKnowledge: 3

--- a/Resources/Prototypes/_Trauma/Recipes/Crafting/rev_ammo.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Crafting/rev_ammo.yml
@@ -1,13 +1,15 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 - type: construction
+  parent: BaseRevGun
   id: RevRPG2HE
   graph: RevRockets
   targetNode: HE
-  category: construction-category-antagonist
-  objectType: Item
   theory:
     RevolutionaryKnowledge: 2
+    WeaponsKnowledge: 2
+  practical:
+    MechanicsKnowledge: 1
     WeaponsKnowledge: 2
 
 - type: construction

--- a/Resources/Prototypes/_Trauma/Recipes/Crafting/rev_mechs.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Crafting/rev_mechs.yml
@@ -1,20 +1,20 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 - type: construction
+  parent: BaseRev
   id: Killdozer
   graph: Killdozer
   targetNode: Killdozer
-  category: construction-category-antagonist
   objectType: Item
   theory:
     RevolutionaryKnowledge: 3
   useQuality: false
 
 - type: construction
+  parent: BaseRev
   id: PowerArmorFrame
   graph: PowerArmorFrame
   targetNode: Frame
-  category: construction-category-antagonist
   objectType: Item
   theory:
     RevolutionaryKnowledge: 2

--- a/Resources/Prototypes/_Trauma/Recipes/Crafting/rev_parts.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Crafting/rev_parts.yml
@@ -4,12 +4,10 @@
 # only for bootstrapping if you lose your starting parts
 - type: construction
   abstract: true
+  parent: BaseRev
   id: BaseRevParts
   graph: RevParts
-  category: construction-category-antagonist
   objectType: Item
-  theory:
-    RevolutionaryKnowledge: 0
   practical:
     FabricationKnowledge: 1
     MetalworkingKnowledge: 1

--- a/Resources/Prototypes/_Trauma/Recipes/Crafting/rev_weapons.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Crafting/rev_weapons.yml
@@ -1,92 +1,60 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 - type: construction
+  abstract: true
+  parent: BaseRev
+  id: BaseRevGun
+  graph: RevGuns
+  objectType: Item
+  theory:
+    RevolutionaryKnowledge: 2
+    GunsmithingKnowledge: 0
+  practical:
+    WeaponsKnowledge: 2
+    GunsmithingKnowledge: 2
+
+- type: construction
+  parent: BaseRevGun
   id: RevLiberator
-  graph: RevGuns
   targetNode: liberator
-  category: construction-category-antagonist
-  objectType: Item
-  theory:
-    RevolutionaryKnowledge: 2
-    WeaponsKnowledge: 0 # revs dont get automatic weapons knowledge :)
-  practical:
-    GunsmithingKnowledge: 2
-    WeaponsKnowledge: 2
 
 - type: construction
+  parent: BaseRevGun
   id: RevResistance
-  graph: RevGuns
   targetNode: resistance
-  category: construction-category-antagonist
-  objectType: Item
-  theory:
-    RevolutionaryKnowledge: 2
-    WeaponsKnowledge: 0
-  practical:
-    GunsmithingKnowledge: 2
-    WeaponsKnowledge: 2
 
 - type: construction
-  id: RPG2
-  graph: RevGuns
+  parent: BaseRevGun
+  id: RevRPG2
   targetNode: RPG2
-  category: construction-category-antagonist
-  objectType: Item
   theory:
     RevolutionaryKnowledge: 2
+    GunsmithingKnowledge: 1
     WeaponsKnowledge: 1
   practical:
     GunsmithingKnowledge: 4
     WeaponsKnowledge: 3
 
 - type: construction
-  id: Flamethrower
-  graph: RevGuns
+  parent: RevRPG2
+  id: RevFlamethrower
   targetNode: Flamethrower
-  category: construction-category-antagonist
-  objectType: Item
-  theory:
-    RevolutionaryKnowledge: 2
-    WeaponsKnowledge: 1
-  practical:
-    GunsmithingKnowledge: 4
-    WeaponsKnowledge: 3
 
 - type: construction
+  parent: RevRPG2
   id: Devastator
-  graph: RevGuns
   targetNode: Devastator
-  category: construction-category-antagonist
-  objectType: Item
-  theory:
-    RevolutionaryKnowledge: 2
-    WeaponsKnowledge: 2
-  practical:
-    GunsmithingKnowledge: 2
-    WeaponsKnowledge: 2
 
 - type: construction
+  parent: RevRPG2
   id: Proletariat
-  graph: RevGuns
   targetNode: Proletariat
-  category: construction-category-antagonist
-  objectType: Item
-  theory:
-    RevolutionaryKnowledge: 2
-    WeaponsKnowledge: 1
-  practical:
-    GunsmithingKnowledge: 4
-    WeaponsKnowledge: 3
 
 - type: construction
+  parent: BaseRevGun
   id: RevIED
   graph: RevIED
   targetNode: IED
-  category: construction-category-antagonist
-  objectType: Item
-  theory:
-    RevolutionaryKnowledge: 2
-    WeaponsKnowledge: 2
   practical:
     MechanicsKnowledge: 2
     WeaponsKnowledge: 2

--- a/Resources/Prototypes/_Trauma/Vampires/Actions/haemomancer.yml
+++ b/Resources/Prototypes/_Trauma/Vampires/Actions/haemomancer.yml
@@ -181,9 +181,10 @@
         targetEffects:
         - !type:ModifyBloodLevel
           amount: -10
-        - !type:EvenHealthChange
+        - !type:HealthChange
           damage:
-            Brute: 5
+            types:
+              Slash: 5
         - !type:SpawnParticles
           particleProto: BloodParticles
     offToggle:


### PR DESCRIPTION
added trauma.skills_enabled cvar, true by default
- disables skills for construction
- prevents gaining skills that arent language or martial arts
- disable weapon class logic
- hide skill stuff from construction

cleaned up other stuff too

## Media

cant make rev shit as non rev

<img width="289" height="229" alt="01:16:16" src="https://github.com/user-attachments/assets/dec3a4e6-f437-476c-94fd-2bf2d478f57d" />

no more skills listed when its disabled

<img width="302" height="378" alt="01:16:27" src="https://github.com/user-attachments/assets/b653fdd9-2ffd-4ac5-929a-d036bdf5a25c" />

no physical etc skills

<img width="395" height="150" alt="01:19:48" src="https://github.com/user-attachments/assets/2f6d2d8b-e3d8-4731-8120-4a3e54ac3a55" />

:cl:
- tweak: Rev constructions are no longer listed for everyone since they can't craft them anyway.