### PR TITLE
fix canisters phasing through glass/edge firelocks

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
@@ -101,7 +101,7 @@
     damageContainer: Inorganic
   - type: Physics
     bodyType: Dynamic
-  - type: eFixtures
+  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
@@ -101,7 +101,7 @@
     damageContainer: Inorganic
   - type: Physics
     bodyType: Dynamic
-  - type: Fixtures
+  - type: eFixtures
     fixtures:
       fix1:
         shape:
@@ -111,6 +111,7 @@
         mask:
         - SmallMobMask
         layer:
+        - HighImpassable # Trauma - prevent canisters phasing through glass/edge firelocks
         - MachineLayer
   - type: AtmosDevice
     requireAnchored: false


### PR DESCRIPTION
added HighImpassable to canister since it was only colliding with opaque firelocks
fixes #3956 