### PR TITLE
Changing some damage co-efficients and fixes one typo.

### DIFF
--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -78,7 +78,7 @@
   id: FlimsyMetallic
   coefficients:
     Blunt: 0.7
-    Slash: 0.5
+    Slash: 0.7
     Piercing: 0.7
     Shock: 1.2
 

--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -78,7 +78,7 @@
   id: FlimsyMetallic
   coefficients:
     Blunt: 0.7
-    Slash: 0.7
+    Slash: 0.7  # Trauma - upped it by 0.2 to be in line with the others.
     Piercing: 0.7
     Shock: 1.2
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -384,7 +384,7 @@
   name: uranium shiv
   parent: Shiv
   id: UraniumShiv
-  description: A crude weapon fashioned from a piece of cloth and a uranium glass shard. Violates the geneva convention!
+  description: A crude weapon fashioned from a piece of cloth and a uranium glass shard. Violates the Geneva convention!
   components:
   # <Trauma>
   - type: PhysicalComposition

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
@@ -142,7 +142,7 @@
     resistance: 3
   - type: Occluder
   - type: Damageable
-    damageModifierSet: StrongMetallic
+    damageModifierSet: Metallic
   - type: Injurable
     damageContainer: StructuralInorganic
   - type: RCDDeconstructable

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
@@ -142,7 +142,7 @@
     resistance: 3
   - type: Occluder
   - type: Damageable
-    damageModifierSet: Metallic
+    damageModifierSet: Metallic # Trauma - Was StrongMetallic, too tanky
   - type: Injurable
     damageContainer: StructuralInorganic
   - type: RCDDeconstructable

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/surveillance_camera.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/surveillance_camera.yml
@@ -246,7 +246,7 @@
     - type: Transform
       anchored: true
     - type: Damageable
-      damageModifierSet: Metallic
+      damageModifierSet: FlimsyMetallic
     - type: Injurable
       damageContainer: StructuralInorganic
     - type: Sprite

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/surveillance_camera.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/surveillance_camera.yml
@@ -246,7 +246,7 @@
     - type: Transform
       anchored: true
     - type: Damageable
-      damageModifierSet: FlimsyMetallic
+      damageModifierSet: FlimsyMetallic # Trauma - Was Metallic, too tanky
     - type: Injurable
       damageContainer: StructuralInorganic
     - type: Sprite


### PR DESCRIPTION

## About the PR

Changed a few damage modifiers and co-efficients that will hopefully result in better antag interactions with core station infastructure. 

## Why / Balance

Doors are too tanky and people find it way easier to just deconstruct a wall rather than destroy a door. Camera's being made FlimsyMetallic should also result in more people finding it easier to play the vision game with AI. Engineers/borgs may actually have reason to build more cameras now. 

## Test plan
Opened a dev environment and made sure the co-efficients matched.
## Media

## Requirements

- [X] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Changelog
:cl:
- tweak: Airlocks and cameras are now easier to break.