### PR TITLE
add locking to ai vision job

### DIFF
--- a/Content.Shared/Silicons/StationAi/StationAiVisionSystem.Trauma.cs
+++ b/Content.Shared/Silicons/StationAi/StationAiVisionSystem.Trauma.cs
@@ -1,0 +1,6 @@
+namespace Content.Shared.Silicons.StationAi;
+
+public sealed partial class StationAiVisionSystem
+{
+    private bool _jobLocked;
+}

--- a/Content.Shared/Silicons/StationAi/StationAiVisionSystem.cs
+++ b/Content.Shared/Silicons/StationAi/StationAiVisionSystem.cs
@@ -64,6 +64,13 @@ public sealed partial class StationAiVisionSystem : EntitySystem
     /// </summary>
     public bool IsAccessible(Entity<BroadphaseComponent, MapGridComponent> grid, Vector2i tile, float expansionSize = 8.5f, bool fastPath = false)
     {
+        // <Trauma>
+        if (_jobLocked)
+        {
+            Log.Error($"Called IsAccessible for {ToPrettyString(grid)} @ {tile} from inside its parallel jobs! Stack trace: {Environment.StackTrace}");
+            return true;
+        }
+        // </Trauma>
         _viewportTiles.Clear();
         _opaque.Clear();
         _seeds.Clear();
@@ -120,7 +127,17 @@ public sealed partial class StationAiVisionSystem : EntitySystem
         _singleTiles.Clear();
         _job.Grid = (grid.Owner, grid.Comp2);
         _job.VisibleTiles = _singleTiles;
-        _parallel.ProcessNow(_job, _job.Data.Count);
+        // <Trauma> - set _jobLocked to prevent recursion
+        try
+        {
+            _jobLocked = true;
+            _parallel.ProcessNow(_job, _job.Data.Count);
+        }
+        finally
+        {
+            _jobLocked = false;
+        }
+        // <Trauma>
 
         return _job.VisibleTiles.Contains(tile);
     }


### PR DESCRIPTION
resolves #3912

if its called recursively it assumes its visible as if theres a player facing cause it's better to let ai see more than it should than be blind and ragequit