### PR TITLE
add subtypes for sling mind roles

### DIFF
--- a/Resources/Changelog/TraumaChangelog.yml
+++ b/Resources/Changelog/TraumaChangelog.yml
@@ -12982,7 +12982,7 @@ Entries:
     message: >-
       Priority job rolls are now captain and a few engineers, doctors, secoffs
       and miners. Players who don't have them set to Never will be chosen for
-      those before regular rolling. 
+      those before regular rolling.
   id: 1416
   time: '2026-08-09T16:38:46.0000000+00:00'
   url: https://github.com/Trauma-Station/Trauma-Station/pull/4009

--- a/Resources/Locale/en-US/_EinsteinEngines/prototypes/roles/antags.ftl
+++ b/Resources/Locale/en-US/_EinsteinEngines/prototypes/roles/antags.ftl
@@ -1,16 +1,3 @@
-# For Sol Alliance Navy Deserters
-ghost-role-information-deserter-name = Solarian Navy Deserter
-ghost-role-information-deserter-description = "I've fucking had it with the quartermaster not giving me my damn paycheck! Let's take one of the dropships for a joyride and go looting to pay ourselves."
-ghost-role-information-deserter-rules =
-    You are not a terrorist, but you're not exactly a great person either. Do whatever it takes to "Get back what the navy owed us".
-    Taking hostages and making unreasonable demands is highly encouraged. Live out your space pirate fantasy here.
-    Don't go out of your way to cause mass destruction, since turning the station to slag will also deny you your payday.
-roles-antag-sol-alliance-navy-deserter = Solarian Navy Deserter
-roles-antag-sol-alliance-navy-deserter-objective = Fill your dropship with as much valuable loot as possible, while living to brag about it at the next freeport.
-id-card-access-level-sol-alliance-navy = SAN
-role-type-SAN-antagonist-name = Deserter
-
-# Shadowling
 roles-antag-shadowling-name = Shadowling
 roles-antag-shadowling-description = Enthrall the crew, ascend and become akin to a God.
 roles-antag-shadowling-objective = Ascend.

--- a/Resources/Prototypes/_EinsteinEngines/Roles/mind_roles.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Roles/mind_roles.yml
@@ -9,6 +9,7 @@
     antagPrototype: Shadowling
     exclusiveAntag: true
     roleType: TeamAntagonist
+    subtype: roles-antag-shadowling-name
   - type: ShadowlingRole
 
 - type: entity
@@ -18,3 +19,4 @@
   components:
   - type: MindRole
     antagPrototype: Thrall
+    subtype: roles-antag-thrall-name


### PR DESCRIPTION
fixes #4013

:cl:
ADMIN:
- fix: Fixed shadowling and thrall players just being listed as team antag.