### PR TITLE
Fix shields applying modifiers twice, also reduce their hp

### DIFF
--- a/Content.Shared/Damage/Systems/DamageableSystem.API.cs
+++ b/Content.Shared/Damage/Systems/DamageableSystem.API.cs
@@ -164,7 +164,10 @@ public sealed partial class DamageableSystem
         if (before.Cancelled)
             return damageDone;
 
-        damage = before.Damage; // Trauma
+        // <Trauma>
+        damage = before.Damage;
+        var isBody = _bodyQuery.HasComp(ent);
+        // </Trauma>
 
         // Apply resistances
         if (!ignoreResistances)
@@ -194,7 +197,8 @@ public sealed partial class DamageableSystem
                 RaiseLocalEvent(ent, ev);
                 modified = ev.Damage;
             }
-            else
+            // Skip applying modifiers to body, they will be applied when we reroute the damage to body parts
+            else if (!isBody)
             {
                 // Not a body part, just apply modifiers normally
                 var ev = new DamageModifyEvent(ent, modified, origin);
@@ -224,7 +228,7 @@ public sealed partial class DamageableSystem
         }
 
         // <Goob> - For entities with a body, route damage through body parts. no damage is added to the body's DamageableComponent
-        if (_bodyQuery.HasComp(ent))
+        if (isBody)
         {
             var vitalDamage = GetVitalDamage(damage);
             damage -= vitalDamage;

--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -75,7 +75,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 75 #This is probably enough damage before it breaks # Trauma - was 125
+        damage: 75 # Trauma - was 125
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]

--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -75,7 +75,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 125 #This is probably enough damage before it breaks
+        damage: 75 #This is probably enough damage before it breaks # Trauma - was 125
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->

Due to woundmed shenanigans shields were twice as effective. It basically applied modifiers twice, first before we apply damage to parts, and then it would call ChangeDamage again and apply modifiers second time.
Also nerfed shields hp cause wtf it had 125 + damage modifiers (literally wont break after you crit, especially with low skill).

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

Grab a shield, hit myself with anything - intended damage based on skill.

One issue is urists have no speices specific skills (cause they dont get humanoid profile applied to them) so they have higher shield skill modifier and block 50% damage without skill. Idk how to fix this in a sane way, but all player species explicitly have 0 shield skill by default (I hate this, but like: if there is no knowledge - event that modifies block fraction wont trigger and it kinda lowers block fraction before level 25 so yeah, it would be 50% instead of 35% with no knowledge but 35% with knowledge at level 0)

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Aviu
- fix: Fixed shields being twice as effective.
- tweak: Shield hp 125 -> 75.