### PR TITLE
fix rev flamethrower fuel

### DIFF
--- a/Resources/Prototypes/_Trauma/Entities/Objects/Revs/unfinished.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Objects/Revs/unfinished.yml
@@ -227,6 +227,7 @@
     tags:
     - RevFuelTank
   - type: Solution
+    id: beaker
     solution:
       maxVol: 100
   - type: MixableSolution


### PR DESCRIPTION
fixes #3975

:cl:
- fix: Fixed revs not being able to make flamethrower fuel tanks.