### PR TITLE
fix emagged recycler

### DIFF
--- a/Content.Server/ImmovableRod/ImmovableRodSystem.cs
+++ b/Content.Server/ImmovableRod/ImmovableRodSystem.cs
@@ -132,7 +132,7 @@ public sealed partial class ImmovableRodSystem : EntitySystem
             return;
         }
 
-        // dont delete/hurt self if polymoprhed into a rod
+        // Don't delete/hurt self if polymorphed into a rod
         if (TryComp<PolymorphedEntityComponent>(uid, out var polymorphed))
         {
             if (polymorphed.Parent == ent)
@@ -143,11 +143,14 @@ public sealed partial class ImmovableRodSystem : EntitySystem
         if (HasComp<BodyComponent>(ent))
         {
             component.MobCount++;
-            _popup.PopupEntity(Loc.GetString("immovable-rod-penetrated-mob", ("rod", uid), ("mob", ent)), uid, PopupType.LargeCaution);
 
-            if (!component.ShouldGib)
+            var coords = Transform(uid).Coordinates;
+
+            _adminLogger.Add(LogType.Gib, LogImpact.Medium, $"Entity {ToPrettyString(uid)} hit {ToPrettyString(ent)} at X:{coords.X} Y:{coords.Y}");
+
+            if (!component.ShouldGib || !_destructible.DestroyEntity(ent))
             {
-                if (component.Damage == null)
+                if (component.Damage is null)
                     return;
 
                 component.DamagedEntities.Add(ent); // Goobstation
@@ -157,10 +160,8 @@ public sealed partial class ImmovableRodSystem : EntitySystem
                 return;
             }
 
-            var coords = Transform(uid).Coordinates;
-            _adminLogger.Add(LogType.Gib, LogImpact.Low, $"Entity {ToPrettyString(uid)} gibbed {ToPrettyString(ent)} at X:{coords.X} Y:{coords.Y}");
-
             _gibbing.Gib(ent);
+            _popup.PopupEntity(Loc.GetString("immovable-rod-penetrated-mob", ("rod", uid), ("mob", ent)), uid, PopupType.LargeCaution);
             return;
         }
 

--- a/Content.Server/Materials/MaterialReclaimerSystem.cs
+++ b/Content.Server/Materials/MaterialReclaimerSystem.cs
@@ -5,6 +5,7 @@ using Content.Server.Popups;
 using Content.Server.Stack;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.EntitySystems;
+using Content.Shared.Damage.Systems;
 using Content.Shared.Database;
 using Content.Shared.Destructible;
 using Content.Shared.Emag.Components;
@@ -36,6 +37,8 @@ public sealed partial class MaterialReclaimerSystem : SharedMaterialReclaimerSys
     [Dependency] private StackSystem _stack = default!;
     [Dependency] private SharedMindSystem _mind = default!;
     [Dependency] private IAdminLogManager _adminLogger = default!;
+    [Dependency] private SharedDestructibleSystem _destructible = default!;
+    [Dependency] private DamageableSystem _damage = default!;
 
     /// <inheritdoc/>
     public override void Initialize()
@@ -154,27 +157,35 @@ public sealed partial class MaterialReclaimerSystem : SharedMaterialReclaimerSys
         if (component.ReclaimMaterials)
             SpawnMaterialsFromComposition(uid, item, completion * component.Efficiency, xform: xform);
 
-        if (CanGib(uid, item, component))
-        {
-            /* <Trauma>
-            var logImpact = HasComp<HumanoidProfileComponent>(item) ? LogImpact.Extreme : LogImpact.Medium;
-            _adminLogger.Add(LogType.Gib, logImpact, $"{ToPrettyString(item):victim} was gibbed by {ToPrettyString(uid):entity} ");
-            if (component.ReclaimSolutions)
-                SpawnChemicalsFromComposition(uid, item, completion, false, component, xform);
-            _gibbing.Gib(item);
-             </Trauma> */
+        var playSound = true;
 
-            _appearance.SetData(uid, RecyclerVisuals.Bloody, true);
-        }
-        else
+        if (CanDamageAndGib(uid, item, component))
         {
-            if (component.ReclaimSolutions)
-                SpawnChemicalsFromComposition(uid, item, completion, true, component, xform);
+            var didBloody = false;
+
+            if (component.DamageOnEmag is not null && _damage.TryChangeDamage(item, component.DamageOnEmag, false)) // It shouldn't ignore resistance
+                didBloody = true;
+
+            if (_destructible.CanDestroy(item) && component.GibOnEmag)
+            {
+                var logImpact = HasComp<HumanoidProfileComponent>(item) ? LogImpact.Extreme : LogImpact.Medium;
+                _adminLogger.Add(LogType.Gib, logImpact, $"{ToPrettyString(item):victim} was gibbed by {ToPrettyString(uid):entity}");
+
+                playSound = false; // Gibbing already make the noise!
+
+                _gibbing.Gib(item);
+
+                didBloody = true;
+            }
+
+            if (didBloody)
+                _appearance.SetData(uid, RecyclerVisuals.Bloody, true);
         }
 
-        var eventArgs = new DestructionEventArgs();
-        RaiseLocalEvent(item, eventArgs);
-        QueueDel(item);
+        if (_destructible.CanDestroy(item) && component.ReclaimSolutions)
+            SpawnChemicalsFromComposition(uid, item, completion, playSound, component, xform);
+
+        _destructible.DestroyEntity(item);
     }
 
     private void SpawnMaterialsFromComposition(EntityUid reclaimer,

--- a/Content.Server/Materials/MaterialReclaimerSystem.cs
+++ b/Content.Server/Materials/MaterialReclaimerSystem.cs
@@ -1,3 +1,6 @@
+// <Trauma>
+using Content.Shared.Body;
+// </Trauma>
 using Content.Server.Administration.Logs;
 using Content.Server.Fluids.EntitySystems;
 using Content.Server.Ghost;
@@ -27,6 +30,9 @@ namespace Content.Server.Materials;
 /// <inheritdoc/>
 public sealed partial class MaterialReclaimerSystem : SharedMaterialReclaimerSystem
 {
+    // <Trauma>
+    [Dependency] private BodySystem _body = default!;
+    // </Trauma>
     [Dependency] private AppearanceSystem _appearance = default!;
     [Dependency] private GhostSystem _ghostSystem = default!;
     [Dependency] private MaterialStorageSystem _materialStorage = default!;
@@ -126,17 +132,30 @@ public sealed partial class MaterialReclaimerSystem : SharedMaterialReclaimerSys
         if (!base.TryFinishProcessItem(uid, component, active))
             return false;
 
-        if (active.ReclaimingContainer.ContainedEntities.FirstOrNull() is not { } item)
+        // <Trauma> - replace container with Processing list
+        var i = active.Processing.Count - 1;
+        if (i < 0)
             return false;
 
-        Container.Remove(item, active.ReclaimingContainer);
-        Dirty(uid, component);
+        var item = active.Processing[i];
+        if (Deleted(item))
+            return false;
+        // </Trauma>
 
         // scales the output if the process was interrupted.
         var completion = 1f - Math.Clamp((float) Math.Round((active.EndTime - Timing.CurTime) / active.Duration),
             0f,
             1f);
         Reclaim(uid, item, completion, component);
+        // <Trauma> - have a delay for damaging mobs, doesnt matter for items since they will just be recycled immediately
+        active.Duration += TimeSpan.FromSeconds(0.5);
+        active.EndTime += TimeSpan.FromSeconds(0.5);
+
+        // if it got deleted (always will for items) stop processing it
+        // keep processing mobs stacking slash damage
+        if (Deleted(item))
+            active.Processing.RemoveAt(i);
+        // </Trauma>
 
         return true;
     }
@@ -163,9 +182,11 @@ public sealed partial class MaterialReclaimerSystem : SharedMaterialReclaimerSys
         {
             var didBloody = false;
 
-            if (component.DamageOnEmag is not null && _damage.TryChangeDamage(item, component.DamageOnEmag, false)) // It shouldn't ignore resistance
+            // Trauma - add targetPart and canMiss
+            if (component.DamageOnEmag is not null && _damage.TryChangeDamage(item, component.DamageOnEmag, false, targetPart: _body.GetRandomExtremity(item), canMiss: false)) // It shouldn't ignore resistance
                 didBloody = true;
 
+            /* Trauma - just delimb instead of gibbing, the mob itself doesnt have destructible thresholds
             if (_destructible.CanDestroy(item) && component.GibOnEmag)
             {
                 var logImpact = HasComp<HumanoidProfileComponent>(item) ? LogImpact.Extreme : LogImpact.Medium;
@@ -177,9 +198,11 @@ public sealed partial class MaterialReclaimerSystem : SharedMaterialReclaimerSys
 
                 didBloody = true;
             }
+            */
 
             if (didBloody)
                 _appearance.SetData(uid, RecyclerVisuals.Bloody, true);
+            return; // Trauma - just damage mobs instead of deleting them
         }
 
         if (_destructible.CanDestroy(item) && component.ReclaimSolutions)

--- a/Content.Server/Species/Systems/NymphSystem.cs
+++ b/Content.Server/Species/Systems/NymphSystem.cs
@@ -2,6 +2,7 @@ using Content.Server.Mind;
 using Content.Server.Zombies;
 using Content.Shared.Body;
 using Content.Shared.Species.Components;
+using Content.Shared.Whitelist;
 using Content.Shared.Zombies;
 using Robust.Shared.Prototypes;
 
@@ -11,6 +12,7 @@ public sealed partial class NymphSystem : EntitySystem
 {
     [Dependency] private MindSystem _mindSystem = default!;
     [Dependency] private ZombieSystem _zombie = default!;
+    [Dependency] private EntityWhitelistSystem _whitelist = default!;
 
     public override void Initialize()
     {
@@ -25,6 +27,9 @@ public sealed partial class NymphSystem : EntitySystem
             return;
 
         if (!ProtoMan.TryIndex<EntityPrototype>(comp.EntityPrototype, out var entityProto))
+            return;
+
+        if (!_whitelist.CheckBoth(args.Target, comp.Blacklist, comp.Whitelist))
             return;
 
         // Get the organs' position & spawn a nymph there

--- a/Content.Shared/Body/BodySystem.Trauma.cs
+++ b/Content.Shared/Body/BodySystem.Trauma.cs
@@ -23,7 +23,9 @@ public sealed partial class BodySystem
     [Dependency] private CommonBodyPartSystem _part = default!;
     [Dependency] private IGameTiming _timing = default!;
     [Dependency] private MobStateSystem _mob = default!;
+    [Dependency] private OrganRelationSystem _relation = default!;
     [Dependency] private StandingStateSystem _standing = default!;
+    [Dependency] private EntityQuery<InternalChildOrganComponent> _internalQuery = default!;
 
     /// <summary>
     /// Body parts' organ categories.
@@ -68,6 +70,7 @@ public sealed partial class BodySystem
     // TODO: vital internal organs???
 
     private readonly HashSet<ProtoId<OrganCategoryPrototype>> _coveredParts = new();
+    private readonly List<EntityUid> _extremities = new();
 
     /// <summary>
     /// Tries to enable a given organ, letting systems run logic.
@@ -146,7 +149,7 @@ public sealed partial class BodySystem
     public List<Entity<OrganComponent>> GetExternalOrgans(Entity<BodyComponent?> body, bool logMissing = false)
     {
         var organs = GetOrgans(body, logMissing);
-        organs.RemoveAll(organ => HasComp<InternalChildOrganComponent>(organ));
+        organs.RemoveAll(organ => _internalQuery.HasComp(organ));
         return organs;
     }
 
@@ -513,7 +516,44 @@ public sealed partial class BodySystem
         return GetRandomBodyPart(target);
     }
 
+    /// <summary>
+    /// Gets a random bodypart that has no child parts, like a hand or an arm with no hand attached.
+    /// </summary>
+    public TargetBodyPart GetRandomExtremity(Entity<BodyComponent?> body)
+    {
+        if (!_bodyQuery.Resolve(body, ref body.Comp, false))
+            return TargetBodyPart.Chest;
+
+        _extremities.Clear();
+        foreach (var part in GetExternalOrgans(body))
+        {
+            if (IsExtremity(part))
+                _extremities.Add(part);
+        }
+
+        if (_extremities.Count == 0)
+            return TargetBodyPart.Chest; // should never happen...
+
+        var rand = SharedRandomExtensions.PredictedRandom(_timing, GetNetEntity(body));
+        var picked = rand.Pick(_extremities);
+        return _part.GetTargetBodyPart(picked) ?? TargetBodyPart.Chest;
+    }
+
     #endregion
+
+    /// <summary>
+    /// Returns true if a bodypart has no child parts.
+    /// </summary>
+    public bool IsExtremity(EntityUid part)
+    {
+        foreach (var child in _relation.AllChildren(part))
+        {
+            if (!_internalQuery.HasComp(child))
+                return false;
+        }
+
+        return true;
+    }
 
     private bool IsDetached(EntityUid uid)
         => (MetaData(uid).Flags & MetaDataFlags.Detached) != 0;

--- a/Content.Shared/Changeling/Components/DestructionResistanceComponent.cs
+++ b/Content.Shared/Changeling/Components/DestructionResistanceComponent.cs
@@ -1,0 +1,18 @@
+using Content.Shared.Changeling.Systems;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Changeling.Components;
+
+/// <summary>
+/// Entities with this component resist being destructed (E.g gibbed, exploded etc...)
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(DestructionResistanceSystem))]
+public sealed partial class DestructionResistanceComponent : Component
+{
+    /// <summary>
+    /// If false, the component deactivates and the entity can now be destroyed again.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool Enabled = true;
+}

