### PR TITLE
Scale spy down a bit

### DIFF
--- a/Content.Trauma.Server/GameTicking/Rules/SpyRuleSystem.cs
+++ b/Content.Trauma.Server/GameTicking/Rules/SpyRuleSystem.cs
@@ -138,7 +138,8 @@ public sealed partial class SpyRuleSystem : GameRuleSystem<SpyRuleComponent>
 
         foreach (var listing in store.LastAvailableListings)
         {
-            if (!listing.OriginalCost.TryGetValue(tc, out var cost) || listing.ProductEntity == null)
+            if (!listing.OriginalCost.TryGetValue(tc, out var cost) || cost > comp.MaxCost ||
+                listing.ProductEntity == null)
                 continue;
 
             var difficulty = SpyBountyDifficulty.Easy;

--- a/Content.Trauma.Shared/Spy/SpyRuleComponent.cs
+++ b/Content.Trauma.Shared/Spy/SpyRuleComponent.cs
@@ -86,9 +86,15 @@ public sealed partial class SpyRuleComponent : Component
     public SortedDictionary<FixedPoint2, SpyBountyDifficulty> CostToDifficulty = new()
     {
         {0, SpyBountyDifficulty.Easy},
-        {30, SpyBountyDifficulty.Medium},
-        {60, SpyBountyDifficulty.Hard},
+        {20, SpyBountyDifficulty.Medium},
+        {50, SpyBountyDifficulty.Hard},
     };
+
+    /// <summary>
+    /// Bounties can't roll uplink items that cost more than this
+    /// </summary>
+    [DataField]
+    public FixedPoint2 MaxCost = 100;
 
     /// <summary>
     /// Chance that reward will be removed from <see cref="LootPool"/> when claimed by someone, based on difficulty

--- a/Content.Trauma.Shared/Spy/SpyUplinkSystem.cs
+++ b/Content.Trauma.Shared/Spy/SpyUplinkSystem.cs
@@ -94,6 +94,7 @@ public sealed partial class SpyUplinkSystem : EntitySystem
         args.Handled = true;
 
         bounty.Claimed = true;
+        Dirty(rule.Value, ruleComp);
         role.Comp2.ClaimedBounties++;
         _audio.PlayPredicted(ent.Comp.StealEndSound, ent, args.User);
 


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->

Closes #4083
Lowered medium/hard bounty reward lower boundary by 10tc.
Also spy can't get anything over 100tc as a reward.
Also fixed spy uplink ui not updating when other spy claims something (forgot to dirty award)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

This makes it so spies get overall slightly worse items for medium/hard bounties.
Spies getting mech and l6 and similar stuff is funny, though kinda unbalanced.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Aviu
- tweak: Removed items that cost more than 100tc from spy possible bounty reward.
- tweak: Medium bounty rewards now start from 20tc down from 30 and hard ones start from 50tc down from 60.
- fix: Fixed spy uplink not updating bounty claimed status when someone else claims it.