### PR TITLE
Track anomaly location in anom vessel

### DIFF
--- a/Content.Server/Anomaly/AnomalySystem.Vessel.cs
+++ b/Content.Server/Anomaly/AnomalySystem.Vessel.cs
@@ -33,6 +33,8 @@ public sealed partial class AnomalySystem
         args.PushText(component.Anomaly == null
             ? Loc.GetString("anomaly-vessel-component-not-assigned")
             : Loc.GetString("anomaly-vessel-component-assigned"));
+
+        args.PushText(component.BeaconLocation ?? Loc.GetString("anomaly-beacon-unknown"), -1); // Trauma
     }
 
     private void OnVesselShutdown(EntityUid uid, AnomalyVesselComponent component, ComponentShutdown args)
@@ -63,10 +65,15 @@ public sealed partial class AnomalySystem
         if (!TryComp<AnomalyComponent>(anomaly, out var anomalyComponent) || anomalyComponent.ConnectedVessel != null)
             return;
 
+        // <Trauma>
+        var beacon = _navmap.GetNearestBeaconString(_transform.GetMapCoordinates(scanner.ScannedAnomaly.Value), true);
+        component.BeaconLocation = Loc.GetString("anomaly-beacon-location", ("location", beacon));
+        // </Trauma>
+
         component.Anomaly = scanner.ScannedAnomaly;
         anomalyComponent.ConnectedVessel = uid;
         _radiation.SetSourceEnabled(uid, true);
-        UpdateVesselAppearance(uid,  component);
+        UpdateVesselAppearance(uid, component);
         Popup.PopupEntity(Loc.GetString("anomaly-vessel-component-anomaly-assigned"), uid);
     }
 

--- a/Content.Server/Anomaly/AnomalySystem.cs
+++ b/Content.Server/Anomaly/AnomalySystem.cs
@@ -1,3 +1,6 @@
+//<Trauma>
+using Content.Server.Pinpointer;
+//</Trauma
 using Content.Server.Anomaly.Components;
 using Content.Server.Atmos.EntitySystems;
 using Content.Server.Audio;
@@ -38,6 +41,10 @@ public sealed partial class AnomalySystem : SharedAnomalySystem
     [Dependency] private RadiationSystem _radiation = default!;
     [Dependency] private SharedAudioSystem _audio = default!;
     [Dependency] private UserInterfaceSystem _ui = default!;
+
+    //<Trauma>
+    [Dependency] private NavMapSystem _navmap = default!;
+    //</Trauma>
 
     public const float MinParticleVariation = 0.8f;
     public const float MaxParticleVariation = 1.2f;

--- a/Content.Server/Anomaly/Components/AnomalyVesselComponent.Trauma.cs
+++ b/Content.Server/Anomaly/Components/AnomalyVesselComponent.Trauma.cs
@@ -1,0 +1,10 @@
+namespace Content.Server.Anomaly.Components;
+
+public sealed partial class AnomalyVesselComponent : Component
+{
+    /// <summary>
+    /// Text of closest beacon of anomaly location
+    /// </summary>
+    [DataField]
+    public string? BeaconLocation;
+}

--- a/Resources/Locale/en-US/_Trauma/anomaly/anomaly.ftl
+++ b/Resources/Locale/en-US/_Trauma/anomaly/anomaly.ftl
@@ -1,0 +1,2 @@
+anomaly-beacon-location = Assigned anomaly is near {$location}.
+anomaly-beacon-unknown = Cannot retrieve anomaly location.


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->
Track the anomaly location using the closest beacon.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
So scientist don't forget. This however don't track when anomaly teleport changed it's position after being assigned but I can do that if you want. It's pretty rare for anomaly to teleport that far so I think it should be fine

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

<img width="476" height="285" alt="image" src="https://github.com/user-attachments/assets/c834c3ff-4823-4208-b159-45ef5b2f8920" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Now you can see assigned anomaly location by examining the anomaly vessel.
