### PR TITLE
Small heretic fix

### DIFF
--- a/Content.Trauma.Server/Heretic/Abilities/HereticAbilitySystem.cs
+++ b/Content.Trauma.Server/Heretic/Abilities/HereticAbilitySystem.cs
@@ -26,6 +26,7 @@ using Content.Shared.Store.Components;
 using Content.Shared.Stunnable;
 using Content.Shared.Weather;
 using Content.Trauma.Common.CollectiveMind;
+using Content.Trauma.Server.Heretic.Systems;
 using Content.Trauma.Server.Heretic.Systems.PathSpecific;
 using Content.Trauma.Shared.Heretic.Events;
 using Content.Trauma.Shared.Heretic.Systems.Abilities;
@@ -34,7 +35,6 @@ using Robust.Server.Containers;
 using Robust.Server.GameStates;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
-using Robust.Shared.Map;
 
 namespace Content.Trauma.Server.Heretic.Abilities;
 
@@ -69,6 +69,7 @@ public sealed partial class HereticAbilitySystem : SharedHereticAbilitySystem
     [Dependency] private SharedSanguineStrikeSystem _lifesteal = default!;
     [Dependency] private ContainerSystem _container = default!;
     [Dependency] private BladeArenaSystem _arena = default!;
+    [Dependency] private HereticSystem _heretic = default!;
 
     #endregion
 
@@ -99,8 +100,7 @@ public sealed partial class HereticAbilitySystem : SharedHereticAbilitySystem
         if (!TryComp<UserInterfaceComponent>(mind, out var uic))
             return;
 
-        var ev = new EventHereticUpdateTargets();
-        RaiseLocalEvent(mind, ev);
+        _heretic.UpdateHereticTargets((mind, heretic));
 
         var uid = args.Performer;
 

--- a/Content.Trauma.Server/Heretic/Systems/HereticSystem.cs
+++ b/Content.Trauma.Server/Heretic/Systems/HereticSystem.cs
@@ -42,7 +42,6 @@ using Content.Trauma.Shared.Heretic.Systems;
 using Robust.Server.GameStates;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
-using Robust.Shared.Enums;
 using Robust.Shared.Player;
 using Robust.Shared.Random;
 
@@ -91,32 +90,6 @@ public sealed partial class HereticSystem : SharedHereticSystem
     public static readonly ProtoId<NpcFactionPrototype> NanotrasenFactionId = "NanoTrasen";
     public static readonly ProtoId<TagPrototype> AscensionRitualTag = "RitualAscension";
     public static readonly ProtoId<TagPrototype> FeastOfOwlsRitualTag = "RitualFeastOfOwls";
-
-    public override void Initialize()
-    {
-        base.Initialize();
-
-        PlayerMan.PlayerStatusChanged += StatusChanged;
-    }
-
-    public override void Shutdown()
-    {
-        base.Shutdown();
-
-        PlayerMan.PlayerStatusChanged -= StatusChanged;
-    }
-
-    private void StatusChanged(object? sender, SessionStatusEventArgs e)
-    {
-        if (e.NewStatus != SessionStatus.InGame)
-            return;
-
-        var query = AllEntityQuery<HereticComponent, MindComponent>();
-        while (query.MoveNext(out var uid, out var comp, out var mind))
-        {
-            UpdateHereticTargets((uid, comp, mind));
-        }
-    }
 
     [SubscribeLocalEvent]
     private void OnStateChanged(MobStateChangedEvent args)
@@ -424,13 +397,7 @@ public sealed partial class HereticSystem : SharedHereticSystem
         ev.WeakToHoly = true;
     }
 
