### PR TITLE
Biblesmashfix + no slash and pierce fails

### DIFF
--- a/Content.Shared/Bible/BibleSystem.cs
+++ b/Content.Shared/Bible/BibleSystem.cs
@@ -3,6 +3,7 @@ using Content.Medical.Common.Damage;
 using Content.Medical.Common.Targeting;
 using Content.Trauma.Common.Bible;
 using Content.Trauma.Common.Familiar;
+using Content.Shared.Mobs.Components;
 // </Trauma>
 using Content.Shared.ActionBlocker;
 using Content.Shared.Actions;
@@ -14,7 +15,6 @@ using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Inventory;
 using Content.Shared.Mobs;
-using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Popups;
 using Content.Shared.Random.Helpers;
@@ -97,7 +97,7 @@ public sealed partial class BibleSystem : EntitySystem
             return;
 
         if (args.Target == null || args.Target == args.User ||
-            !HasComp<MobStateComponent>(args.Target.Value) || // Trauma - no more bucket exploding, still heals crit targets.
+            !HasComp<MobStateComponent>(args.Target.Value) || // Trauma - Was IsAlive now works on critical, Added MobStateComponent to only targets creatures.
             _mobState.IsDead(args.Target.Value))
             return;
 

--- a/Content.Shared/Bible/BibleSystem.cs
+++ b/Content.Shared/Bible/BibleSystem.cs
@@ -1,9 +1,9 @@
 // <Trauma>
 using Content.Medical.Common.Damage;
 using Content.Medical.Common.Targeting;
+using Content.Shared.Mobs.Components;
 using Content.Trauma.Common.Bible;
 using Content.Trauma.Common.Familiar;
-using Content.Shared.Mobs.Components;
 // </Trauma>
 using Content.Shared.ActionBlocker;
 using Content.Shared.Actions;
@@ -96,10 +96,12 @@ public sealed partial class BibleSystem : EntitySystem
         if (!TryComp<UseDelayComponent>(ent, out var useDelay) || _delay.IsDelayed((ent, useDelay)))
             return;
 
+        // <Trauma> - Was IsAlive now works on critical, Added MobStateComponent to only targets creatures.
         if (args.Target == null || args.Target == args.User ||
-            !HasComp<MobStateComponent>(args.Target.Value) || // Trauma - Was IsAlive now works on critical, Added MobStateComponent to only targets creatures.
+            !HasComp<MobStateComponent>(args.Target.Value) ||
             _mobState.IsDead(args.Target.Value))
             return;
+        // </Trauma>
 
         // <Trauma>
         var bibleUsedEv = new BibleUsedEvent();

--- a/Content.Shared/Bible/BibleSystem.cs
+++ b/Content.Shared/Bible/BibleSystem.cs
@@ -14,6 +14,7 @@ using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Inventory;
 using Content.Shared.Mobs;
+using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Popups;
 using Content.Shared.Random.Helpers;
@@ -95,7 +96,9 @@ public sealed partial class BibleSystem : EntitySystem
         if (!TryComp<UseDelayComponent>(ent, out var useDelay) || _delay.IsDelayed((ent, useDelay)))
             return;
 
-        if (args.Target == null || args.Target == args.User || _mobState.IsDead(args.Target.Value)) // Trauma - was IsAlive bible heals crit targets now
+        if (args.Target == null || args.Target == args.User ||
+            !HasComp<MobStateComponent>(args.Target.Value) || // Trauma - no more bucket exploding, still heals crit targets.
+            _mobState.IsDead(args.Target.Value))
             return;
 
         // <Trauma>

--- a/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
@@ -63,6 +63,8 @@
   parent: BaseStorageItem
   id: Bible
   components:
+  - type: HolyIgniteOnMeleeHit # Trauma - it makes holy water
+    fireStacks: 1.0
   - type: UseDelay
     delay: 10.0
   - type: Bible
@@ -77,9 +79,7 @@
         Shock: -5
     damageOnFail:
       types:
-        Blunt: 5
-        Piercing: 5
-        Slash: 5
+        Blunt: 5 # Trauma - no slash and pierce?
         Asphyxiation: 15
     damageOnUntrainedUse: ## What a non-chaplain takes when attempting to heal someone
       types:

--- a/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
@@ -79,7 +79,7 @@
         Shock: -5
     damageOnFail:
       types:
-        Blunt: 5 # Trauma - no slash and pierce?
+        Blunt: 5 # Trauma - no slash and pierce
         Asphyxiation: 15
     damageOnUntrainedUse: ## What a non-chaplain takes when attempting to heal someone
       types:

--- a/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
@@ -79,7 +79,7 @@
         Shock: -5
     damageOnFail:
       types:
-        Blunt: 5 # Trauma - no slash and pierce
+        Blunt: 15 # Trauma - no slash and pierce
         Asphyxiation: 15
     damageOnUntrainedUse: ## What a non-chaplain takes when attempting to heal someone
       types:


### PR DESCRIPTION
Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md
NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
## About the PR
bible doesn't heal or break containers like jugs, bible attacks put 1 holy fire stack on hit.

## Why / Balance
bible is a book why would it deal slash and pierce damage + bug fix + holy fire on holy book attacks

## Test plan
attacked vamp, healed and harmed urist with bible and made holy water with several containers.

## Media


https://github.com/user-attachments/assets/817e983c-c8ae-4386-b5bd-cdb9d19c6720



## Requirements
- [x] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.

## Changelog
:cl:
- add: minor holy fire on bible attacks
- tweak: no pierce and slash on bible fails
- fix: bible cant heal or hurt objects anymore https://github.com/Trauma-Station/Trauma-Station/issues/3868
