### PR TITLE
bioweapon time change

### DIFF
--- a/Resources/Prototypes/_Trauma/Entities/Objects/Devices/Reinforcements/catalog.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Objects/Devices/Reinforcements/catalog.yml
@@ -192,9 +192,9 @@
     Spesos: 15000
   categories:
   - Bioweapons
-  restockTime: 45m
+  restockTime: 30m
   resetRestockOnPurchase: true
-  restockAfterPurchase: 45m
+  restockAfterPurchase: 30m
 
 # Medical
 


### PR DESCRIPTION
changed the bioweapon time to 30 from 45

<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->
i changed the time from 45 to 30 for the bioweapon caller
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
because bioweapons ARENT that strong. they don't need such a big time nerf. 30 is enough  a normal round is about 1 hour and 30 minutes you'll get 3 if you buy it at 30 at the mark per
## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves. 
-->
i haven't tested  but it should be simple enough for it not to really matter, go into game with this and then get the sec caller and look at bioweapons should be 30 minutes
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Souk
- tweak: bioweapons restock/stock timer reduced to 30m from 45m


