### PR TITLE
make botany chems heal ballistic

### DIFF
--- a/Resources/Prototypes/Reagents/botany.yml
+++ b/Resources/Prototypes/Reagents/botany.yml
@@ -128,6 +128,7 @@
       - !type:HealthChange
         damage:
           types:
+            Ballistic: -2 # Trauma
             Poison: -2
             Blunt: -3
             Slash: -3

--- a/Resources/Prototypes/_Goobstation/Reagents/botany.yml
+++ b/Resources/Prototypes/_Goobstation/Reagents/botany.yml
@@ -54,6 +54,7 @@
             Blunt: -0.4
             Slash: -0.4
             Piercing: -0.4
+            Ballistic: -0.4
             Heat: -0.8
             Cold: -0.8
         conditions:


### PR DESCRIPTION
fixes #3950 

:cl:
- fix: Fixed robust harvest and saltpeter not healing ballistic damage on dionae.