--- a/Content.Shared/Changeling/Systems/DestructionResistanceSystem.cs
+++ b/Content.Shared/Changeling/Systems/DestructionResistanceSystem.cs
@@ -1,0 +1,33 @@
+using Content.Shared.Changeling.Components;
+using Content.Shared.Destructible;
+
+namespace Content.Shared.Changeling.Systems;
+
+public sealed partial class DestructionResistanceSystem : EntitySystem
+{
+    /// <summary>
+    /// Prevent destruction via non-ashing sources, if appropriate.
+    /// </summary>
+    /// <param name="ent">The entity.</param>
+    /// <param name="args">The destruction event args. Canceled if the component is set to disable gibbing.</param>
+    [SubscribeLocalEvent]
+    private void OnDestruction(Entity<DestructionResistanceComponent> ent, ref DestructionAttemptEvent args)
+    {
+        if (ent.Comp.Enabled)
+            args.Cancel();
+    }
+
+    /// <summary>
+    /// Enable or disable the DestructionResistanceComponent.
+    /// </summary>
+    /// <param name="ent">The entity that has the component.</param>
+    /// <param name="enabled">If it is enabled or not.</param>
+    public void SetEnabled(Entity<DestructionResistanceComponent?> ent, bool enabled)
+    {
+        if (!Resolve(ent, ref ent.Comp, false))
+            return;
+
+        ent.Comp.Enabled = enabled;
+        Dirty(ent);
+    }
+}