-    [SubscribeLocalEvent]
-    private void OnUpdateTargets(Entity<HereticComponent> ent, ref EventHereticUpdateTargets args)
-    {
-        UpdateHereticTargets(ent);
-    }
-
-    private void UpdateHereticTargets(Entity<HereticComponent, MindComponent?> ent)
+    public void UpdateHereticTargets(Entity<HereticComponent, MindComponent?> ent)
     {
         List<EntityUid>? targets = null;
         _toRemove.Clear();
@@ -532,11 +499,25 @@ public sealed partial class HereticSystem : SharedHereticSystem
         if (targets.Count == 0)
             return null;
 
-        var picked = SacrificeTypes.TryGetValue(data.Type, out var type)
-            ? _rand.Pick(targets.Where(x => HasComp(x, type)).ToList())
-            : _rand.Pick(targets);
+        var dataType = data.Type;
+
+        EntityUid picked;
+        if (SacrificeTypes.TryGetValue(dataType, out var type))
+        {
+            var list = targets.Where(x => HasComp(x, type)).ToList();
+            if (list.Count == 0)
+            {
+                picked = _rand.Pick(targets);
+                dataType = SacrificeTargetType.None;
+            }
+            else
+                picked = _rand.Pick(list);
+        }
+        else
+            picked = _rand.Pick(targets);
+
         targets.Remove(picked);
-        return GetData(picked, data.Type);
+        return GetData(picked, dataType);
     }
 
     [SubscribeLocalEvent]

