### PR TITLE
fix dwarf woundable visuals

### DIFF
--- a/Content.Medical.Client/Wounds/WoundableVisualsComponent.cs
+++ b/Content.Medical.Client/Wounds/WoundableVisualsComponent.cs
@@ -2,6 +2,7 @@
 
 using Content.Medical.Common.Wounds;
 using Content.Shared.Damage.Prototypes;
+using Content.Shared.DisplacementMap;
 using Content.Shared.FixedPoint;
 
 namespace Content.Medical.Client.Wounds;
@@ -42,4 +43,7 @@ public sealed partial class WoundableVisualsComponent : Component
         (BleedingSeverity.Severe, 7),
         (BleedingSeverity.Minor, 2.6)
     ];
+
+    [DataField]
+    public ProtoId<DisplacementDataPrototype>? Displacement;
 }

--- a/Content.Medical.Client/Wounds/WoundableVisualsSystem.cs
+++ b/Content.Medical.Client/Wounds/WoundableVisualsSystem.cs
@@ -5,6 +5,7 @@ using Content.Medical.Common.Wounds;
 using Content.Medical.Shared.Body;
 using Content.Medical.Shared.Traumas;
 using Content.Medical.Shared.Wounds;
+using Content.Client.DisplacementMap;
 using Content.Shared.Body;
 using Content.Shared.Damage.Prototypes;
 using Content.Shared.FixedPoint;
@@ -22,6 +23,7 @@ public sealed partial class WoundableVisualsSystem : EntitySystem
     [Dependency] private AppearanceSystem _appearance = default!;
     [Dependency] private BodySystem _body = default!;
     [Dependency] private BodyPartSystem _part = default!;
+    [Dependency] private DisplacementMapSystem _displacement = default!;
     [Dependency] private IGameTiming _timing = default!;
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private SpriteSystem _sprite = default!;
@@ -48,7 +50,7 @@ public sealed partial class WoundableVisualsSystem : EntitySystem
             GetLayer(ent) is not {} layer)
             return;
 
-        AddDamageLayerToSprite((body, sprite), overlay, BuildStateKey(layer, MinorSuffix), BuildLayerKey(layer, BleedingSuffix));
+        AddDamageLayerToSprite((body, sprite), ent.Comp, overlay, BuildStateKey(layer, MinorSuffix), BuildLayerKey(layer, BleedingSuffix));
     }
 
     private void InitDamage(Entity<WoundableVisualsComponent> ent)
