### PR TITLE
Tweak some side knowledge

### DIFF
--- a/Content.Trauma.Shared/Heretic/Components/Side/LionhunterRifleProjectileComponent.cs
+++ b/Content.Trauma.Shared/Heretic/Components/Side/LionhunterRifleProjectileComponent.cs
@@ -16,12 +16,6 @@ public sealed partial class LionhunterRifleProjectileComponent : Component
     public ComponentRegistry ComponentsOnEmpower;
 
     /// <summary>
-    /// Damage multiplier if empowered
-    /// </summary>
-    [DataField]
-    public float EmpowerDamageMultiplier = 2f;
-
-    /// <summary>
     /// Knockdown time for target if empowered
     /// </summary>
     [DataField]

--- a/Content.Trauma.Shared/Heretic/Components/Side/UnfathomableCurioShieldComponent.cs
+++ b/Content.Trauma.Shared/Heretic/Components/Side/UnfathomableCurioShieldComponent.cs
@@ -13,7 +13,7 @@ public sealed partial class UnfathomableCurioShieldComponent : Component
     public Color Color = Color.LimeGreen;
 
     [DataField]
-    public TimeSpan ActivateDelay = TimeSpan.FromSeconds(20);
+    public TimeSpan ActivateDelay = TimeSpan.FromSeconds(30);
 
     [DataField]
     public TimeSpan FadeTime = TimeSpan.FromMilliseconds(500);
@@ -37,7 +37,7 @@ public sealed partial class UnfathomableCurioShieldComponent : Component
     public float SlowdownRadius = 1.5f;
 
     [DataField]
-    public float BulletSlowdown = 0.02f;
+    public float BulletSlowdown = 0.03f;
 
     [DataField]
     public EntityWhitelist BulletWhitelist = new()

--- a/Content.Trauma.Shared/Heretic/Systems/Side/LionhunterRifleSystem.cs
+++ b/Content.Trauma.Shared/Heretic/Systems/Side/LionhunterRifleSystem.cs
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-using System.Linq;
 using Content.Lavaland.Common.Weapons.Ranged;
 using Content.Shared.CombatMode;
-using Content.Shared.Damage;
 using Content.Shared.DoAfter;
 using Content.Shared.Examine;
 using Content.Shared.Hands.EntitySystems;
@@ -130,19 +128,8 @@ public sealed partial class LionhunterRifleSystem : EntitySystem
 
         var uid = args.FiredProjectile;
 
-        if (!_lionhunterProjectileQuery.TryComp(uid, out var comp) ||
-            !_projectileQuery.TryComp(uid, out var projectile))
+        if (!_lionhunterProjectileQuery.TryComp(uid, out var comp))
             return;
-
-        projectile.Damage = new DamageSpecifier
-        {
-            DamageDict =
-                projectile.Damage.DamageDict.ToDictionary(x => x.Key, x => x.Value * comp.EmpowerDamageMultiplier),
-            ArmorPenetration = projectile.Damage.ArmorPenetration,
-            WoundSeverityMultipliers = projectile.Damage.WoundSeverityMultipliers,
-        };
-
-        Dirty(uid, projectile);
 
         EntityManager.AddComponents(uid, comp.ComponentsOnEmpower);
 

