### PR TITLE
re enable headrev conversion when demindshielded

### DIFF
--- a/Content.IntegrationTests/Tests/_Trauma/RevsTest.cs
+++ b/Content.IntegrationTests/Tests/_Trauma/RevsTest.cs
@@ -107,16 +107,16 @@ public sealed class RevsTest : InteractionTest
         Assert.That(STryComp<MindShieldStatusComponent>(SPlayer, out var shield), "Mind shield didn't get broken");
         Assert.That(shield.IsBroken, "Mind shield was not broken on headrev");
 
+        await SpawnTarget(Urist);
+        await AddTargetMind();
+        await AssertConvert("Mindshielded headrevs must not be able to convert players");
+        await DelTarget();
+
         await Server.WaitPost(() =>
         {
             _implant.ForceRemove(SPlayer, implant);
         });
         Assert.That(SComp<HeadRevolutionaryComponent>(SPlayer).ConvertAbilityEnabled, "Removing mind shield didn't re-enable conversion");
-
-        await SpawnTarget(Urist);
-        await AddTargetMind();
-        await AssertConvert("Mindshielded headrevs must not be able to convert players");
-        await DelTarget();
     }
 
     private async Task AssertConvert(string reason, bool works = false)

--- a/Content.IntegrationTests/Tests/_Trauma/RevsTest.cs
+++ b/Content.IntegrationTests/Tests/_Trauma/RevsTest.cs
@@ -97,14 +97,21 @@ public sealed class RevsTest : InteractionTest
     [Test]
     public async Task HeadrevBreaksMindshield()
     {
+        var implant = EntityUid.Invalid;
         await MakePlayerHeadRev();
         await Server.WaitPost(() =>
         {
-            _implant.AddImplant(SPlayer, MindShieldImplant);
+            implant = _implant.AddImplant(SPlayer, MindShieldImplant)!;
         });
         Assert.That(!SComp<HeadRevolutionaryComponent>(SPlayer).ConvertAbilityEnabled, "Mind shield didn't disable conversion");
         Assert.That(STryComp<MindShieldStatusComponent>(SPlayer, out var shield), "Mind shield didn't get broken");
         Assert.That(shield.IsBroken, "Mind shield was not broken on headrev");
+
+        await Server.WaitPost(() =>
+        {
+            _implant.ForceRemove(SPlayer, implant);
+        });
+        Assert.That(SComp<HeadRevolutionaryComponent>(SPlayer).ConvertAbilityEnabled, "Removing mind shield didn't re-enable conversion");
 
         await SpawnTarget(Urist);
         await AddTargetMind();

--- a/Content.IntegrationTests/Tests/_Trauma/RevsTest.cs
+++ b/Content.IntegrationTests/Tests/_Trauma/RevsTest.cs
@@ -101,7 +101,7 @@ public sealed class RevsTest : InteractionTest
         await MakePlayerHeadRev();
         await Server.WaitPost(() =>
         {
-            implant = _implant.AddImplant(SPlayer, MindShieldImplant)!;
+            implant = _implant.AddImplant(SPlayer, MindShieldImplant)!.Value;
         });
         Assert.That(!SComp<HeadRevolutionaryComponent>(SPlayer).ConvertAbilityEnabled, "Mind shield didn't disable conversion");
         Assert.That(STryComp<MindShieldStatusComponent>(SPlayer, out var shield), "Mind shield didn't get broken");

--- a/Content.Shared/Implants/MindshieldImplantSystem.Trauma.cs
+++ b/Content.Shared/Implants/MindshieldImplantSystem.Trauma.cs
@@ -19,6 +19,9 @@ public sealed partial class MindshieldImplantSystem
             return false;
         }
 
+        var brokenEv = new MindShieldBrokenEvent();
+        RaiseLocalEvent(uid, ref brokenEv);
+
         _popup.PopupEntity(Loc.GetString(cancelPopup), uid);
         var shield = Comp<MindShieldComponent>(implant);
         shield.Broken = true;

--- a/Content.Shared/Revolutionary/RevolutionarySystem.Trauma.cs
+++ b/Content.Shared/Revolutionary/RevolutionarySystem.Trauma.cs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 using Content.Shared.Revolutionary.Components;
-using Content.Trauma.Common.Mindshield;
 
 namespace Content.Shared.Revolutionary;
 
