### PR TITLE
TrashBagHolding can now fit in janibelt

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/trashbag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/trashbag.yml
@@ -61,7 +61,7 @@
     sprite: Objects/Specific/Janitorial/trashbag.rsi
     equippedState: blue-equipped-BELT
   - type: Storage
-    maxItemSize: Large
+#    maxItemSize: Large # Trauma - Allow TrashBagHolding to fit in Janibelt
     grid:
     - 0,0,19,9
     quickInsert: true


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->
This one line of yaml took me far to long to hunt down. 
I hate it here.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
All the sprites etc already existed, but it didn't fit because of this one line. slop.
I don't even think there is any large size trash 🥹 
## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
nah its fine because....
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="329" height="237" alt="image" src="https://github.com/user-attachments/assets/f8475b4a-effd-4afd-af58-bdea6d38abc7" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Trash bag of Holding now fits in janibelt.