### PR TITLE
Heretic reroll cleanup

### DIFF
--- a/Content.Trauma.Client/Waypointer/WaypointerSystem.cs
+++ b/Content.Trauma.Client/Waypointer/WaypointerSystem.cs
@@ -69,17 +69,11 @@ public sealed partial class WaypointerSystem : SharedWaypointerSystem
 
     private void OnPlayerAttached(EntityUid player, ActiveWaypointerComponent comp, LocalPlayerAttachedEvent args)
     {
-        if (args.Entity != _player.LocalEntity)
-            return;
-
         _overlay.AddOverlay(_waypointerOverlay);
     }
 
     private void OnPlayerDetached(EntityUid player, ActiveWaypointerComponent comp, LocalPlayerDetachedEvent args)
     {
-        if (args.Entity != _player.LocalEntity)
-            return;
-
         _overlay.RemoveOverlay(_waypointerOverlay);
     }
 }

--- a/Content.Trauma.Client/Waypointer/WaypointerSystem.cs
+++ b/Content.Trauma.Client/Waypointer/WaypointerSystem.cs
@@ -41,17 +41,17 @@ public sealed partial class WaypointerSystem : SharedWaypointerSystem
         _waypointerOverlay = new WaypointerOverlay();
     }
 
-    private void OnAddition(EntityUid uid, ActiveWaypointerComponent comp, ref ComponentStartup args)
+    private void OnAddition(EntityUid player, ActiveWaypointerComponent comp, ref ComponentStartup args)
     {
-        if (_player.LocalEntity is not { } player || player != uid)
+        if (_player.LocalEntity != player)
             return;
 
         _overlay.AddOverlay(_waypointerOverlay);
     }
 
-    private void OnRemoval(EntityUid uid, ActiveWaypointerComponent comp, ref ComponentShutdown args)
+    private void OnRemoval(EntityUid player, ActiveWaypointerComponent comp, ref ComponentShutdown args)
     {
-        if (_player.LocalEntity is not { } player || player != uid)
+        if (_player.LocalEntity != player)
             return;
 
         _overlay.RemoveOverlay(_waypointerOverlay);
@@ -67,7 +67,7 @@ public sealed partial class WaypointerSystem : SharedWaypointerSystem
             _overlay.RemoveOverlay(_waypointerOverlay);
     }
 
-    private void OnPlayerAttached(EntityUid uid, ActiveWaypointerComponent comp, LocalPlayerAttachedEvent args)
+    private void OnPlayerAttached(EntityUid player, ActiveWaypointerComponent comp, LocalPlayerAttachedEvent args)
     {
         if (args.Entity != _player.LocalEntity)
             return;
@@ -75,7 +75,7 @@ public sealed partial class WaypointerSystem : SharedWaypointerSystem
         _overlay.AddOverlay(_waypointerOverlay);
     }
 
-    private void OnPlayerDetached(EntityUid uid, ActiveWaypointerComponent comp, LocalPlayerDetachedEvent args)
+    private void OnPlayerDetached(EntityUid player, ActiveWaypointerComponent comp, LocalPlayerDetachedEvent args)
     {
         if (args.Entity != _player.LocalEntity)
             return;

--- a/Content.Trauma.Client/Waypointer/WaypointerSystem.cs
+++ b/Content.Trauma.Client/Waypointer/WaypointerSystem.cs
@@ -26,14 +26,14 @@ public sealed partial class WaypointerSystem : SharedWaypointerSystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<ActiveWaypointerComponent, ComponentInit>(OnAddition);
-        SubscribeLocalEvent<ActiveWaypointerComponent, ComponentRemove>(OnRemoval);
+        SubscribeLocalEvent<ActiveWaypointerComponent, ComponentStartup>(OnAddition);
+        SubscribeLocalEvent<ActiveWaypointerComponent, ComponentShutdown>(OnRemoval);
 
         SubscribeLocalEvent<ActiveWaypointerComponent, LocalPlayerAttachedEvent>(OnPlayerAttached);
         SubscribeLocalEvent<ActiveWaypointerComponent, LocalPlayerDetachedEvent>(OnPlayerDetached);
 
-        SubscribeLocalEvent<SimpleWaypointerComponent, ComponentInit>(OnAddition);
-        SubscribeLocalEvent<SimpleWaypointerComponent, ComponentRemove>(OnRemoval);
+        SubscribeLocalEvent<SimpleWaypointerComponent, ComponentStartup>(OnAddition);
+        SubscribeLocalEvent<SimpleWaypointerComponent, ComponentShutdown>(OnRemoval);
 
         SubscribeLocalEvent<SimpleWaypointerComponent, LocalPlayerAttachedEvent>(OnPlayerAttached);
         SubscribeLocalEvent<SimpleWaypointerComponent, LocalPlayerDetachedEvent>(OnPlayerDetached);
@@ -41,19 +41,17 @@ public sealed partial class WaypointerSystem : SharedWaypointerSystem
         _waypointerOverlay = new WaypointerOverlay();
     }
 