--- a/Content.Trauma.Shared/Heretic/Systems/Side/SharedUnfathomableCurioSystem.cs
+++ b/Content.Trauma.Shared/Heretic/Systems/Side/SharedUnfathomableCurioSystem.cs
@@ -85,8 +85,15 @@ public abstract partial class SharedUnfathomableCurioSystem : EntitySystem
     [SubscribeLocalEvent]
     private void OnTakeDamage(Entity<UnfathomableCurioShieldComponent> ent, ref BeforeDamageChangedEvent args)
     {
-        if (!ent.Comp.Active || args.Cancelled || args.Damage.GetTotal() < 5)
+        if (args.Cancelled || args.Damage.GetTotal() < 5)
             return;
+
+        if (!ent.Comp.Active)
+        {
+            ent.Comp.ActivateTime = _timing.CurTime + ent.Comp.ActivateDelay;
+            Dirty(ent);
+            return;
+        }
 
         args.Cancelled = true;
         ResetShield(ent, true, args.Origin);

--- a/Resources/Prototypes/_Goobstation/Heretic/Entities/Objects/Weapons/Melee/heretic_blades.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Entities/Objects/Weapons/Melee/heretic_blades.yml
@@ -12,6 +12,8 @@
   components:
   - type: TriggerOnThrown
     keyOut: activate
+  - type: TriggerOnMeleeHit
+    keyOut: activate
   - type: TriggerOnGotEquippedHand
     keyOut: deactivate
   - type: GenericTriggerCondition
@@ -35,7 +37,7 @@
     targetUser: true
     effects:
     - !type:SetThrowCooldown
-      cooldown: 1
+      cooldown: 0.9
   - type: ItemToggleOnTrigger
     keysIn: [activate]
     canDeactivate: false

--- a/Resources/Prototypes/_Goobstation/Heretic/Entities/Structures/Specific/Heretic/tiles.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Entities/Structures/Specific/Heretic/tiles.yml
@@ -89,15 +89,6 @@
       effectProto: ShadowCloakStatusEffect
       time: 180
       type: Remove
-    - !type:ModifyStatusEffect
-      effectProto: StatusEffectBlurryVision
-      time: 6
-    - !type:ModifyStatusEffect
-      effectProto: StatusEffectDeaf
-      time: 6
-    - !type:ModifyStatusEffect
-      effectProto: StatusEffectMuted
-      time: 6
   - type: Transform
     anchored: true
   - type: Physics

--- a/Resources/Prototypes/_Goobstation/Heretic/StatusEffects/effects.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/StatusEffects/effects.yml
@@ -226,15 +226,12 @@
     - type: ShadowCloaked
 
 - type: entity
-  parent: [StatusEffectWormBlacklist, StatusEffectSpeed]
+  parent: StatusEffectWormBlacklist
   id: ShadowCloakPaleStatusEffect
   name: forest admonitions
   components:
   - type: StatusEffectAlert
     alert: ForestAdmonitions
-  - type: MovementModStatusEffect
-    sprintSpeedModifier: 1.1
-    walkSpeedModifier: 1.1
   - type: HereticCloakedStatusEffect
     loseFocusMessage: heretic-ability-lose-focus-pale-cloak
   - type: GrantComponentsStatusEffect
@@ -252,13 +249,17 @@
     walkSpeedModifier: 0.75
 
 - type: entity
-  parent: StatusEffectSlowdown
+  parent: [ StatusEffectSlowdown, MutedStatusEffectBase ]
   id: PaleFogAffectedStatusEffect
   name: pale fog affected
   components:
   - type: MovementModStatusEffect
     sprintSpeedModifier: 0.85
     walkSpeedModifier: 0.85
+  - type: GrantComponentsStatusEffect
+    components:
+    - type: Deaf
+    - type: BlurryVision
 
 - type: entity
   parent: StatusEffectBase
@@ -323,12 +324,3 @@
   name: influence xray
   components:
   - type: XRayVisionStatusEffect
-
-- type: entity
-  parent: MobStatusEffectBase
-  id: StatusEffectDeaf
-  name: deaf
-  components:
-  - type: GrantComponentsStatusEffect
-    components:
-    - type: Deaf


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->

Nerf to unfathomable curio: shield delay 20 -> 30s and it now stops recharging upon taking damage if shield is not active. Also its slows bullets a bit less.
Pale cloak no longer speeds up heretic (it still slows down other people)
Lionhunter rifle empowered shot doesnt deal double damage (its full parity now)
Changed sharp medal boomerangs to reset throwing cd when hitting in melee to prevent melee + throw immediately combo, but buffed throwing cd slightly so its still worth using over ashen eyes.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Now that we give people side points instead of main points for sacrifices, we realize that side knowledge is actually very strong because it was balanced around noone ever using it :trollface: 

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl: Aviu
- tweak: Unfathomable curio shield nerfed to have higher recharge cd and to recharge out of combat and not always.
- tweak: Lionhunter rifle empowered shot no longer deals double damage.
- tweak: Pale cloak doesn't speed up heretic by 10% anymore.
- tweak: Sharp medal blad throwing cd lowered, but you can't throw immediately after melee attack.