### PR TITLE
unsuperbuff the station pets

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -2559,7 +2559,7 @@
   description: Infiltrates your domain, spies on you, and somehow still a cool pet.
   components:
   # <Trauma>
-  - type: NPCRetaliation
+  - type: NPCRetaliation # Parrots will remember you forever.
   - type: HTN
     rootTask:
       task: RuminantHostileCompound
@@ -3161,6 +3161,7 @@
   components:
   # <Trauma>
   - type: NPCRetaliation
+    attackMemoryLength: 15
   - type: HTN
     rootTask:
       task: RuminantHostileCompound
@@ -3254,6 +3255,7 @@
   components:
   # <Trauma>
   - type: NPCRetaliation
+    attackMemoryLength: 15
   - type: HTN
     rootTask:
       task: RuminantHostileCompound
@@ -3416,6 +3418,7 @@
   components:
   # <Trauma>
   - type: NPCRetaliation
+    attackMemoryLength: 5
   - type: HTN
     rootTask:
       task: RuminantHostileCompound
@@ -3618,6 +3621,7 @@
   components:
   # <Trauma>
   - type: NPCRetaliation
+    attackMemoryLength: 10
   - type: HTN
     rootTask:
       task: RuminantHostileCompound
@@ -3873,6 +3877,7 @@
   components:
   # <Trauma>
   - type: NPCRetaliation
+    attackMemoryLength: 5
   - type: HTN
     rootTask:
       task: RuminantHostileCompound
@@ -3951,6 +3956,7 @@
   components:
   # <Trauma>
   - type: NPCRetaliation
+    attackMemoryLength: 5
   - type: HTN
     rootTask:
       task: RuminantHostileCompound
@@ -4190,6 +4196,7 @@
   components:
   # <Trauma>
   - type: NPCRetaliation
+    attackMemoryLength: 60 # pigs are smart
   - type: MeleeWeapon
     angle: 0
     animation: WeaponArcBite
@@ -4417,6 +4424,7 @@
         Piercing: 22
     animation: WeaponArcFist
   - type: NPCRetaliation
+    attackMemoryLength: 15 # Trauma, used to not have memory length.
   - type: FactionException
   - type: NpcFactionMember
     factions:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -3171,7 +3171,7 @@
     animation: WeaponArcBite
     damage:
       types:
-        Slash: 10
+        Slash: 5
   # </Trauma>
   - type: Sprite
     drawdepth: Mobs
@@ -3264,7 +3264,7 @@
     animation: WeaponArcBite
     damage:
       types:
-        Slash: 10
+        Slash: 7.5
   # </Trauma>
   - type: Sprite
     drawdepth: Mobs
@@ -3387,7 +3387,7 @@
       path: /Audio/Effects/bite.ogg
     damage:
       types:
-        Piercing: 15 # Trauma, was 8
+        Piercing: 8
   - type: NpcFactionMember
     factions:
     - Passive
@@ -3426,7 +3426,7 @@
       path: /Audio/Effects/bite.ogg
     damage:
       types:
-        Piercing: 15
+        Piercing: 2 # basically a rat
   # </Trauma>
   - type: Sprite
     drawdepth: Mobs
@@ -3679,7 +3679,7 @@
       path: /Audio/Effects/bite.ogg
     damage:
       types:
-        Slash: 10 # Trauma - was 5 Piercing
+        Piercing: 5
   - type: Grammar
     attributes:
       gender: epicene
@@ -3877,13 +3877,14 @@
     rootTask:
       task: RuminantHostileCompound
   - type: MeleeWeapon
+    attackRate: 0.05 # its a sloth
     soundHit:
         path: /Audio/Effects/bite.ogg
     angle: 0
     animation: WeaponArcBite
     damage:
       types:
-        Slash: 10
+        Piercing: 20 # sloths are vicious
   # </Trauma>
   - type: MovementSpeedModifier
     baseWalkSpeed : 0.5
@@ -3954,13 +3955,14 @@
     rootTask:
       task: RuminantHostileCompound
   - type: MeleeWeapon
+    attackRate: 2 # It's a ferret.
     soundHit:
         path: /Audio/Effects/bite.ogg
     angle: 0
     animation: WeaponArcBite
     damage:
       types:
-        Slash: 10
+        Piercing: 2.5 # We are not the size of a rabbit. We'll be fine.
   # </Trauma>
   - type: Sprite
     drawdepth: Mobs
@@ -4195,7 +4197,7 @@
       path: /Audio/Effects/bite.ogg
     damage:
       types:
-        Piercing: 15
+        Piercing: 10 # Pigs can stay deadly
   # </Trauma>
   - type: Sprite
     drawdepth: Mobs


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->
nerf station pets damage back to old values mostly, some are still absurd
they also have memory except parrots because refrence
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
insurgents have it bad enough as is
## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
as tested as the original armok pr
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Station pets no being fed steroids.
- tweak: Station pets no longer have a memory longer than yours. Except parrots. They know what you did.