-    private void OnAddition(EntityUid player, ActiveWaypointerComponent comp, ref ComponentInit args)
+    private void OnAddition(EntityUid uid, ActiveWaypointerComponent comp, ref ComponentStartup args)
     {
-        if (_player.LocalEntity == null || player != _player.LocalEntity.Value
-            || _timing.ApplyingState)
+        if (_player.LocalEntity is not { } player || player != uid)
             return;
 
         _overlay.AddOverlay(_waypointerOverlay);
     }
 
-    private void OnRemoval(EntityUid player, ActiveWaypointerComponent comp, ref ComponentRemove args)
+    private void OnRemoval(EntityUid uid, ActiveWaypointerComponent comp, ref ComponentShutdown args)
     {
-        if (_player.LocalEntity == null || player != _player.LocalEntity.Value
-            || _timing.ApplyingState)
+        if (_player.LocalEntity is not { } player || player != uid)
             return;
 
         _overlay.RemoveOverlay(_waypointerOverlay);
@@ -69,7 +67,7 @@ public sealed partial class WaypointerSystem : SharedWaypointerSystem
             _overlay.RemoveOverlay(_waypointerOverlay);
     }
 
-    private void OnPlayerAttached(EntityUid player, ActiveWaypointerComponent comp, LocalPlayerAttachedEvent args)
+    private void OnPlayerAttached(EntityUid uid, ActiveWaypointerComponent comp, LocalPlayerAttachedEvent args)
     {
         if (args.Entity != _player.LocalEntity)
             return;
@@ -77,7 +75,7 @@ public sealed partial class WaypointerSystem : SharedWaypointerSystem
         _overlay.AddOverlay(_waypointerOverlay);
     }
 
-    private void OnPlayerDetached(EntityUid player, ActiveWaypointerComponent comp, LocalPlayerDetachedEvent args)
+    private void OnPlayerDetached(EntityUid uid, ActiveWaypointerComponent comp, LocalPlayerDetachedEvent args)
     {
         if (args.Entity != _player.LocalEntity)
             return;

--- a/Content.Trauma.Server/Heretic/Systems/HereticSystem.cs
+++ b/Content.Trauma.Server/Heretic/Systems/HereticSystem.cs
@@ -84,6 +84,9 @@ public sealed partial class HereticSystem : SharedHereticSystem
         { SacrificeTargetType.Security, typeof(SecurityStaffComponent) },
     };
 
+    private List<SacrificeTargetData> _toRemove = new();
+    private List<SacrificeTargetData> _toAdd = new();
+
     public static readonly ProtoId<NpcFactionPrototype> HereticFactionId = "Heretic";
     public static readonly ProtoId<NpcFactionPrototype> NanotrasenFactionId = "NanoTrasen";
     public static readonly ProtoId<TagPrototype> AscensionRitualTag = "RitualAscension";
@@ -111,7 +114,7 @@ public sealed partial class HereticSystem : SharedHereticSystem
         var query = AllEntityQuery<HereticComponent, MindComponent>();
         while (query.MoveNext(out var uid, out var comp, out var mind))
         {
-            HereticTargetsUpdated((uid, comp, mind));
+            UpdateHereticTargets((uid, comp, mind));
         }
     }
 
