### PR TITLE
limit skillchip removal

### DIFF
--- a/Content.Trauma.Shared/Body/Chips/OrganChipComponent.cs
+++ b/Content.Trauma.Shared/Body/Chips/OrganChipComponent.cs
@@ -35,6 +35,18 @@ public sealed partial class OrganChipComponent : Component
     /// </summary>
     [DataField]
     public TimeSpan LongDelay = TimeSpan.FromSeconds(8);
+
+    /// <summary>
+    /// Whether this chip can be pulled out by non-admins.
+    /// </summary>
+    [DataField]
+    public bool CanRemove = true;
+
+    /// <summary>
+    /// Whether this chip can be pulled out by yourself, unless you are an admin.
+    /// </summary>
+    [DataField]
+    public bool CanSelfRemove = true;
 }
 
 /// <summary>

--- a/Content.Trauma.Shared/Body/Chips/OrganChipSystem.cs
+++ b/Content.Trauma.Shared/Body/Chips/OrganChipSystem.cs
@@ -159,14 +159,22 @@ public sealed partial class OrganChipSystem : EntitySystem
         }
 
         var user = args.User;
+        var isSelf = _body.GetBody(ent.Owner);
+        var isAdmin = _bypassQuery.HasComp(user);
         // you remember which skill chip is installing in yourself, for others they are just numbered
-        var known = _body.GetBody(ent.Owner) == user || _bypassQuery.HasComp(user);
+        var known = isSelf || isAdmin;
 
         var i = 0;
         foreach (var chip in ent.Comp.Container.ContainedEntities)
         {
+            var comp = _query.Comp(chip);
             var chipCopy = chip; // amazing language
-            var canRemove = true; // TODO: make it support self unremovable chips
+
+            var canRemove = comp.CanRemove;
+            if (!comp.CanSelfRemove)
+                canRemove &= !isSelf;
+            canRemove |= isAdmin; // aghosts can always remove chips
+
             args.Verbs.Add(new()
             {
                 Text = known ? $"Remove {Name(chip)}" : $"Remove {name} chip {++i}",

--- a/Content.Trauma.Shared/Body/Chips/OrganChipSystem.cs
+++ b/Content.Trauma.Shared/Body/Chips/OrganChipSystem.cs
@@ -159,7 +159,7 @@ public sealed partial class OrganChipSystem : EntitySystem
         }
 
         var user = args.User;
-        var isSelf = _body.GetBody(ent.Owner);
+        var isSelf = _body.GetBody(ent.Owner) == user;
         var isAdmin = _bypassQuery.HasComp(user);
         // you remember which skill chip is installing in yourself, for others they are just numbered
         var known = isSelf || isAdmin;

--- a/Content.Trauma.Shared/Knowledge/Components/ExperienceOnCookingComponent.cs
+++ b/Content.Trauma.Shared/Knowledge/Components/ExperienceOnCookingComponent.cs
@@ -8,11 +8,24 @@ namespace Content.Trauma.Shared.Knowledge.Components;
 /// Knowledge component to gain XP whenever you cook food in a microwave etc.
 /// </summary>
 [RegisterComponent, NetworkedComponent, Access(typeof(ExperienceOnCookingSystem))]
+[AutoGenerateComponentState]
 public sealed partial class ExperienceOnCookingComponent : Component
 {
     /// <summary>
     /// How much XP you get per food cooked.
     /// </summary>
     [DataField]
-    public int Scale = 1;
+    public int Scale = 15;
+
+    /// <summary>
+    /// All recipes that have been made so far.
+    /// </summary>
+    [DataField]
+    public HashSet<string> Cooked = new();
+
+    /// <summary>
+    /// Limit on gaining XP from cooking the same thing, synced with <see cref="Cooked"/> count.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public int Limit;
 }

--- a/Content.Trauma.Shared/Knowledge/Systems/ExperienceOnCookingSystem.cs
+++ b/Content.Trauma.Shared/Knowledge/Systems/ExperienceOnCookingSystem.cs
@@ -15,15 +15,21 @@ public sealed partial class ExperienceOnCookingSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<KnowledgeHolderComponent, CookedFoodEvent>(_knowledge.RelayActiveEvent);
-        SubscribeLocalEvent<ExperienceOnCookingComponent, CookedFoodEvent>(OnCookedFood);
     }
 
+    [SubscribeLocalEvent]
     private void OnCookedFood(Entity<ExperienceOnCookingComponent> ent, ref CookedFoodEvent args)
     {
+        // increase limit for each unique recipe made
+        if (ent.Comp.Cooked.Add(args.Result))
+        {
+            ent.Comp.Limit = ent.Comp.Cooked.Count;
+            Dirty(ent);
+        }
+
         // TODO: scale XP gain by the nutrition or something
         var xp = args.Count * ent.Comp.Scale;
-        // TODO: limit level by total unique foods you've made
-        var limit = 100;
+        var limit = Math.Min(100, ent.Comp.Limit);
         _knowledge.AddExperience(ent.Owner, args.User, xp, limit);
     }
 }