--- a/Content.Shared/Damage/Systems/DamageableSystem.API.cs
+++ b/Content.Shared/Damage/Systems/DamageableSystem.API.cs
@@ -237,7 +237,7 @@ public sealed partial class DamageableSystem
             var ev = new DamageDealtEvent(damage, origin, interruptsDoAfters, ignoreBlockers, damage);
             RaiseLocalEvent(ent, ref ev);
 
-            return damage;
+            return ev.ModifiedDamage;
         }
         // </Goob>
 

--- a/Content.Shared/Destructible/SharedDestructibleSystem.cs
+++ b/Content.Shared/Destructible/SharedDestructibleSystem.cs
@@ -12,15 +12,25 @@ public abstract partial class SharedDestructibleSystem : EntitySystem
     /// </summary>
     public bool DestroyEntity(EntityUid owner)
     {
-        var ev = new DestructionAttemptEvent();
-        RaiseLocalEvent(owner, ev);
-        if (ev.Cancelled)
+        if (!CanDestroy(owner))
             return false;
 
         var eventArgs = new DestructionEventArgs();
         RaiseLocalEvent(owner, eventArgs);
 
         PredictedQueueDel(owner);
+        return true;
+    }
+
+    /// <param name="owner">Entity that your checking.</param>
+    /// <returns>If it can be destroyed</returns>
+    public bool CanDestroy(EntityUid owner)
+    {
+        var ev = new DestructionAttemptEvent();
+        RaiseLocalEvent(owner, ev);
+        if (ev.Cancelled)
+            return false;
+
         return true;
     }
 

