### PR TITLE
Remove Blob as a Midround Antagonist

### DIFF
--- a/Resources/Prototypes/GameRules/dynamic_rules.yml
+++ b/Resources/Prototypes/GameRules/dynamic_rules.yml
@@ -66,13 +66,13 @@
           - !type:MaxRuleOccurenceCondition
           - !type:PlayerCountCondition
             min: 25
-        - id: BlobGameMode
-          weight: 10
-          conditions:
-          - !type:HasBudgetCondition
-          - !type:MaxRuleOccurenceCondition
-          - !type:PlayerCountCondition
-            min: 20
+        # - id: BlobGameMode # Removed until blob is fixed
+        #   weight: 10
+        #   conditions:
+        #   - !type:HasBudgetCondition
+        #   - !type:MaxRuleOccurenceCondition
+        #   - !type:PlayerCountCondition
+        #     min: 20
         # </Trauma>
       # Roundstart Minor Rules
       - !type:GroupSelector

--- a/Resources/Prototypes/GameRules/dynamic_rules.yml
+++ b/Resources/Prototypes/GameRules/dynamic_rules.yml
@@ -66,7 +66,7 @@
           - !type:MaxRuleOccurenceCondition
           - !type:PlayerCountCondition
             min: 25
-        # - id: BlobGameMode # Removed until blob is fixed
+        # - id: BlobGameMode # Disabled until its major bugs are fixed
         #   weight: 10
         #   conditions:
         #   - !type:HasBudgetCondition

--- a/Resources/Prototypes/_Goobstation/threats.yml
+++ b/Resources/Prototypes/_Goobstation/threats.yml
@@ -27,10 +27,10 @@
   announcement: terror-lone-operative
   rule: LoneOpsSpawn
 
-- type: ninjaHackingThreat
-  id: Blob
-  announcement: terror-blob
-  rule: BlobMidround
+# - type: ninjaHackingThreat # Disabled until its major bugs are fixed
+#   id: Blob
+#   announcement: terror-blob
+#   rule: BlobMidround
 
 - type: ninjaHackingThreat
   id: VoxRaiders

--- a/Resources/Prototypes/_Trauma/GameRules/events.yml
+++ b/Resources/Prototypes/_Trauma/GameRules/events.yml
@@ -31,7 +31,7 @@
   id: ModerateAntagEventsTrauma
   table: !type:AllSelector
     children:
-    - id: BlobMidround
+    #- id: BlobMidround # Disabled until its major bugs are fixed
     - id: DuoAbductorSpawn
     - id: BingleSpawn
     - id: XenomorphsInfestation

--- a/Resources/Prototypes/_Trauma/GameRules/security.yml
+++ b/Resources/Prototypes/_Trauma/GameRules/security.yml
@@ -24,8 +24,8 @@
         weight: 0.5 # even more antags!
       - id: LoneOpsSpawn
         weight: 0.2
-      - id: BlobMidround
-        weight: 0.2
+      # - id: BlobMidround # Disabled until its major bugs are fixed
+      #   weight: 0.2
       - !type:AllSelector
         weight: 0.3
         children: # double whammy


### PR DESCRIPTION
## About the PR
fixes #3897, I have removed blobs as a potential midround antagonist for 
- Ninja Threats
- Security Threats
- ModerateAntagEventsTrauma
- DynamicEventScheduler (just to be safe)

## Why / Balance
Blobs currently need more work. This is a follow up to PR #3683 


## Requirements
- [X] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Changelog
:cl:
- remove: Removed Blob Midround spawn
