### PR TITLE
allow building apcs etc without a wall again

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/utilities.yml
+++ b/Resources/Prototypes/Recipes/Construction/utilities.yml
@@ -16,8 +16,10 @@
   parent: BaseUtility
   id: BaseUtilityWallmount
   canBuildInImpassable: true
-  conditions:
-  - !type:WallmountCondition
+  # <Trauma> - its chuddy and theres no reason you cant have a battery on the floor
+  # conditions:
+  #- !type:WallmountCondition
+  # </Trauma>
 # endregion Base
 
 # region Surveillance


### PR DESCRIPTION
resolves #4093

real life parity just leave it on the floor + no reason for it to exist its just annoying

:cl:
- tweak: You can build APCs etc without a wall again.