### PR TITLE
Fix heretic combat verbs

### DIFF
--- a/Content.Shared/Movement/Pulling/Systems/PullingSystem.Trauma.cs
+++ b/Content.Shared/Movement/Pulling/Systems/PullingSystem.Trauma.cs
@@ -309,7 +309,7 @@ public sealed partial class PullingSystem
             _ => throw new ArgumentOutOfRangeException()
         };
 
-        pullable.Comp.GrabEscapeChance = Math.Clamp(puller.Comp.EscapeChances[stage] / escapeAttemptModifier, 0f, 1f);
+        pullable.Comp.GrabEscapeChance = Math.Clamp(puller.Comp.EscapeChances[stage] * escapeAttemptModifier, 0f, 1f);
 
         _alertsSystem.ShowAlert(puller.Owner, puller.Comp.PullingAlert, puller.Comp.PullingAlertSeverity[stage]);
         _alertsSystem.ShowAlert(pullable.Owner, pullable.Comp.PulledAlert, pullable.Comp.PulledAlertAlertSeverity[stage]);

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -398,12 +398,13 @@ public abstract partial class SharedMeleeWeaponSystem : EntitySystem
         AttemptAttack(user, weaponUid, weapon, new LightAttackEvent(null, GetNetEntity(weaponUid), GetNetCoordinates(coordinates)), null);
     }
 
-    public bool AttemptLightAttack(EntityUid user, EntityUid weaponUid, MeleeWeaponComponent weapon, EntityUid target, bool canParry = true) // Trauma - added CanParry
+    public bool AttemptLightAttack(EntityUid user, EntityUid weaponUid, MeleeWeaponComponent weapon, EntityUid target,
+        bool canParry = true) // Trauma - added CanParry
     {
         if (!TryComp(target, out TransformComponent? targetXform))
             return false;
 
-        return AttemptAttack(user, weaponUid, weapon, new LightAttackEvent(GetNetEntity(target), GetNetEntity(weaponUid), GetNetCoordinates(targetXform.Coordinates)), null);
+        return AttemptAttack(user, weaponUid, weapon, new LightAttackEvent(GetNetEntity(target), GetNetEntity(weaponUid), GetNetCoordinates(targetXform.Coordinates), canParry: canParry), null); // Trauma - added canParry
     }
 
     public bool AttemptDisarmAttack(EntityUid user, EntityUid weaponUid, MeleeWeaponComponent weapon, EntityUid target)

--- a/Content.Trauma.Shared/Heretic/Components/PathSpecific/Lock/BurglarsFinesseSystem.cs
+++ b/Content.Trauma.Shared/Heretic/Components/PathSpecific/Lock/BurglarsFinesseSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Verbs;
 using Content.Shared.Weapons.Melee;
 using Content.Trauma.Shared.Heretic.Systems;
+using Robust.Shared.Player;
 
 namespace Content.Trauma.Shared.Heretic.Components.PathSpecific.Lock;
 
@@ -16,17 +17,11 @@ public sealed partial class BurglarsFinesseSystem : EntitySystem
     [Dependency] private SharedCombatModeSystem _combat = default!;
     [Dependency] private SharedHandsSystem _hands = default!;
 
-    public override void Initialize()
-    {
-        base.Initialize();
-
-        SubscribeLocalEvent<HandsComponent, GetVerbsEvent<AlternativeVerb>>(OnGetAltVerb);
-    }
-
+    [SubscribeLocalEvent]
     private void OnGetAltVerb(Entity<HandsComponent> ent, ref GetVerbsEvent<AlternativeVerb> args)
     {
         var user = args.User;
-        if (user == ent.Owner || args.Using is not { } used)
+        if (user == ent.Owner || args.Using is not { } used || !args.CanAccess || !args.CanInteract)
             return;
 
         if (!CanSteal(user, used))
@@ -35,13 +30,7 @@ public sealed partial class BurglarsFinesseSystem : EntitySystem
         args.Verbs.Add(new AlternativeVerb
         {
             Priority = 9,
-            Act = () =>
-            {
-                if (!CanSteal(user, used)) // check again
-                    return;
-
-                DoSteal(user, used, ent);
-            },
+            Act = () => DoSteal(user, used, ent)
         });
     }
 
@@ -57,7 +46,8 @@ public sealed partial class BurglarsFinesseSystem : EntitySystem
         if (!TryComp(used, out MeleeWeaponComponent? melee))
             return;
 