@@ -17,12 +16,5 @@ public sealed partial class RevolutionarySystem
 
         ent.Comp.ConvertAbilityEnabled = enabled;
         Dirty(ent);
-    }
-
-    [SubscribeLocalEvent]
-    private void OnHeadMindShieldAttempt(Entity<HeadRevolutionaryComponent> ent, ref MindShieldAttemptEvent args)
-    {
-        SetConvertAbility(ent, false);
-        args.CancelPopup = "head-rev-break-mindshield";
     }
 }

--- a/Content.Trauma.Common/Mindshield/MindShieldBrokenEvent.cs
+++ b/Content.Trauma.Common/Mindshield/MindShieldBrokenEvent.cs
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Content.Trauma.Common.Mindshield;
+
+/// <summary>
+/// Raised on a mob when it gets mindshielded but it was broken by <see cref="MindShieldAttemptEvent"/>.
+/// </summary>
+[ByRefEvent]
+public record struct MindShieldBrokenEvent();

--- a/Content.Trauma.Shared/Mindshield/MindShieldRemovedSystem.cs
+++ b/Content.Trauma.Shared/Mindshield/MindShieldRemovedSystem.cs
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Shared.Implants;
+using Content.Shared.Mindshield.Components;
+
+namespace Content.Trauma.Shared.Mindshield;
+
+/// <summary>
+/// Raises <see cref="MindShieldRemovedEvent"/> on a mob if its mindshield is removed.
+/// </summary>
+public sealed partial class MindShieldRemovedSystem : EntitySystem
+{
+    [SubscribeLocalEvent]
+    private void OnImplantRemoved(Entity<MindShieldImplantComponent> ent, ref ImplantRemovedEvent args)
+    {
+        var ev = new MindShieldRemovedEvent();
+        RaiseLocalEvent(args.Implanted, ref ev);
+    }
+}
+
+[ByRefEvent]
+public record struct MindShieldRemovedEvent();

--- a/Content.Trauma.Shared/Revolutionary/HeadRevSystem.cs
+++ b/Content.Trauma.Shared/Revolutionary/HeadRevSystem.cs
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Shared.Revolutionary;
+using Content.Shared.Revolutionary.Components;
+using Content.Trauma.Common.Mindshield;
+using Content.Trauma.Shared.Mindshield;
+
+namespace Content.Trauma.Shared.Revolutionary;
+
+/// <summary>
+/// Handles headrev mindshield interaction with it disabling conversion ability.
+/// </summary>
+public sealed partial class HeadRevSystem : EntitySystem
+{
+    [Dependency] private RevolutionarySystem _rev = default!;
+
+    [SubscribeLocalEvent]
+    private void OnMindShieldAttempt(Entity<HeadRevolutionaryComponent> ent, ref MindShieldAttemptEvent args)
+    {
+        args.CancelPopup = "head-rev-break-mindshield";
+    }
+
+    [SubscribeLocalEvent]
+    private void OnMindShielded(Entity<HeadRevolutionaryComponent> ent, ref MindShieldedEvent args)
+    {
+        _rev.SetConvertAbility(ent, false);
+    }
+
+    [SubscribeLocalEvent]
+    private void OnMindShieldRemoved(Entity<HeadRevolutionaryComponent> ent, ref MindShieldRemovedEvent args)
+    {
+        _rev.SetConvertAbility(ent, true);
+    }
+}

--- a/Content.Trauma.Shared/Revolutionary/HeadRevSystem.cs
+++ b/Content.Trauma.Shared/Revolutionary/HeadRevSystem.cs
@@ -21,7 +21,7 @@ public sealed partial class HeadRevSystem : EntitySystem
     }
 
     [SubscribeLocalEvent]
-    private void OnMindShielded(Entity<HeadRevolutionaryComponent> ent, ref MindShieldedEvent args)
+    private void OnMindShieldBroken(Entity<HeadRevolutionaryComponent> ent, ref MindShieldBrokenEvent args)
     {
         _rev.SetConvertAbility(ent, false);
     }


### PR DESCRIPTION
fixes #4126 

:cl:
- fix: Fixed mindshielded headrevs still being unable to convert if demindshielded.