### PR TITLE
fulton tweaks

### DIFF
--- a/Content.Shared/Salvage/Fulton/SharedFultonSystem.cs
+++ b/Content.Shared/Salvage/Fulton/SharedFultonSystem.cs
@@ -136,7 +136,7 @@ public abstract partial class SharedFultonSystem : EntitySystem
             return;
         // </Trauma>
 
-        if (Deleted(component.Beacon))
+        if (Deleted(component.Beacon) || _foldable.IsFolded(component.Beacon.Value)) // Trauma - check if the beacon's folded
         {
             // <Trauma> - predict it properly with HasBeacon, very rarely will the beacon actually be deleted so mispredicting that once is fine
             if (_net.IsServer || !component.HasBeacon)
@@ -145,6 +145,7 @@ public abstract partial class SharedFultonSystem : EntitySystem
                 {
                     // no more mispredicts now
                     component.HasBeacon = false;
+                    component.Beacon = null;
                     Dirty(uid, component);
                 }
                 _popup.PopupEntity(Loc.GetString("fulton-not-found"), uid, args.User);

--- a/Content.Trauma.Shared/Salvage/FultonEffectSystem.cs
+++ b/Content.Trauma.Shared/Salvage/FultonEffectSystem.cs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+using Content.Shared.ActionBlocker;
+using Content.Shared.Alert;
+using Content.Shared.Popups;
 using Content.Shared.Salvage.Fulton;
 using Content.Shared.StatusEffectNew;
 using Robust.Shared.Map;
@@ -8,14 +11,18 @@ using Robust.Shared.Timing;
 namespace Content.Trauma.Shared.Salvage;
 
 /// <summary>
-/// Predicts fulton effect spawn/despawn and adding a status effect while fultoned.
+/// Predicts fulton effect spawn/despawn and adding a status effect/alert while fultoned.
 /// </summary>
 public sealed partial class FultonEffectSystem : EntitySystem
 {
     [Dependency] private IGameTiming _timing = default!;
+    [Dependency] private ActionBlockerSystem _blocker = default!;
+    [Dependency] private AlertsSystem _alerts = default!;
+    [Dependency] private SharedPopupSystem _popup = default!;
     [Dependency] private StatusEffectsSystem _status = default!;
 
     public static readonly EntProtoId StatusEffect = "BeingFultonedStatusEffect";
+    public static readonly ProtoId<AlertPrototype> Alert = "Fultoned";
 
     [SubscribeLocalEvent]
     private void OnStartup(Entity<FultonedComponent> ent, ref ComponentStartup args)
@@ -23,6 +30,7 @@ public sealed partial class FultonEffectSystem : EntitySystem
         if (_timing.ApplyingState)
             return;
 
+        _alerts.ShowAlert(ent.Owner, Alert);
         _status.TryAddStatusEffect(ent, StatusEffect, out _);
 
         if (Exists(ent.Comp.Effect))
@@ -39,9 +47,28 @@ public sealed partial class FultonEffectSystem : EntitySystem
         if (_timing.ApplyingState)
             return;
 
+        _alerts.ClearAlert(ent.Owner, Alert);
         _status.TryRemoveStatusEffect(ent, StatusEffect);
 
         PredictedDel(ent.Comp.Effect);
         ent.Comp.Effect = EntityUid.Invalid;
     }
+
+    [SubscribeLocalEvent]
+    private void OnAlertClicked(Entity<FultonedComponent> ent, ref RemoveFultonAlertEvent args)
+    {
+        if (!_blocker.CanInteract(ent, target: null))
+            return;
+
+        if (!ent.Comp.Removeable)
+        {
+            _popup.PopupEntity("You aren't able to remove the fulton!", ent, ent, PopupType.SmallCaution);
+            return;
+        }
+
+        _popup.PopupEntity("You detach the fulton from yourself.", ent, ent);
+        RemCompDeferred(ent, ent.Comp);
+    }
 }
+
+public sealed partial class RemoveFultonAlertEvent : BaseAlertEvent;

--- a/Content.Trauma.Shared/Salvage/FultonProjectileSystem.cs
+++ b/Content.Trauma.Shared/Salvage/FultonProjectileSystem.cs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+using Content.Shared.Foldable;
 using Content.Shared.Projectiles;
 using Content.Shared.Salvage.Fulton;
 using Robust.Shared.Audio.Systems;
@@ -12,6 +13,7 @@ namespace Content.Trauma.Shared.Salvage;
 /// </summary>
 public sealed partial class FultonProjectileSystem : EntitySystem
 {
+    [Dependency] private FoldableSystem _foldable = default!;
     [Dependency] private IGameTiming _timing = default!;
     [Dependency] private INetManager _net = default!;
     [Dependency] private SharedAudioSystem _audio = default!;
@@ -36,7 +38,7 @@ public sealed partial class FultonProjectileSystem : EntitySystem
             return;
         }
 