-        if (!_melee.AttemptLightAttack(user, used, melee, target, false))
+        if (!_melee.AttemptLightAttack(user, used, melee, target, false) ||
+            !_melee.InRange(user, target, melee.Range, CompOrNull<ActorComponent>(user)?.PlayerSession, out _))
             return;
 
         melee.NextAttack += TimeSpan.FromSeconds(1f / _melee.GetAttackRate(used, user, melee));

--- a/Content.Trauma.Shared/Heretic/Components/PathSpecific/Lock/BurglarsFinesseSystem.cs
+++ b/Content.Trauma.Shared/Heretic/Components/PathSpecific/Lock/BurglarsFinesseSystem.cs
@@ -46,8 +46,8 @@ public sealed partial class BurglarsFinesseSystem : EntitySystem
         if (!TryComp(used, out MeleeWeaponComponent? melee))
             return;
 
-        if (!_melee.AttemptLightAttack(user, used, melee, target, false) ||
-            !_melee.InRange(user, target, melee.Range, CompOrNull<ActorComponent>(user)?.PlayerSession, out _))
+        if (!_melee.InRange(user, target, melee.Range, CompOrNull<ActorComponent>(user)?.PlayerSession, out _) ||
+            !_melee.AttemptLightAttack(user, used, melee, target, false))
             return;
 
         melee.NextAttack += TimeSpan.FromSeconds(1f / _melee.GetAttackRate(used, user, melee));

--- a/Content.Trauma.Shared/Heretic/Systems/PathSpecific/Blade/ChampionHookSystem.cs
+++ b/Content.Trauma.Shared/Heretic/Systems/PathSpecific/Blade/ChampionHookSystem.cs
@@ -39,47 +39,21 @@ public sealed partial class ChampionHookSystem : EntitySystem
 
     [Dependency] private EntityQuery<MeleeWeaponComponent> _meleeQuery = default!;
 
-    public override void Initialize()
-    {
-        base.Initialize();
-
-        SubscribeLocalEvent<ChampionHookComponent, BeforeSpawnPullingVirtualItemsEvent>(OnVirtualItems);
-        SubscribeLocalEvent<ChampionHookComponent, MeleeAttackEvent>(OnMelee);
-        SubscribeLocalEvent<ChampionHookComponent, GetGrabMovespeedEvent>(OnGetMovespeed);
-        SubscribeLocalEvent<ChampionHookComponent, PullStoppedMessage>(OnHookStopped);
-
-        SubscribeLocalEvent<HereticBladeComponent, GotUnequippedHandEvent>(OnUnequipHand);
-        SubscribeLocalEvent<HereticBladeComponent, AttemptMeleeEvent>(OnMeleeAttempt);
-
-        SubscribeLocalEvent<ChampionHookedComponent, CanStandWhileImmobileEvent>(OnImmobileStand);
-        SubscribeLocalEvent<ChampionHookedComponent, BeingPulledAttemptEvent>(OnPullAttempt);
-        SubscribeLocalEvent<ChampionHookedComponent, PullStoppedMessage>(OnHookedStopped);
-        SubscribeLocalEvent<ChampionHookedComponent, StoodEvent>(OnStand);
-        SubscribeLocalEvent<ChampionHookedComponent, BeforeHarmfulActionEvent>(OnBeforeHarmfulAction);
-
-        SubscribeLocalEvent<CrawlerComponent, GetVerbsEvent<AlternativeVerb>>(OnGetAltVerbs);
-    }
-
+    [SubscribeLocalEvent]
     private void OnGetAltVerbs(Entity<CrawlerComponent> ent, ref GetVerbsEvent<AlternativeVerb> args)
     {
         var user = args.User;
 
-        if (user == ent.Owner || args.Using is not { } used)
+        if (user == ent.Owner || args.Using is not { } used || !args.CanAccess || !args.CanInteract)
             return;
 
-        if (!CanHook(user, used, out _))
+        if (!CanHook(user, used, out var hook))
             return;
 
         args.Verbs.Add(new AlternativeVerb
         {
             Priority = 9,
-            Act = () =>
-            {
-                if (!CanHook(user, used, out var hook)) // check again
-                    return;
-
-                DoHook((user, hook), used, ent);
-            },
+            Act = () => DoHook((user, hook), used, ent)
         });
     }
 
