### PR TITLE
THE FOG IS COMING THE FOG IS COMING THE FOG IS COMING

### DIFF
--- a/Resources/Prototypes/Atmospherics/gases.yml
+++ b/Resources/Prototypes/Atmospherics/gases.yml
@@ -99,6 +99,11 @@
   molarHeatCapacity: 40
   heatCapacityRatio: 1.3
   molarMass: 44
+  # <Trauma>
+  gasOverlaySprite:
+    sprite: /Textures/Effects/atmospherics.rsi
+    state: water_vapor # Is it THE FOG or is it INSTANT SLEEP?
+  # </Trauma>
   color: '#8F00FF'
   reagent: NitrousOxide
   pricePerMole: 0.1 # Goobstation - Gas Prices


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->
nitrous oxide looks exactly like water vapor now
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
its not white irl but invisible instakill was removed in bz so why not do it for invisible instasleep too
## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
THE FOG IS COMING THE FOG IS COMING THE FOG IS COMING
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: THE FOG IS COMING
- tweak: Nitrous Oxide made from invisible instasleep gas to visible instasleep gas. 