@@ -63,6 +65,7 @@ public sealed partial class WoundableVisualsSystem : EntitySystem
         {
             var color = GetColor(ent, group);
             AddDamageLayerToSprite((body, spriteComp),
+                ent.Comp,
                 sprite,
                 BuildStateKey(layer, group, "100"),
                 BuildLayerKey(layer, group),
@@ -93,6 +96,7 @@ public sealed partial class WoundableVisualsSystem : EntitySystem
 
                 var color = GetColor(ent, group);
                 AddDamageLayerToSprite((body, sprite),
+                    ent.Comp,
                     rsiPath,
                     BuildStateKey(layer, group, "100"),
                     BuildLayerKey(layer, group),
@@ -104,6 +108,7 @@ public sealed partial class WoundableVisualsSystem : EntitySystem
             && ent.Comp.BleedingOverlay is {} overlay)
         {
             AddDamageLayerToSprite((body, sprite),
+                ent.Comp,
                 overlay,
                 BuildStateKey(layer, MinorSuffix),
                 BuildLayerKey(layer, BleedingSuffix));
@@ -154,7 +159,7 @@ public sealed partial class WoundableVisualsSystem : EntitySystem
             if (!_sprite.LayerMapTryGet(ent, layerKey, out var layer, false))
                 continue;
 
-            _sprite.LayerSetVisible(ent, layer, false);
+            _displacement.EnsureDisplacementIsNotOnSprite((ent, ent.Comp), layerKey);
             _sprite.RemoveLayer(ent, layer);
             _sprite.LayerMapRemove(ent, layerKey);
         }
@@ -163,12 +168,13 @@ public sealed partial class WoundableVisualsSystem : EntitySystem
         if (!_sprite.LayerMapTryGet(ent, bleedingKey, out var bleedLayer, false))
             return;
 
-        _sprite.LayerSetVisible(ent, bleedLayer, false);
+        _displacement.EnsureDisplacementIsNotOnSprite((ent, ent.Comp), bleedingKey);
         _sprite.RemoveLayer(ent, bleedLayer, out _, false);
         _sprite.LayerMapRemove(ent, bleedingKey, out _);
     }
 
     private void AddDamageLayerToSprite(Entity<SpriteComponent?> ent,
+        WoundableVisualsComponent visuals,
         string sprite,
         string state,
         string mapKey,
@@ -186,6 +192,12 @@ public sealed partial class WoundableVisualsSystem : EntitySystem
         if (color != null)
             _sprite.LayerSetColor(ent, newLayer, color.Value);
         _sprite.LayerSetVisible(ent, newLayer, false);
+
+        var ent2 = (ent, ent.Comp);
+        if (visuals.Displacement is { } dispId)
+            _displacement.TryAddDisplacement(ProtoMan.Index(dispId).Displacement, ent2, newLayer, mapKey, out _);
+        else
+            _displacement.EnsureDisplacementIsNotOnSprite(ent2, mapKey);
     }
     #endregion
 

--- a/Resources/Prototypes/Body/Species/dwarf.yml
+++ b/Resources/Prototypes/Body/Species/dwarf.yml
@@ -193,6 +193,12 @@
   parent: [ OrganHumanTorso, OrganDwarfAppearance ]
   id: OrganDwarfTorso
   components:
+  # <Trauma>
+  # it doesnt use a base dwarf external prototype :)
+  - &woundable_visuals
+    type: WoundableVisuals
+    displacement: Dwarfism
+  # </Trauma>
   - type: VisualOrganMarkings
     markingsDisplacement:
       Chest:
@@ -235,6 +241,9 @@
   parent: [ OrganHumanHead, OrganDwarfAppearance ]
   id: OrganDwarfHead
   components:
+  # <Trauma>
+  - *woundable_visuals
+  # </Trauma>
   - type: VisualOrganMarkings
     markingsDisplacement:
       Head:
@@ -277,6 +286,9 @@
   parent: [ OrganHumanArmLeft, OrganDwarfAppearance ]
   id: OrganDwarfArmLeft
   components:
+  # <Trauma>
+  - *woundable_visuals
+  # </Trauma>
   - type: VisualOrganMarkings
     markingsDisplacement:
       LArm:
@@ -289,6 +301,9 @@
   parent: [ OrganHumanArmRight, OrganDwarfAppearance ]
   id: OrganDwarfArmRight
   components:
+  # <Trauma>
+  - *woundable_visuals
+  # </Trauma>
   - type: VisualOrganMarkings
     markingsDisplacement:
       RArm:
@@ -301,6 +316,9 @@
   parent: [ OrganHumanHandRight, OrganDwarfAppearance ]
   id: OrganDwarfHandRight
   components:
+  # <Trauma>
+  - *woundable_visuals
+  # </Trauma>
   - type: VisualOrganMarkings
     markingsDisplacement:
       RHand:
@@ -313,6 +331,9 @@
   parent: [ OrganHumanHandLeft, OrganDwarfAppearance ]
   id: OrganDwarfHandLeft
   components:
+  # <Trauma>
+  - *woundable_visuals
+  # </Trauma>
   - type: VisualOrganMarkings
     markingsDisplacement:
       LHand:
@@ -325,6 +346,9 @@
   parent: [ OrganHumanLegLeft, OrganDwarfAppearance ]
   id: OrganDwarfLegLeft
   components:
+  # <Trauma>
+  - *woundable_visuals
+  # </Trauma>
   - type: VisualOrganMarkings
     markingsDisplacement:
       LLeg:
@@ -337,6 +361,9 @@
   parent: [ OrganHumanLegRight, OrganDwarfAppearance ]
   id: OrganDwarfLegRight
   components:
+  # <Trauma>
+  - *woundable_visuals
+  # </Trauma>
   - type: VisualOrganMarkings
     markingsDisplacement:
       RLeg:
@@ -349,6 +376,9 @@
   parent: [ OrganHumanFootLeft, OrganDwarfAppearance ]
   id: OrganDwarfFootLeft
   components:
+  # <Trauma>
+  - *woundable_visuals
+  # </Trauma>
   - type: VisualOrganMarkings
     markingsDisplacement:
       LFoot:
@@ -361,6 +391,9 @@
   parent: [ OrganHumanFootRight, OrganDwarfAppearance ]
   id: OrganDwarfFootRight
   components:
+  # <Trauma>
+  - *woundable_visuals
+  # </Trauma>
   - type: VisualOrganMarkings
     markingsDisplacement:
       RFoot:


### PR DESCRIPTION
fixes #4039

## Media

fixed top broken bottom

<img width="86" height="134" alt="00:05:32" src="https://github.com/user-attachments/assets/0f3cb884-92c4-468f-9dff-ca886398e954" />

## Changelog

:cl:
- fix: Fixed dwarf damage sprites not matching their bodyparts.