### PR TITLE
10x nerf human heat capacity

### DIFF
--- a/Resources/Prototypes/Body/species_base.yml
+++ b/Resources/Prototypes/Body/species_base.yml
@@ -114,7 +114,7 @@
       - !type:WashCreamPie
   - type: StatusEffects
     allowed:
-    # <Trauma>
+    # <Trauma> - TODO: replace with status effect entities
     - Vulgarity
     - Brainrotted
     - Dementia
@@ -260,6 +260,7 @@
   - type: Fingerprint
   - type: Blindable
   - type: Temperature
+    specificHeat: 300 # Trauma - 10x lower heat capacity so spacing etc doesnt literally do nothing
   - type: TemperatureDamage
     heatDamageThreshold: 325
     coldDamageThreshold: 273.15

--- a/Resources/Prototypes/_EinsteinEngines/Body/Species/ipc.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Body/Species/ipc.yml
@@ -232,6 +232,7 @@
         layer:
         - MobLayer
   - type: Temperature
+    specificHeat: 300
     temperature: 310.15 # 310K is the standard operating temperature of a home circuit breaker
   - type: TemperatureDamage
     heatDamageThreshold: 450 # Wanted to do 363.15 for le realism, but reptiles have 400K limit which is ????

--- a/Resources/Prototypes/_EinsteinEngines/Body/Species/plasmaman.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Body/Species/plasmaman.yml
@@ -133,6 +133,7 @@
   - type: Inventory
     templateId: plasmaman
   - type: Temperature
+    specificHeat: 300
     temperature: 270.15  # -3 celsius
   - type: TemperatureDamage
     heatDamageThreshold: 308    # 35 celsius, -17 from base heat damage threshold


### PR DESCRIPTION
fixes #4064 

space and heating back up is now a bit more reasonable

it doesnt have internal temperature and temperature is currently forced to use the entire body mass despite only having conductivity for the skin... a thorough rework with heatstroke/hypothermia can be done later idc

:cl:
- fix: Fixed players heating up or cooling down way too slowly, space actually matters now. 