--- a/Content.Shared/Kitchen/SharedKitchenSpikeSystem.cs
+++ b/Content.Shared/Kitchen/SharedKitchenSpikeSystem.cs
@@ -149,8 +149,14 @@ public sealed partial class SharedKitchenSpikeSystem : EntitySystem
     {
         var victim = ent.Comp.BodyContainer.ContainedEntity;
 
-        if (args.Handled || !TryComp<ButcherableComponent>(victim, out var butcherable) || butcherable.SpawnedEntities.Count == 0)
+        if (args.Handled || !TryComp<ButcherableComponent>(victim, out var butcherable))
             return;
+
+        if (butcherable.SpawnedEntities.Count == 0)
+        {
+            _popupSystem.PopupClient(Loc.GetString("comp-kitchen-spike-butcher-empty", ("victim", Identity.Entity(victim.Value, EntityManager))), ent, args.User, PopupType.MediumCaution);
+            return;
+        }
 
         args.Handled = true;
 

--- a/Content.Shared/Materials/ActiveMaterialReclaimerComponent.Trauma.cs
+++ b/Content.Shared/Materials/ActiveMaterialReclaimerComponent.Trauma.cs
@@ -1,0 +1,10 @@
+namespace Content.Shared.Materials;
+
+public sealed partial class ActiveMaterialReclaimerComponent
+{
+    /// <summary>
+    /// List of entities being processed.
+    /// </summary>
+    [DataField]
+    public List<EntityUid> Processing = new();
+}

--- a/Content.Shared/Materials/ActiveMaterialReclaimerComponent.cs
+++ b/Content.Shared/Materials/ActiveMaterialReclaimerComponent.cs
@@ -8,14 +8,16 @@ namespace Content.Shared.Materials;
 /// Tracker component for the process of reclaiming entities
 /// <seealso cref="MaterialReclaimerComponent"/>
 /// </summary>
-[RegisterComponent, NetworkedComponent, Access(typeof(SharedMaterialReclaimerSystem)), AutoGenerateComponentPause]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentPause] // Trauma - removed Access
 public sealed partial class ActiveMaterialReclaimerComponent : Component
 {
+    /* Trauma - reworked to not store mobs in a container...
     /// <summary>
     /// Container used to store the item currently being reclaimed
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
     public Container ReclaimingContainer = default!;
+    */
 
     /// <summary>
     /// When the reclaiming process ends.

--- a/Content.Shared/Materials/MaterialReclaimerComponent.cs
+++ b/Content.Shared/Materials/MaterialReclaimerComponent.cs
@@ -1,7 +1,11 @@
+using Content.Shared.Damage;
+using Content.Shared.Damage.Prototypes;
+using Content.Shared.FixedPoint;
 using Content.Shared.Whitelist;
 using JetBrains.Annotations;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
@@ -137,6 +141,24 @@ public sealed partial class MaterialReclaimerComponent : Component
     /// </remarks>
     [DataField, AutoNetworkedField]
     public int ItemsProcessed;
+
+    /// <summary>
+    /// Damage that gets dealt when a creature is in the emagged recycler.
+    /// </summary>
+    [DataField]
+    public DamageSpecifier? DamageOnEmag = new DamageSpecifier
+    {
+        DamageDict = new Dictionary<ProtoId<DamageTypePrototype>, FixedPoint2>
+        {
+            ["Slash"] = 35.0,
+        },
+    };
+
+    /// <summary>
+    /// If it should gib creatures when they enter and the machine is emagged
+    /// </summary>
+    [DataField]
+    public bool GibOnEmag = true;
 }
 
 [NetSerializable, Serializable]

