### PR TITLE
fix traitor objectives picking noncrew

### DIFF
--- a/Resources/Prototypes/Objectives/base_objectives.yml
+++ b/Resources/Prototypes/Objectives/base_objectives.yml
@@ -60,6 +60,12 @@
   components:
   - type: PickRandomPerson
     conditions:
+    # <Trauma>
+    - !type:RoleWhitelist # pls kill operator met a. game
+      whitelist:
+        components:
+        - JobRole
+    # </Trauma>
     # Can't have multiple objectives to kill the same person.
     - !type:ObjectiveTargetCondition
       inverted: true

--- a/Resources/Prototypes/Objectives/base_objectives.yml
+++ b/Resources/Prototypes/Objectives/base_objectives.yml
@@ -61,7 +61,7 @@
   - type: PickRandomPerson
     conditions:
     # <Trauma>
-    - !type:RoleWhitelist # pls kill operator met a. game
+    - !type:RoleCondition # pls kill operator met a. game
       whitelist:
         components:
         - JobRole


### PR DESCRIPTION
fixes #3793

:cl:
- tweak: Traitor objectives now only pick people who have jobs. No more kill nukie or admin objective.