@@ -89,6 +63,7 @@ public sealed partial class ChampionHookSystem : EntitySystem
                HasComp<HereticBladeComponent>(used);
     }
 
+    [SubscribeLocalEvent]
     private void OnUnequipHand(Entity<HereticBladeComponent> ent, ref GotUnequippedHandEvent args)
     {
         if (!TryComp(args.User, out ChampionHookComponent? hook) || hook.Weapon != ent.Owner ||
@@ -98,6 +73,7 @@ public sealed partial class ChampionHookSystem : EntitySystem
         _pulling.TryStopPull(hooked, pullable, args.User, true);
     }
 
+    [SubscribeLocalEvent]
     private void OnMeleeAttempt(Entity<HereticBladeComponent> ent, ref AttemptMeleeEvent args)
     {
         if (!TryComp(args.User, out ChampionHookComponent? hook) || hook.Weapon != ent.Owner ||
@@ -133,22 +109,26 @@ public sealed partial class ChampionHookSystem : EntitySystem
         }
     }
 
+    [SubscribeLocalEvent]
     private void OnImmobileStand(Entity<ChampionHookedComponent> ent, ref CanStandWhileImmobileEvent args)
     {
         args.CanStand = true;
     }
 
+    [SubscribeLocalEvent]
     private void OnStand(Entity<ChampionHookedComponent> ent, ref StoodEvent args)
     {
         _pulling.StopAllPulls(ent, stopPuller: false);
     }
 
+    [SubscribeLocalEvent]
     private void OnGetMovespeed(Entity<ChampionHookComponent> ent, ref GetGrabMovespeedEvent args)
     {
         if (ent.Comp.HookedMob != null)
             args.Speed += ent.Comp.MovespeedBuff;
     }
 
+    [SubscribeLocalEvent]
     private void OnMelee(Entity<ChampionHookComponent> ent, ref MeleeAttackEvent args)
     {
         if (ent.Comp.HookedMob == null || args.Weapon == ent.Comp.Weapon ||
@@ -163,6 +143,7 @@ public sealed partial class ChampionHookSystem : EntitySystem
         Dirty(args.Weapon, weapon);
     }
 
+    [SubscribeLocalEvent]
     private void OnHookStopped(Entity<ChampionHookComponent> ent, ref PullStoppedMessage args)
     {
         if (ent.Owner != args.PullerUid)
@@ -173,6 +154,7 @@ public sealed partial class ChampionHookSystem : EntitySystem
         Dirty(ent);
     }
 
+    [SubscribeLocalEvent]
     private void OnHookedStopped(Entity<ChampionHookedComponent> ent, ref PullStoppedMessage args)
     {
         if (ent.Owner != args.PulledUid)
@@ -181,17 +163,20 @@ public sealed partial class ChampionHookSystem : EntitySystem
         RemComp(ent, ent.Comp);
     }
 
+    [SubscribeLocalEvent]
     private void OnBeforeHarmfulAction(Entity<ChampionHookedComponent> ent, ref BeforeHarmfulActionEvent args)
     {
         if (args.Type == HarmfulActionType.Grab)
             args.Cancelled = true;
     }
 
+    [SubscribeLocalEvent]
     private void OnPullAttempt(Entity<ChampionHookedComponent> ent, ref BeingPulledAttemptEvent args)
     {
         args.Cancel();
     }
 
+    [SubscribeLocalEvent]
     private void OnVirtualItems(Entity<ChampionHookComponent> ent, ref BeforeSpawnPullingVirtualItemsEvent args)
     {
         if (ent.Comp.HookedMob != args.Pulled)
@@ -204,7 +189,8 @@ public sealed partial class ChampionHookSystem : EntitySystem
     {
         if (!TryComp(used, out MeleeWeaponComponent? melee))
             return;
-        if (!_melee.AttemptLightAttack(ent, used, melee, target, false))
+        if (!_melee.AttemptLightAttack(ent, used, melee, target, false) ||
+            !_melee.InRange(ent, target, melee.Range, CompOrNull<ActorComponent>(ent)?.PlayerSession, out _))
             return;
 
         melee.NextAttack += TimeSpan.FromSeconds(1f / _melee.GetAttackRate(used, ent, melee));

--- a/Content.Trauma.Shared/Heretic/Systems/PathSpecific/Blade/ChampionHookSystem.cs
+++ b/Content.Trauma.Shared/Heretic/Systems/PathSpecific/Blade/ChampionHookSystem.cs
@@ -189,8 +189,9 @@ public sealed partial class ChampionHookSystem : EntitySystem
     {
         if (!TryComp(used, out MeleeWeaponComponent? melee))
             return;
-        if (!_melee.AttemptLightAttack(ent, used, melee, target, false) ||
-            !_melee.InRange(ent, target, melee.Range, CompOrNull<ActorComponent>(ent)?.PlayerSession, out _))
+
+        if (!_melee.InRange(ent, target, melee.Range, CompOrNull<ActorComponent>(ent)?.PlayerSession, out _) ||
+            !_melee.AttemptLightAttack(ent, used, melee, target, false))
             return;
 
         melee.NextAttack += TimeSpan.FromSeconds(1f / _melee.GetAttackRate(used, ent, melee));

--- a/Content.Trauma.Shared/Weapons/SheathCounterattack/SheathCounterAttackSystem.cs
+++ b/Content.Trauma.Shared/Weapons/SheathCounterattack/SheathCounterAttackSystem.cs
@@ -38,21 +38,7 @@ public sealed partial class SheathCounterAttackSystem : EntitySystem
 
     [Dependency] private EntityQuery<CounterAttackerComponent> _counterAttackerQuery = default!;
 
-    public override void Initialize()
-    {
-        base.Initialize();
-
-        SubscribeLocalEvent<CounterAttackerComponent, BeforeHarmfulActionEvent>(OnBeforeHarmfulAction);
-
-        Subs.SubscribeWithRelay<SheathCounterattackComponent, GetCounterAttackSheathEvent>(OnGetSheath,
-            baseEvent: false,
-            held: false);
-
-        SubscribeLocalEvent<CombatModeComponent, GetVerbsEvent<AlternativeVerb>>(OnGetAltVerbs);
-
-        SubscribeLocalEvent<CounterAttackingStatusEffectComponent, StatusEffectRemovedEvent>(OnRemove);
-    }
-
+    [SubscribeLocalEvent]
     private void OnRemove(Entity<CounterAttackingStatusEffectComponent> ent, ref StatusEffectRemovedEvent args)
     {
         // Don't apply blocker status effect if this effect has ended early
@@ -67,11 +53,13 @@ public sealed partial class SheathCounterAttackSystem : EntitySystem
             TimeSpan.FromMilliseconds(1));
     }
 
-    private void OnGetSheath(Entity<SheathCounterattackComponent> ent, ref GetCounterAttackSheathEvent args)
+    [SubscribeLocalEvent]
+    private void OnGetSheath(Entity<SheathCounterattackComponent> ent, ref InventoryRelayedEvent<GetCounterAttackSheathEvent> args)
     {
-        args.Sheath ??= ent;
+        args.Args.Sheath ??= ent;
     }
 
+    [SubscribeLocalEvent]
     private void OnGetAltVerbs(Entity<CombatModeComponent> ent, ref GetVerbsEvent<AlternativeVerb> args)
     {
         var user = args.User;
@@ -90,9 +78,6 @@ public sealed partial class SheathCounterAttackSystem : EntitySystem
             Priority = 10,
             Act = () =>
             {
-                if (!CanCounterAttack(user)) // check again
-                    return;
-
                 if (GetSheathAndWeapon(user) is not { } tuple)
                     return;
 
@@ -149,6 +134,7 @@ public sealed partial class SheathCounterAttackSystem : EntitySystem
         return (sheath, (weapon, melee));
     }
 
+    [SubscribeLocalEvent]
     private void OnBeforeHarmfulAction(Entity<CounterAttackerComponent> ent, ref BeforeHarmfulActionEvent args)
     {
         // This isn't predicted because it calls _riposte.CounterAttack which calls


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->

Fixed burglars finesse and champion hook not taking into account interaction range... Even melee system doesn't return false if light attack isn't in range - also include this to be more accurate.
Fixed grab escape change being divided instead of multiplied by escape modifier for some reason? (it caused blade champion hook to be escapeable while prone which is not intended).
Removed double checks from verbs - its not needed, the system handles it by checking verbs second time when client requests verb execution.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

Tested lock path burglars finesse and blade path champion hook.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Aviu
- fix: Fixed heretic burglar's finesse and champion hook having infinite range.
- fix: Fixed champion hook grab being escapeable while prone.