--- a/Content.Shared/Materials/SharedMaterialReclaimerSystem.cs
+++ b/Content.Shared/Materials/SharedMaterialReclaimerSystem.cs
@@ -54,7 +54,7 @@ public abstract partial class SharedMaterialReclaimerSystem : EntitySystem
         SubscribeLocalEvent<MaterialReclaimerComponent, GotEmaggedEvent>(OnEmagged);
         SubscribeLocalEvent<MaterialReclaimerComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<CollideMaterialReclaimerComponent, StartCollideEvent>(OnCollide);
-        SubscribeLocalEvent<ActiveMaterialReclaimerComponent, ComponentStartup>(OnActiveStartup);
+        //SubscribeLocalEvent<ActiveMaterialReclaimerComponent, ComponentStartup>(OnActiveStartup); // Trauma
         SubscribeLocalEvent<MaterialReclaimerComponent, InteractUsingEvent>(OnInteractUsing,
             before: [typeof(SolutionTransferSystem), typeof(AnchorableSystem)]);
     }
@@ -115,10 +115,12 @@ public abstract partial class SharedMaterialReclaimerSystem : EntitySystem
         TryStartProcessItem(uid, args.OtherEntity, reclaimer);
     }
 
+    /* Trauma
     private void OnActiveStartup(EntityUid uid, ActiveMaterialReclaimerComponent component, ComponentStartup args)
     {
         component.ReclaimingContainer = Container.EnsureContainer<Container>(uid, ActiveReclaimerContainerId);
     }
+    */
 
     /// <summary>
     /// Tries to start processing an item via a <see cref="MaterialReclaimerComponent"/>.
@@ -174,7 +176,7 @@ public abstract partial class SharedMaterialReclaimerSystem : EntitySystem
         var active = EnsureComp<ActiveMaterialReclaimerComponent>(uid);
         active.Duration = duration;
         active.EndTime = Timing.CurTime + duration;
-        Container.Insert(item, active.ReclaimingContainer);
+        active.Processing.Add(item); // Trauma - add to list instead of a container
         return true;
     }
 
@@ -191,7 +193,10 @@ public abstract partial class SharedMaterialReclaimerSystem : EntitySystem
         if (!Resolve(uid, ref component, ref active, false))
             return false;
 
-        RemCompDeferred(uid, active);
+        // <Trauma> - only remove it when done processing everything
+        if (active.Processing.Count == 0)
+            RemCompDeferred(uid, active);
+        // </Trauma>
         return true;
     }
 
