### PR TITLE
Interdyne defib nerf

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/defib.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/defib.yml
@@ -135,5 +135,5 @@
     activatedDamage:
       types:
         Blunt: 8
-        Shock: 8
+        Shock: 8 # Trauma - was 16, adjusted for balance
         Heat: 8

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/defib.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/defib.yml
@@ -118,6 +118,7 @@
         map: ["enum.PowerDeviceVisualLayers.Powered"]
         shader: unshaded
   - type: MeleeWeapon
+    canWideSwing: false
     damage:
       types:
         Blunt: 8
@@ -134,4 +135,5 @@
     activatedDamage:
       types:
         Blunt: 8
-        Shock: 16
+        Shock: 8
+        Heat: 8

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/defib.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/defib.yml
@@ -118,7 +118,7 @@
         map: ["enum.PowerDeviceVisualLayers.Powered"]
         shader: unshaded
   - type: MeleeWeapon
-    canWideSwing: false
+    canWideSwing: false # Trauma - removed for balance purposes
     damage:
       types:
         Blunt: 8
@@ -136,4 +136,4 @@
       types:
         Blunt: 8
         Shock: 8 # Trauma - was 16, adjusted for balance
-        Heat: 8
+        Heat: 8 # Trauma - was 0, adjusted for balance


### PR DESCRIPTION
## About the PR
Adjusted Interdyne defib damage from 16 shock damage and 8 blunt, --> to 8 shock, 8 heat, 8 blunt.

also removed wideswing capability

## Why / Balance
Turbo said it was bad and turbo is always right https://github.com/Trauma-Station/Trauma-Station/issues/4030

Defib will still be viable as a melee weapon but heat-resistance is now effective against it.

## Test plan
Spawn in Interdyne defib and health analyzer
Smack a guy with it (notice that you cant wideswing anymore)
Use health analyzer and see that damage worked as intended

## Requirements
- [X] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Changelog
:cl:
- remove: Removed syndi defib wideswing
- tweak: Reduced syndi defib shock damage and added heat damage
