### PR TITLE
Fix worm gibbing

### DIFF
--- a/Content.Server/Destructible/DestructibleSystem.cs
+++ b/Content.Server/Destructible/DestructibleSystem.cs
@@ -67,6 +67,11 @@ public sealed partial class DestructibleSystem : SharedDestructibleSystem
     {
         var (uid, comp) = entity;
 
+        // <Trauma>
+        if (!comp.Enabled)
+            return;
+        // </Trauma>
+
         comp.IsBroken = false;
 
         foreach (var threshold in comp.Thresholds)

--- a/Content.Shared/Destructible/DestructibleComponent.Trauma.cs
+++ b/Content.Shared/Destructible/DestructibleComponent.Trauma.cs
@@ -9,4 +9,10 @@ public sealed partial class DestructibleComponent
     /// </summary>
     [DataField, AutoNetworkedField]
     public FixedPoint2 Scale = 1;
+
+    /// <summary>
+    /// If false, thresholds won't trigger
+    /// </summary>
+    [DataField]
+    public bool Enabled = true;
 }

--- a/Resources/Prototypes/_Goobstation/Heretic/Entities/Mobs/NPC/eldritch_mobs.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Entities/Mobs/NPC/eldritch_mobs.yml
@@ -8,7 +8,8 @@
     slots: []
   - type: Boneless
   - type: Destructible
-    thresholds: []
+    enabled: false
+    generateOverkillThreshold: false
 
 - type: entity
   parent:


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->

Fixes #4003

Making threshold list empty does nothing now cause its AlwaysPushInheritance
No way to ignore parent gib thresholds pretty sure.
Tried setting scale to 9999 which prevented blunt gib behavior, but any amount of piercing damage triggered piercing gib threshold for some reason.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Aviu
- fix: Fixed lord of the night gibbing at 400 damage.