@@ -424,8 +427,15 @@ public sealed partial class HereticSystem : SharedHereticSystem
     [SubscribeLocalEvent]
     private void OnUpdateTargets(Entity<HereticComponent> ent, ref EventHereticUpdateTargets args)
     {
+        UpdateHereticTargets(ent);
+    }
+
+    private void UpdateHereticTargets(Entity<HereticComponent, MindComponent?> ent)
+    {
         List<EntityUid>? targets = null;
-        foreach (var target in ent.Comp.SacrificeTargets.ToList())
+        _toRemove.Clear();
+        _toAdd.Clear();
+        foreach (var target in ent.Comp1.SacrificeTargets)
         {
             if (TryGetEntity(target.Entity, out var tent) &&
                 Exists(tent.Value) && !Paused(tent.Value) &&
@@ -434,11 +444,23 @@ public sealed partial class HereticSystem : SharedHereticSystem
 
             targets ??= GetHereticTargets(ent);
 
-            RerollIndividualTarget(ent, target, targets, false);
+            if (RerollIndividualTarget(ent, target, targets) is { } newTarget)
+                _toAdd.Add(newTarget);
+            _toRemove.Add(target);
+        }
+
+        foreach (var target in _toRemove)
+        {
+            ent.Comp1.SacrificeTargets.Remove(target);
+        }
+
+        foreach (var target in _toAdd)
+        {
+            ent.Comp1.SacrificeTargets.Add(target);
         }
 
         HereticTargetsUpdated(ent);
-        Dirty(ent);
+        Dirty(ent, ent.Comp1);
     }
 
     private List<EntityUid> GetHereticTargets(Entity<HereticComponent> ent)
@@ -450,17 +472,20 @@ public sealed partial class HereticSystem : SharedHereticSystem
 
         bool IsSessionValid(ICommonSession session)
         {
-            if (!_humanoidQuery.HasComp(session.AttachedEntity))
+            if (session.AttachedEntity is not { } uid)
                 return false;
 
-            if (IsHereticOrGhoul(session.AttachedEntity.Value))
+            if (!_humanoidQuery.HasComp(uid))
                 return false;
 
-            if (_targetQuery.TryComp(session.AttachedEntity.Value, out var target) &&
+            if (IsHereticOrGhoul(uid))
+                return false;
+
+            if (_targetQuery.TryComp(uid, out var target) &&
                 target.HereticMinds.Contains(ent))
                 return false;
 
-            if (!_mind.TryGetMind(session.AttachedEntity.Value, out var mind, out _) ||
+            if (!_mind.TryGetMind(uid, out var mind, out _) ||
                 mind == ent.Owner || !_job.MindTryGetJobId(mind, out _))
                 return false;
 
@@ -483,14 +508,15 @@ public sealed partial class HereticSystem : SharedHereticSystem
 
     private void RemoveSacrificeTarget(Entity<HereticComponent, MindComponent?> ent, SacrificeTargetData data)
     {
-        if (!ent.Comp1.SacrificeTargets.Remove(data) ||
-            !TryGetEntity(data.Entity, out var uid) ||
-            !TryComp(uid, out HereticSacrificeTargetComponent? target))
+        if (!TryGetEntity(data.Entity, out var uid))
             return;
 
-        target.HereticMinds.Remove(ent);
-        if (target.HereticMinds.Count == 0)
-            RemComp(uid.Value, target);
+        if (TryComp(uid, out HereticSacrificeTargetComponent? target))
+        {
+            target.HereticMinds.Remove(ent);
+            if (target.HereticMinds.Count == 0)
+                RemComp(uid.Value, target);
+        }
 
         if (!Resolve(ent, ref ent.Comp2) || !PlayerMan.TryGetSessionById(ent.Comp2.UserId, out var session))
             return;
@@ -498,29 +524,20 @@ public sealed partial class HereticSystem : SharedHereticSystem
         _pvs.RemoveSessionOverride(uid.Value, session);
     }
 
-    private void RerollIndividualTarget(Entity<HereticComponent> ent, SacrificeTargetData data, List<EntityUid>? targets = null, bool dirtyAndUpdate = true)
+    private SacrificeTargetData? RerollIndividualTarget(Entity<HereticComponent> ent, SacrificeTargetData data, List<EntityUid>? targets = null)
     {
-        if (!ent.Comp.SacrificeTargets.Contains(data))
-            return;
-
         RemoveSacrificeTarget(ent, data);
 
         targets ??= GetHereticTargets(ent);
 
         if (targets.Count == 0)
-            return;
+            return null;
 
         var picked = SacrificeTypes.TryGetValue(data.Type, out var type)
             ? _rand.Pick(targets.Where(x => HasComp(x, type)).ToList())
             : _rand.Pick(targets);
         targets.Remove(picked);
-        ent.Comp.SacrificeTargets.Add(GetData(picked, data.Type));
-
-        if (!dirtyAndUpdate)
-            return;
-
-        HereticTargetsUpdated(ent);
-        Dirty(ent);
+        return GetData(picked, data.Type);
     }
 
     [SubscribeLocalEvent]
@@ -530,6 +547,8 @@ public sealed partial class HereticSystem : SharedHereticSystem
         {
             RemoveSacrificeTarget(ent, target);
         }
+
+        ent.Comp.SacrificeTargets.Clear();
 
         var targets = GetHereticTargets(ent);
         if (targets.Count == 0)

--- a/Content.Trauma.Server/Heretic/Systems/HereticSystem.cs
+++ b/Content.Trauma.Server/Heretic/Systems/HereticSystem.cs
@@ -438,8 +438,7 @@ public sealed partial class HereticSystem : SharedHereticSystem
         foreach (var target in ent.Comp1.SacrificeTargets)
         {
             if (TryGetEntity(target.Entity, out var tent) &&
-                Exists(tent.Value) && !Paused(tent.Value) &&
-                !EntityManager.IsQueuedForDeletion(tent.Value))
+                !TerminatingOrDeleted(tent.Value) && !Paused(tent.Value))
                 continue;
 
             targets ??= GetHereticTargets(ent);


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->

Changed reroll system a bit to not cause errors. Also waypointers didnt work unless you relogged because of overlay wasn't being added to you on startup.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

Log in with 2 clients. Make 1 heretic, test waypointer living heart - works. respawn as the other and sacrifice old body - auto reroll works. Respawn again and do relentless heartbeat reroll ritual - works.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
