### PR TITLE
fix circuit pulse input handling

### DIFF
--- a/Content.Shared/EntityConditions/SharedEntityConditionsSystem.cs
+++ b/Content.Shared/EntityConditions/SharedEntityConditionsSystem.cs
@@ -146,13 +146,13 @@ public abstract partial class EntityCondition
 /// </summary>
 /// <param name="Condition">The Condition we're checking</param>
 [ByRefEvent]
-[DataRecord]
+//[DataRecord] // Trauma - yml has no reason to store these
 public partial record struct EntityConditionEvent<T>(T Condition, EntityUid? SourceEnt) where T : EntityConditionBase<T>
 {
     /// <summary>
     /// The result of our check, defaults to false if nothing handles it.
     /// </summary>
-    [DataField]
+    //[DataField] // Trauma
     public bool Result;
 
     /// <summary>

--- a/Content.Trauma.Server/Circuits/CircuitSystem.cs
+++ b/Content.Trauma.Server/Circuits/CircuitSystem.cs
@@ -16,25 +16,28 @@ public sealed partial class CircuitSystem : EntitySystem
     [Dependency] private DeviceLinkSystem _device = default!;
     [Dependency] private EntityQuery<CircuitComponent> _query = default!;
 
-    public override void Initialize()
-    {
-        base.Initialize();
-
-        SubscribeLocalEvent<CircuitHousingComponent, SignalReceivedEvent>(OnSignalReceived);
-
-        SubscribeLocalEvent<CircuitComponent, MapInitEvent>(OnMapInit);
-
-        SubscribeLocalEvent<ActiveCircuitComponent, ComponentInit>(OnActiveInit);
-        SubscribeLocalEvent<ActiveCircuitComponent, ComponentShutdown>(OnActiveShutdown);
-    }
+    private List<int> _changed = new();
 
     public override void Update(float frameTime)
     {
         base.Update(frameTime);
 
         var query = EntityQueryEnumerator<ActiveCircuitComponent, CircuitComponent>();
-        while (query.MoveNext(out var uid, out _, out var comp))
+        while (query.MoveNext(out _, out _, out var comp))
         {
+            // update any momentary pulses's gates
+            for (var i = 0; i < comp.Inputs.Count; i++)
+            {
+                if (comp.Inputs[i] != Pulse.Instance)
+                    continue;
+
+                foreach (var input in comp.LinkedInputs[i])
+                {
+                    ValueChanged(comp, input, False.Instance);
+                }
+            }
+
+            UpdateChangedGates(comp);
             // change any momentary pulses back to low since theyve been processed
             for (var i = 0; i < comp.Inputs.Count; i++)
             {
@@ -42,36 +45,37 @@ public sealed partial class CircuitSystem : EntitySystem
                     continue;
 
                 comp.Inputs[i] = False.Instance;
-                foreach (var input in comp.LinkedInputs[i])
-                {
-                    ValueChanged(comp, input, False.Instance);
-                }
-            }
-
-            var changed = comp.Changed;
-            if (changed.Count == 0)
-                continue;
-
-            comp.Changed = new();
-            var gates = comp.Data.Gates;
-            foreach (var i in changed)
-            {
-                if (!gates.TryGetValue(i, out var gate))
-                    continue; // invalid...
-
-                var old = gate.Output;
-                gate.Update(comp);
-                if (gate.Output.Equals(old))
-                    continue; // no change
-
-                foreach (var output in gate.LinkedOutputs)
-                {
-                    ValueChanged(comp, output, gate.Output);
-                }
             }
         }
     }
 
+    private void UpdateChangedGates(CircuitComponent comp)
+    {
+        if (comp.Changed.Count == 0)
+            return;
+
+        _changed.Clear();
+        _changed.AddRange(comp.Changed);
+        comp.Changed.Clear();
+        var gates = comp.Data.Gates;
+        foreach (var i in _changed)
+        {
+            if (!gates.TryGetValue(i, out var gate))
+                continue; // invalid...
+
+            var old = gate.Output;
+            gate.Update(comp);
+            if (gate.Output.Equals(old))
+                continue; // no change
+
+            foreach (var output in gate.LinkedOutputs)
+            {
+                ValueChanged(comp, output, gate.Output);
+            }
+        }
+    }
+
+    [SubscribeLocalEvent]
     private void OnSignalReceived(Entity<CircuitHousingComponent> ent, ref SignalReceivedEvent args)
     {
         if (!ent.Comp.Powered ||
@@ -99,6 +103,7 @@ public sealed partial class CircuitSystem : EntitySystem
         }
     }
 
+    [SubscribeLocalEvent]
     private void OnMapInit(Entity<CircuitComponent> ent, ref MapInitEvent args)
     {
         var data = ent.Comp.Data;
@@ -120,6 +125,7 @@ public sealed partial class CircuitSystem : EntitySystem
         }
     }
 
+    [SubscribeLocalEvent]
     private void OnActiveInit(Entity<ActiveCircuitComponent> ent, ref ComponentInit args)
     {
         if (!_query.TryComp(ent, out var comp))
@@ -132,6 +138,7 @@ public sealed partial class CircuitSystem : EntitySystem
         }
     }
 
+    [SubscribeLocalEvent]
     private void OnActiveShutdown(Entity<ActiveCircuitComponent> ent, ref ComponentShutdown args)
     {
         if (!_query.TryComp(ent, out var comp))


### PR DESCRIPTION
it was clearing the pulse before actually processing the gates

:cl:
- fix: Fixed not being able to use pulses for circuit inputs.