### PR TITLE
Heretic blade surgery bugfix

### DIFF
--- a/Resources/Prototypes/_Goobstation/Heretic/Entities/Objects/Weapons/Melee/heretic_blades.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Entities/Objects/Weapons/Melee/heretic_blades.yml
@@ -77,6 +77,7 @@
   - type: LandAtCursor
   - type: UnholyItem
   - type: HereticBlade
+  - type: SurgeryTool
   - type: Tool
     qualities:
     - Slicing


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->
Fixes heretic blades not being bonesaws or scalpels
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Someone on discord asked if heretic blades should be bonesaws, and I said they should be. Checked on a localhost, and they weren't.
## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
I spawned in a heretic blade without the change. No surgical qualities. Checked after change. Has surgical qualities.
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

before
<img width="465" height="335" alt="no surgical tool" src="https://github.com/user-attachments/assets/4c52964d-023b-4f9a-8eac-71ea1db9c8ed" />

after
<img width="488" height="368" alt="yes surgery tool" src="https://github.com/user-attachments/assets/9db3593f-6048-46a5-9005-e7c8ce3e446b" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: RatherUncreativeName
- fix: Fixed heretic blades not acting as bonesaws or scalpels