-        if (Deleted(fulton.Beacon))
+        if (Deleted(fulton.Beacon) || _foldable.IsFolded(fulton.Beacon.Value))
         {
             // same prediction as regular fulton interaction
             if (_net.IsServer || !fulton.HasBeacon)
@@ -44,6 +46,7 @@ public sealed partial class FultonProjectileSystem : EntitySystem
                 if (fulton.HasBeacon)
                 {
                     fulton.HasBeacon = false;
+                    fulton.Beacon = null;
                     Dirty(weapon, fulton);
                 }
                 _audio.PlayLocal(ent.Comp.PopSound, target, null);

--- a/Resources/Locale/en-US/_Trauma/alerts/alerts.ftl
+++ b/Resources/Locale/en-US/_Trauma/alerts/alerts.ftl
@@ -3,3 +3,6 @@ alerts-on-holy-fire-desc = You're [color=cyan]on holy fire[/color]. Click the al
 
 alerts-morph-biomass-name = Biomass
 alerts-morph-biomass-desc = The collection of meat and fat taken from consuming living things.
+
+alerts-fultoned-name = [color=yellow]Fultoned[/color]
+alerts-fultoned-desc = You're being [color=yellow]fultoned[/color] to a remote location! Click to quickly remove it.

--- a/Resources/Locale/en-US/alerts/alerts.ftl
+++ b/Resources/Locale/en-US/alerts/alerts.ftl
@@ -1,24 +1,3 @@
-# SPDX-FileCopyrightText: 2022 Morb <14136326+Morb0@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 Kara <lunarautomaton6@gmail.com>
-# SPDX-FileCopyrightText: 2023 Phill101 <28949487+Phill101@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 Phill101 <holypics4@gmail.com>
-# SPDX-FileCopyrightText: 2023 Vordenburg <114301317+Vordenburg@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 deltanedas <39013340+deltanedas@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 deltanedas <@deltanedas:kde.org>
-# SPDX-FileCopyrightText: 2023 keronshb <54602815+keronshb@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 lapatison <100279397+lapatison@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Errant <35878406+Errant-4@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Hannah Giovanna Dawson <karakkaraz@gmail.com>
-# SPDX-FileCopyrightText: 2024 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 SlamBamActionman <83650252+SlamBamActionman@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 Aiden <aiden@djkraz.com>
-# SPDX-FileCopyrightText: 2025 Simon <63975668+Simyon264@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 SpeltIncorrectyl <66873282+SpeltIncorrectyl@users.noreply.github.com>
-#
-# SPDX-License-Identifier: AGPL-3.0-or-later
-
 alerts-low-oxygen-name = [color=red]Low Oxygen[/color]
 alerts-low-oxygen-desc = There is [color=red]not enough oxygen[/color] in the air you are breathing. Put on [color=green]internals[/color].
 

--- a/Resources/Prototypes/Alerts/alerts.yml
+++ b/Resources/Prototypes/Alerts/alerts.yml
@@ -6,9 +6,11 @@
   order:
   - category: Health
   - category: Stamina
-  - alertType: ParryExhaustion # Trauma
-  - alertType: ChangelingBiomass # goobstation - changelings
-  - alertType: ChangelingChemicals # goobstation - changelings
+  # <Trauma>
+  - alertType: ParryExhaustion
+  - alertType: ChangelingBiomass
+  - alertType: ChangelingChemicals
+  # </Trauma>
   - alertType: SuitPower
   - alertType: ModsuitPower # Goobstation - Modsuits
   - category: Internals
@@ -16,6 +18,7 @@
   - alertType: HolyFire # Trauma
   - alertType: Handcuffed
   - alertType: Ensnared
+  - alertType: Fultoned # Trauma
   - category: Buckled
   - alertType: Pulling
   - alertType: Walking
@@ -33,10 +36,12 @@
   - alertType: Rooted
   - alertType: Pacified
   - alertType: Stealthy
-  - alertType: ShadowCloak # Goobstation
-  - alertType: DragonPower # Goobstation
-  - category: Ninjutsu # Goobstation
-  - category: Counter # WD EDIT
+  # <Trauma>
+  - alertType: ShadowCloak
+  - alertType: DragonPower
+  - category: Ninjutsu
+  - category: Counter
+  # </Trauma>
 
 - type: entity
   id: AlertSpriteView

--- a/Resources/Prototypes/_Trauma/Alerts/fultoned.yml
+++ b/Resources/Prototypes/_Trauma/Alerts/fultoned.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: alert
   id: Fultoned
   name: alerts-fultoned-name

--- a/Resources/Prototypes/_Trauma/Alerts/fultoned.yml
+++ b/Resources/Prototypes/_Trauma/Alerts/fultoned.yml
@@ -1,0 +1,8 @@
+- type: alert
+  id: Fultoned
+  name: alerts-fultoned-name
+  description: alerts-fultoned-desc
+  clickEvent: !type:RemoveFultonAlertEvent
+  icons:
+  - sprite: /Textures/Objects/Tools/fulton.rsi
+    state: extraction_pack


### PR DESCRIPTION
- being fultoned has an alert for people that didnt know you can right click
- the beacon being folded now counts as being unlinked

## Media

<img width="360" height="132" alt="21:11:00" src="https://github.com/user-attachments/assets/78357adb-ea7e-47c0-9900-fb03f8c246b3" />

## Changelog
:cl:
- add: Being fultoned now has an alert you can click to remove the fulton without the context menu.
- tweak: Fultons now require the beacon to be unfolded to work.