### PR TITLE
changed Ranching BaseRanchingEgg name from "egg" to "fertilized egg"

### DIFF
--- a/Resources/Prototypes/_Trauma/Ranching/eggs.yml
+++ b/Resources/Prototypes/_Trauma/Ranching/eggs.yml
@@ -4,7 +4,7 @@
   abstract: true
   parent: FoodEggBase
   id: BaseRanchingEgg
-  name: egg
+  name: fertilized egg
   components:
   - type: Perishable
     rotAfter: 99999999 # For my birthday wish I wish to remove rotting


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->
Changed Name variable of `BaseRanchingEgg` from "`egg"` to `"Fertilized egg"`

## Why / Balance
Make it possible for  anyone to clearly see what egg is compatible with the ranching activities.

## Test 
Tested on localhost. All  ranching eggs are correctly affected, doesn't impact other feature of the module or SS14.

## Media
<img width="279" height="205" alt="image1" src="https://github.com/user-attachments/assets/461b1ce7-04f9-4c5b-b50a-9583bad1cf71" />

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:

- tweak: Eggs related to ranching are now named fertilized eggs. No more confusion ! 🥚 