--- a/Content.Trauma.Server/Heretic/Systems/PathSpecific/LeechingWalkSystem.cs
+++ b/Content.Trauma.Server/Heretic/Systems/PathSpecific/LeechingWalkSystem.cs
@@ -82,8 +82,11 @@ public sealed partial class LeechingWalkSystem : EntitySystem
             var boneHeal = FixedPoint2.Zero;
             if (_hereticQuery.TryComp(mindContainer.Mind, out var heretic))
             {
+                if (heretic.CurrentPath != HereticPath.Rust)
+                    continue;
+
                 multiplier += heretic.PassiveLevel * 0.5f;
-                if (heretic is { Ascended: true, CurrentPath: HereticPath.Rust })
+                if (heretic.Ascended)
                 {
                     if (_respiratorQuery.TryComp(uid, out var respirator))
                     {

--- a/Content.Trauma.Shared/Heretic/Components/Side/Carvings/CarvingKnifeComponent.cs
+++ b/Content.Trauma.Shared/Heretic/Components/Side/Carvings/CarvingKnifeComponent.cs
@@ -19,7 +19,7 @@ public sealed partial class CarvingKnifeComponent : Component
     public int MaxRuneAmount = 3;
 
     [DataField]
-    public TimeSpan RuneDrawTime = TimeSpan.FromSeconds(3f);
+    public TimeSpan RuneDrawTime = TimeSpan.FromSeconds(1f);
 
     [DataField]
     public SoundSpecifier Sound = new SoundPathSpecifier("/Audio/_Goobstation/Heretic/sheath.ogg");

--- a/Content.Trauma.Shared/Heretic/Events/HereticEvents.cs
+++ b/Content.Trauma.Shared/Heretic/Events/HereticEvents.cs
@@ -34,9 +34,6 @@ public sealed partial class EventHereticAscension : EntityEventArgs;
 public sealed partial class EventHereticRerollTargets : EntityEventArgs;
 
 [DataDefinition]
-public sealed partial class EventHereticUpdateTargets : EntityEventArgs;
-
-[DataDefinition]
 public sealed partial class EventHereticResolveStarGazer : EntityEventArgs;
 
 [DataDefinition]

--- a/Content.Trauma.Shared/Heretic/Systems/Abilities/SharedHereticAbilitySystem.Rust.cs
+++ b/Content.Trauma.Shared/Heretic/Systems/Abilities/SharedHereticAbilitySystem.Rust.cs
@@ -352,6 +352,7 @@ public abstract partial class SharedHereticAbilitySystem
 
         var mapCoords = _transform.ToMapCoordinates(args.Target);
 
+        _lookupMobs.Clear();
         Lookup.GetEntitiesInRange(args.Target, args.MobCheckRange, _lookupMobs, LookupFlags.Dynamic);
         foreach (var (entity, _) in _lookupMobs)
         {

--- a/Content.Trauma.Shared/Heretic/Systems/Abilities/SharedHereticAbilitySystem.Rust.cs
+++ b/Content.Trauma.Shared/Heretic/Systems/Abilities/SharedHereticAbilitySystem.Rust.cs
@@ -57,7 +57,7 @@ public abstract partial class SharedHereticAbilitySystem
     [SubscribeLocalEvent]
     private void OnBeforeHarmfulAction(Entity<RustbringerComponent> ent, ref BeforeHarmfulActionEvent args)
     {
-        if (args.Cancelled || args.Type is HarmfulActionType.Disarm or HarmfulActionType.Grab)
+        if (args.Cancelled || args.Type is not (HarmfulActionType.Disarm or HarmfulActionType.Grab))
             return;
 
         if (!IsOnRust(ent))

--- a/Resources/Prototypes/_Goobstation/Heretic/Entities/Structures/Specific/Heretic/carvings.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Entities/Structures/Specific/Heretic/carvings.yml
@@ -12,7 +12,7 @@
   - type: Sprite
     drawdepth: FloorEffects
     sprite: _Goobstation/Heretic/carvings.rsi
-    color: '#FFFFFF14'
+    color: '#FFFFFF7D'
   - type: Fixtures
     fixtures:
       fix1:
@@ -108,7 +108,7 @@
     sprite: _Goobstation/Heretic/carvings.rsi
     state: alert_rune
   - type: Sprite
-    color: '#FFFFFF0a'
+    color: '#FFFFFF14'
     state: alert_rune
   - type: WizardTrap
     sparks: false

--- a/Resources/Prototypes/_Goobstation/Heretic/Heretic/heretic_rituals.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Heretic/heretic_rituals.yml
@@ -43,12 +43,6 @@
         applyOn: Targets
         min: 1
         cancelLoc: heretic-ritual-fail-sacrifice-ineligible
-    - !type:EffectsRitualEffect
-      applyOn: Mind
-      effects:
-      - !type:RaiseEvents
-        events:
-        - !type:EventHereticUpdateTargets
 
 - type: entity
   id: RitualAmberFocus
@@ -398,7 +392,6 @@
       - !type:RaiseEvents
         events:
         - !type:EventHereticAscension
-        - !type:EventHereticUpdateTargets
         - !type:EventHereticAddKnowledge
           knowledge:
           - AshlordRite
@@ -563,7 +556,6 @@
       - !type:RaiseEvents
         events:
         - !type:EventHereticAscension
-        - !type:EventHereticUpdateTargets
         - !type:EventHereticAddKnowledge
           knowledge:
           - MaelstromOfSilver
@@ -937,7 +929,6 @@
       - !type:RaiseEvents
         events:
         - !type:EventHereticAscension
-        - !type:EventHereticUpdateTargets
         - !type:EventHereticAddKnowledge
           knowledge:
           - PriestFinalHymn
@@ -1106,7 +1097,6 @@
       - !type:RaiseEvents
         events:
         - !type:EventHereticAscension
-        - !type:EventHereticUpdateTargets
         - !type:EventHereticAddKnowledge
           knowledge:
           - WaltzAtTheEndOfTime
@@ -1273,7 +1263,6 @@
       - !type:RaiseEvents
         events:
         - !type:EventHereticAscension
-        - !type:EventHereticUpdateTargets
         - !type:EventHereticAddKnowledge
           knowledge:
           - RustbringersOath
@@ -1441,7 +1430,6 @@
       - !type:RaiseEvents
         events:
         - !type:EventHereticAscension
-        - !type:EventHereticUpdateTargets
         - !type:EventHereticResolveStarGazer
         - !type:EventHereticAddKnowledge
           knowledge:
@@ -1750,7 +1738,6 @@
       - !type:RaiseEvents
         events:
         - !type:EventHereticAscension
-        - !type:EventHereticUpdateTargets
         - !type:EventHereticAddKnowledge
           knowledge:
           - UnlockTheLabyrinth
@@ -2378,6 +2365,9 @@
         - whitelist:
             tags:
             - Knife
+          blacklist:
+            components:
+            - CarvingKnife
           name: heretic-ritual-ingredient-knife
     - !type:EffectsRitualEffect
       applyOn: Delete


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->

Fixed inverted if statement making ascended rust heretics immune to melee.
Fix rust construction not working cause it didn't clear lookup hashset.
Fixed yet another reroll exception that occurs if no sec or command members exist when trying to reroll one.
Just removed target update event from heretic rituals, its useless and its being updated when heretic uses living heart anyway.
Carving knife now draws runes 3x faster, but runes are much more visible. Should make it more viable in combat and make it something that is not cancer trapping tool that spawns invisible runes in large quantities. People barely even used it anyway, they wont use it now either so whatever.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Aviu
- fix: Fix rust ascended heretics being immune to melee.
- tweak: Carving knife draws runes 3x faster but they are much more visible.
- fix: Fix rust construction not working.