@@ -240,9 +245,8 @@ public abstract partial class SharedMaterialReclaimerSystem : EntitySystem
     /// </summary>
     public bool CanStart(EntityUid uid, MaterialReclaimerComponent component)
     {
-        /* Goobstation - Recycle Update - Commented to prevent recycling one item several times
-          if (HasComp<ActiveMaterialReclaimerComponent>(uid))
-            return false;*/
+        if (HasComp<ActiveMaterialReclaimerComponent>(uid))
+            return false;
 
         return component.Powered && component.Enabled && !component.Broken;
     }
@@ -273,6 +277,10 @@ public abstract partial class SharedMaterialReclaimerSystem : EntitySystem
         if (!Resolve(reclaimer, ref reclaimerComponent))
             return TimeSpan.Zero;
 
+        // <Trauma> - delay for mincing mobs
+        if (HasComp<MobStateComponent>(item))
+            return TimeSpan.FromSeconds(0.5f);
+        // </Trauma>
         if (!reclaimerComponent.ScaleProcessSpeed ||
             !Resolve(item, ref compositionComponent, false))
             return reclaimerComponent.MinimumProcessDuration;

--- a/Content.Shared/Materials/SharedMaterialReclaimerSystem.cs
+++ b/Content.Shared/Materials/SharedMaterialReclaimerSystem.cs
@@ -131,11 +131,12 @@ public abstract partial class SharedMaterialReclaimerSystem : EntitySystem
         if (!CanStart(uid, component))
             return false;
 
-        // Goobstation - Recycle update - Check to prevent recycling closed lockers
+        // <Trauma> - Check to prevent recycling closed lockers
         if (HasComp<RecyclableOnUnlockComponent>(item) && _lock.IsLocked(item))
             return false;
+        // </Trauma>
 
