### PR TITLE
comms and wallmount changes

### DIFF
--- a/Content.Server/Communications/CommunicationsConsoleSystem.cs
+++ b/Content.Server/Communications/CommunicationsConsoleSystem.cs
@@ -299,13 +299,17 @@ namespace Content.Server.Communications
             var maxLength = _cfg.GetCVar(CCVars.ChatMaxAnnouncementLength);
             var reason = SharedChatSystem.SanitizeAnnouncement(message.Reason, maxLength);
             if (string.IsNullOrEmpty(reason))
-                reason = "No reason provided.";
-            else
-                comp.AnnouncementCooldownRemaining = comp.Delay;
+            {
+                _popupSystem.PopupEntity("Missing shuttle call reason", uid, message.Actor);
+                return;
+            }
+
             var attemptEv = new UserMessageAttemptEvent(mob, message.Reason);
             RaiseLocalEvent(ref attemptEv);
             if (attemptEv.Cancelled)
                 return;
+
+            comp.AnnouncementCooldownRemaining = comp.Delay;
 
             // aghosts dont show the caller or reason
             var text = uid == mob
@@ -335,13 +339,17 @@ namespace Content.Server.Communications
             var maxLength = _cfg.GetCVar(CCVars.ChatMaxAnnouncementLength);
             var reason = SharedChatSystem.SanitizeAnnouncement(message.Reason, maxLength);
             if (string.IsNullOrEmpty(reason))
-                reason = "No reason provided.";
-            else
-                comp.AnnouncementCooldownRemaining = comp.Delay;
+            {
+                _popupSystem.PopupEntity("Missing shuttle recall reason", uid, message.Actor);
+                return; // dont be a chud
+            }
+
             var attemptEv = new UserMessageAttemptEvent(mob, message.Reason);
             RaiseLocalEvent(ref attemptEv);
             if (attemptEv.Cancelled)
                 return;
+
+            comp.AnnouncementCooldownRemaining = comp.Delay;
 
             // aghosts dont show the caller or reason
             var text = uid == mob

--- a/Resources/Prototypes/AlertLevels/alert_levels.yml
+++ b/Resources/Prototypes/AlertLevels/alert_levels.yml
@@ -38,7 +38,7 @@
   color: Red
   emergencyLightColor: Red
   forceEnableEmergencyLights: true
-  shuttleTime: 5m # Trauma - was 10m, we do have alert level lock...
+  shuttleTime: 600
   # No reduction in time as we don't have swiping for red alert like in /tg/.
   # Shuttle times are intended to create friction,
   # so having a way to brainlessly bypass that would be dumb.

--- a/Resources/Prototypes/Recipes/Construction/atmospherics.yml
+++ b/Resources/Prototypes/Recipes/Construction/atmospherics.yml
@@ -74,8 +74,10 @@
   graph: AirAlarm
   targetNode: air_alarm
   canBuildInImpassable: true
-  conditions:
-  - !type:WallmountCondition
+  # <Trauma>
+  #conditions:
+  #- !type:WallmountCondition
+  # </Trauma>
 
 - type: construction
   parent: BaseAtmos
@@ -83,8 +85,10 @@
   graph: FireAlarm
   targetNode: fire_alarm
   canBuildInImpassable: true
-  conditions:
-  - !type:WallmountCondition
+  # <Trauma>
+  #conditions:
+  #- !type:WallmountCondition
+  # </Trauma>
 
 - type: construction
   parent: BaseAtmos

--- a/Resources/Prototypes/Recipes/Construction/machines.yml
+++ b/Resources/Prototypes/Recipes/Construction/machines.yml
@@ -18,9 +18,9 @@
   parent: BaseMachine
   id: BaseSwitch
   canBuildInImpassable: true
-  conditions:
-  - !type:WallmountCondition
   # <Trauma>
+  #conditions:
+  #- !type:WallmountCondition
   theory:
     ElectronicsKnowledge: 0
   useQuality: false

--- a/Resources/Prototypes/_Trauma/AlertLevels/alert_levels.yml
+++ b/Resources/Prototypes/_Trauma/AlertLevels/alert_levels.yml
@@ -37,3 +37,4 @@
 - type: alertLevel
   parent: DeltaNuke
   id: DeltaSling
+  shuttleTime: 5m # shit bad


### PR DESCRIPTION
resolves #4179

## Media

shitcommand suicide watch
<img width="188" height="86" alt="18:07:15" src="https://github.com/user-attachments/assets/06e93504-633b-4435-8cc7-2344141507ed" />

## Changelog
:cl:
- remove: You can no longer call/recall evac 4 no raisin.
- tweak: Ascended shadowling evac is 5 minutes instead of 20.
- tweak: Red alert evac is back to 10 minutes.
- tweak: More wallmount items no longer need a wall to build them.