--- a/Resources/Changelog/TraumaChangelog.yml
+++ b/Resources/Changelog/TraumaChangelog.yml
@@ -13124,7 +13124,7 @@ Entries:
   - type: Fix
     message: >-
       Fixed players heating up or cooling down way too slowly, space actually
-      matters now. 
+      matters now.
   id: 1431
   time: '2026-08-13T11:56:08.0000000+00:00'
   url: https://github.com/Trauma-Station/Trauma-Station/pull/4066

--- a/Resources/Prototypes/_Trauma/Entities/Objects/Specific/BrainChips/MRAM.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Objects/Specific/BrainChips/MRAM.yml
@@ -282,6 +282,8 @@
   id: SkillChipChef
   name: MRAM-Chip (Memories of a Chef)
   components:
+  - type: OrganChip
+    canRemove: false # too chuddy
   - type: KnowledgeGrantOnWear
     skills:
       MartialArtCQCChef: 1

--- a/Resources/Prototypes/_Trauma/Entities/Objects/Specific/BrainChips/PSON.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Objects/Specific/BrainChips/PSON.yml
@@ -8,7 +8,6 @@
   - type: KnowledgeGrantOnWear
     skills:
       MagicalLiteracyKnowledge: -1000
-  - type: UnremoveableOrgan # Todo, make these work
 
 - type: entity
   parent: BaseSkillChipPSON
@@ -32,39 +31,21 @@
       KnowledgeWeaponsNonLethal: -1000
       KnowledgeWeaponsPolearm: -1000
       MeleeKnowledge: -1000
-  - type: UnremoveableOrgan
 
-- type: entity # Todo, add drooling marking when this gets used on you
-  parent: BaseSkillChipPSON
+- type: entity # TODO: add drooling marking when this gets used on you
+  parent: SkillChipCombatDampener
   id: SkillChipMindPurge
   name: PSON-Chip (Purge Mind)
-  components:
-  - type: KnowledgeGrantOnWear
-    skills:
-      KnowledgeWeaponsHeavy: -1000
-      KnowledgeWeaponsLaser: -1000
-      ShootingKnowledge: -1000
-      KnowledgeWeaponsMining: -1000
-      KnowledgeWeaponsPistol: -1000
-      KnowledgeWeaponsRifle: -1000
-      KnowledgeWeaponsShotgun: -1000
-      KnowledgeWeaponsSniper: -1000
-      KnowledgeWeaponsShield: -1000
-      KnowledgeWeaponsBludgeon: -1000
-      KnowledgeWeaponsShortBlade: -1000
-      KnowledgeWeaponsLongBlade: -1000
-      KnowledgeWeaponsNonLethal: -1000
-      KnowledgeWeaponsPolearm: -1000
-      MeleeKnowledge: -1000
-  - type: UnremoveableOrgan
 
 - type: entity
   parent: BaseSkillChipPSON
   id: SkillChipTiderDampener
   name: PSON-Chip (Neural Dampener)
   components:
+  - type: OrganChip
+    canRemove: true
+    canSelfRemove: false # make a friend challenge
   - type: KnowledgeGrantOnWear
     skills:
       MeleeKnowledge: -15
       ShootingKnowledge: -15
-  - type: UnremoveableOrgan

--- a/Resources/Prototypes/_Trauma/Entities/Objects/Specific/BrainChips/base.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Objects/Specific/BrainChips/base.yml
@@ -47,7 +47,8 @@
   name: PSON-Chip
   description: A sterilized microchip assembly that can directly interface with the brain. This one rewires the brain to weaken innate skills and overwrite personalities.
   components:
-  - type: UnremoveableOrgan
+  - type: OrganChip
+    canRemove: false # 1984
 
 - type: entity
   abstract: true


### PR DESCRIPTION
tider chip cant be self removed
PSON chips cant be removed
chef cqc is limited by unique recipes made
chef cqc chip cant be removed, fixes #4056

:cl:
- tweak: Some harmful skillchips can no longer be removed.
- tweak: Leveling up chef CQC requires cooking unique recipes not 5000 bread.