-        if (HasComp<MobStateComponent>(item) && !CanGib(uid, item, component)) // whitelist? We be gibbing, boy!
+        if (HasComp<MobStateComponent>(item) && !CanDamageAndGib(uid, item, component)) // whitelist? We be gibbing, boy!
             return false;
 
         if (_whitelistSystem.IsWhitelistFail(component.Whitelist, item) ||
@@ -250,7 +251,7 @@ public abstract partial class SharedMaterialReclaimerSystem : EntitySystem
     /// Whether or not the reclaimer satisfies the conditions
     /// allowing it to gib/reclaim a living creature.
     /// </summary>
-    public bool CanGib(EntityUid uid, EntityUid victim, MaterialReclaimerComponent component)
+    public bool CanDamageAndGib(EntityUid uid, EntityUid victim, MaterialReclaimerComponent component)
     {
         return component.Powered &&
                component.Enabled &&

--- a/Content.Shared/Species/Components/NymphComponent.cs
+++ b/Content.Shared/Species/Components/NymphComponent.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Whitelist;
 using Robust.Shared.Prototypes;
 using Robust.Shared.GameStates;
 
@@ -21,4 +22,18 @@ public sealed partial class NymphComponent : Component
     /// </summary>
     [DataField]
     public bool TransferMind = false;
+
+    /// <summary>
+    /// Whitelist the owner of the organ needs to meet for the organ to turn into a nymph.
+    /// Can be null.
+    /// </summary>
+    [DataField]
+    public EntityWhitelist? Whitelist;
+
+    /// <summary>
+    /// Blacklist for the owner of the organ for it to turn into a nymph.
+    /// Can be null.
+    /// </summary>
+    [DataField]
+    public EntityWhitelist? Blacklist;
 }

--- a/Content.Trauma.Shared/Materials/TraumaMaterialReclaimerSystem.cs
+++ b/Content.Trauma.Shared/Materials/TraumaMaterialReclaimerSystem.cs
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Shared.Materials;
+using Robust.Shared.Physics.Events;
+
+namespace Content.Trauma.Shared.Materials;
+
+/// <summary>
+/// Makes it so when you stop colliding with an emagged recycler it won't just mince you forever remotely.
+/// </summary>
+public sealed partial class TraumaMaterialReclaimerSystem : EntitySystem
+{
+    [Dependency] private EntityQuery<ActiveMaterialReclaimerComponent> _activeQuery = default!;
+
+    [SubscribeLocalEvent]
+    private void OnEndCollide(Entity<CollideMaterialReclaimerComponent> ent, ref EndCollideEvent args)
+    {
+        if (args.OurFixtureId != ent.Comp.FixtureId || !_activeQuery.TryComp(ent, out var active))
+            return;
+
+        active.Processing.Remove(args.OtherEntity);
+    }
+}

--- a/Resources/Locale/en-US/kitchen/components/kitchen-spike-component.ftl
+++ b/Resources/Locale/en-US/kitchen/components/kitchen-spike-component.ftl
@@ -28,6 +28,8 @@ comp-kitchen-spike-begin-butcher = { CAPITALIZE(THE($user)) } begins to butcher 
 comp-kitchen-spike-butcher-self = You butchered { THE($victim) }!
 comp-kitchen-spike-butcher = { CAPITALIZE(THE($user)) } butchered { THE($victim) }!
 
+comp-kitchen-spike-butcher-empty = { CAPITALIZE(THE($victim)) } has no meat left to butcher!
+
 comp-kitchen-spike-need-tool-quality = { $quality } tool required to butcher { THE($target) }.
 
 comp-kitchen-spike-unhook-verb = Unhook

--- a/Resources/Prototypes/Body/Species/diona.yml
+++ b/Resources/Prototypes/Body/Species/diona.yml
@@ -299,7 +299,7 @@
   - type: Nymph
     blacklist:
       components:
-      - ChangelingTransform
+      - ChangelingIdentity # Trauma - was ChangelingTransform, that doesnt exist here
 
 - type: entity
   parent: [ OrganDionaBrain, BaseNymphingOrgan ]

--- a/Resources/Prototypes/Body/Species/diona.yml
+++ b/Resources/Prototypes/Body/Species/diona.yml
@@ -293,7 +293,16 @@
     stages: [ Digestion, Bloodstream, Metabolites ]
 
 - type: entity
-  parent: OrganDionaBrain
+  abstract: true
+  id: BaseNymphingOrgan
+  components:
+  - type: Nymph
+    blacklist:
+      components:
+      - ChangelingTransform
+
+- type: entity
+  parent: [ OrganDionaBrain, BaseNymphingOrgan ]
   suffix: "Diona, Nymphing"
   id: OrganDionaBrainNymphing
   components:
@@ -302,7 +311,7 @@
     entityPrototype: OrganDionaNymphBrain
 
 - type: entity
-  parent: OrganDionaLungs
+  parent: [ OrganDionaLungs, BaseNymphingOrgan ]
   suffix: "Diona, Nymphing"
   id: OrganDionaLungsNymphing
   components:
@@ -310,7 +319,7 @@
     entityPrototype: OrganDionaNymphLungs
 
 - type: entity
-  parent: OrganDionaStomach
+  parent: [ OrganDionaStomach, BaseNymphingOrgan ]
   suffix: "Diona, Nymphing"
   id: OrganDionaStomachNymphing
   components:

--- a/Resources/Prototypes/Entities/Objects/Magic/immovable_rod.yml
+++ b/Resources/Prototypes/Entities/Objects/Magic/immovable_rod.yml
@@ -12,8 +12,13 @@
     state: icon
     noRot: false
   - type: ImmovableRod
-    minSpeed: 15 # Goobstation
-    maxSpeed: 15 # Goobstation
+    # <Trauma>
+    minSpeed: 15
+    maxSpeed: 15
+    # </Trauma>
+    damage:
+      types:
+        Blunt: 70 # Trauma - was 190
   - type: GravityAffected
   - type: Physics
     bodyType: Dynamic
@@ -72,23 +77,38 @@
   id: ImmovableRodWizard
   suffix: Wizard
   components:
+  # <Trauma>
+  - type: Input
+    context: "human"
+  - type: Trail
+    frequency: 0.1
+    lifetime: 1
+    lerpTime: 0.1
+    alphaLerpAmount: 0.4
+    sprite:
+      sprite: /Textures/Objects/Fun/immovable_rod.rsi
+      state: icon
+  - type: StatusIcon
+    bounds: -0.5,-0.5,0.5,0.5
+  - type: IsDeadIC
+    dead: false
+  # </Trauma>
   - type: ImmovableRod
-    minSpeed: 6 # Goob edit
-    maxSpeed: 6 # Goob edit
-    hitSoundProbability: 1 # Goob edit
-    ignoreResistances: true # Goobstation
-    knockdownTime: 4 # Goobstation
+    # <Trauma>
+    minSpeed: 6
+    maxSpeed: 6
+    hitSoundProbability: 1
+    ignoreResistances: true
+    knockdownTime: 4
+    # </Trauma>
     destroyTiles: false
     randomizeVelocity: false
     shouldGib: false
-    damage:
-      types:
-        Blunt: 70 # Goob edit - was 190
-  #- type: Physics # Goob
+  # <Trauma> - replaced by Input above
+  #- type: Physics
   #  bodyType: KinematicController
-  #- type: InputMover # Goob
-  - type: Input # Goob
-    context: "human"
+  #- type: InputMover
+  # </Trauma>
   - type: MovementSpeedModifier
     baseWeightlessAcceleration: 5
     baseWeightlessModifier: 2
@@ -98,18 +118,6 @@
   - type: CanMoveInAir
   - type: MovementAlwaysTouching
   - type: NoSlip
-  - type: Trail # Goobstation
-    frequency: 0.1
-    lifetime: 1
-    lerpTime: 0.1
-    alphaLerpAmount: 0.4
-    sprite:
-      sprite: /Textures/Objects/Fun/immovable_rod.rsi
-      state: icon
-  - type: StatusIcon # Goobstation
-    bounds: -0.5,-0.5,0.5,0.5
-  - type: IsDeadIC # Goobstation
-    dead: false
 
 - type: entity
   parent: ImmovableRodKeepTiles

--- a/Resources/Prototypes/Entities/Structures/Machines/recycler.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/recycler.yml
@@ -4,20 +4,6 @@
   name: recycler
   description: A large crushing machine used to recycle small items inefficiently. There are lights on the side.
   components:
-  # <Trauma>
-  - type: EntityEffectOnEmagged
-    effects:
-    - !type:AddComponents
-      components:
-      - type: DamageContacts
-        damageSound:
-          path: /Audio/Effects/saw.ogg
-          params:
-            volume: -3
-        damage:
-          types:
-            Slash: 20
-  # </Trauma>
   - type: AmbientSound
     enabled: false
     volume: -8

--- a/Resources/Prototypes/Roles/Antags/changeling.yml
+++ b/Resources/Prototypes/Roles/Antags/changeling.yml
@@ -25,6 +25,9 @@
   components:
   # removed most of upstreams components, ling is mostly implemented in ChangelingRule shitcode
   - type: Changeling
+  - type: DestructionResistance
+  - type: RevolutionaryImmune
+  - type: ZombieImmune
   # </Trauma>
   mindRoles:
   - MindRoleChangeling

--- a/Resources/Textures/Interface/Alerts/breathing.rsi/meta.json
+++ b/Resources/Textures/Interface/Alerts/breathing.rsi/meta.json
@@ -1,1 +1,83 @@
-{"version": 1, "size": {"x": 32, "y": 32}, "license": "CC-BY-SA-3.0", "copyright": "https://github.com/tgstation/tgstation/blob/2f18e6232ce5897554351194082469a043c5ab06/icons/hud/screen_alert.dmi", "states": [{"name": "not_enough_co2", "delays": [[0.5, 0.5]]}, {"name": "not_enough_nitro", "delays": [[0.5, 0.5]]}, {"name": "not_enough_oxy", "delays": [[0.5, 0.5]]}, {"name": "not_enough_tox", "delays": [[0.5, 0.5]]}, {"name": "too_much_co2", "delays": [[0.5, 0.5]]}, {"name": "too_much_nitro", "delays": [[0.5, 0.5]]}, {"name": "too_much_oxy", "delays": [[0.5, 0.5]]}, {"name": "too_much_tox", "delays": [[0.5, 0.5]]}]}
+{
+    "version": 1,
+    "size": {
+        "x": 32,
+        "y": 32
+    },
+    "license": "CC-BY-SA-3.0",
+    "copyright": "https://github.com/tgstation/tgstation/blob/2f18e6232ce5897554351194082469a043c5ab06/icons/hud/screen_alert.dmi",
+    "states": [
+        {
+            "name": "not_enough_co2",
+            "delays": [
+                [
+                    0.5,
+                    0.5
+                ]
+            ]
+        },
+        {
+            "name": "not_enough_nitro",
+            "delays": [
+                [
+                    0.5,
+                    0.5
+                ]
+            ]
+        },
+        {
+            "name": "not_enough_oxy",
+            "delays": [
+                [
+                    0.5,
+                    0.5
+                ]
+            ]
+        },
+        {
+            "name": "not_enough_tox",
+            "delays": [
+                [
+                    0.5,
+                    0.5
+                ]
+            ]
+        },
+        {
+            "name": "too_much_co2",
+            "delays": [
+                [
+                    0.5,
+                    0.5
+                ]
+            ]
+        },
+        {
+            "name": "too_much_nitro",
+            "delays": [
+                [
+                    0.5,
+                    0.5
+                ]
+            ]
+        },
+        {
+            "name": "too_much_oxy",
+            "delays": [
+                [
+                    0.5,
+                    0.5
+                ]
+            ]
+        },
+        {
+            "name": "too_much_tox",
+            "delays": [
+                [
+                    0.5,
+                    0.5
+                ]
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
W sneaking 10 random things into ling pr without mentioning anything in pr desc

upstream has slow emagged recycler now so use it instead of literally completely untested slop

also made it mince a random extremity instead of any part, it will do less vital damage on average until it cuts your limbs off

fixes #4089

:cl:
- fix: Fixed emagged recycler just deleting people.