### PR TITLE
restrict heiro club teleport to lavaland

### DIFF
--- a/Content.Lavaland.Shared/Megafauna/Systems/MegafaunaActionsSystem.cs
+++ b/Content.Lavaland.Shared/Megafauna/Systems/MegafaunaActionsSystem.cs
@@ -15,14 +15,7 @@ public sealed partial class MegafaunaActionsSystem : EntitySystem
     [Dependency] private SharedTransformSystem _xform = default!;
     [Dependency] private INetManager _net = default!;
 
-    public override void Initialize()
-    {
-        base.Initialize();
-
-        SubscribeLocalEvent<ActionsComponent, SpawnEntityActionEvent>(OnAttackAction);
-        SubscribeLocalEvent<ActionsComponent, ToggleTileMovementActionEvent>(OnTileMovement);
-    }
-
+    [SubscribeLocalEvent]
     private void OnAttackAction(Entity<ActionsComponent> ent, ref SpawnEntityActionEvent args)
     {
         if (_net.IsClient // PredictedSpawn doesn't support spawning entities without initializing them yet...
@@ -51,6 +44,7 @@ public sealed partial class MegafaunaActionsSystem : EntitySystem
         args.Handled = true;
     }
 
+    [SubscribeLocalEvent]
     private void OnTileMovement(Entity<ActionsComponent> ent, ref ToggleTileMovementActionEvent args)
     {
         if (args.Handled)

--- a/Content.Lavaland.Shared/Megafauna/Systems/MegafaunaBlinkSystem.cs
+++ b/Content.Lavaland.Shared/Megafauna/Systems/MegafaunaBlinkSystem.cs
@@ -2,7 +2,9 @@
 
 using Content.Lavaland.Shared.Megafauna.Components;
 using Content.Lavaland.Shared.Megafauna.Events;
+using Content.Lavaland.Shared.Procedural.Components;
 using Content.Shared.Coordinates.Helpers;
+using Content.Shared.Popups;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map;
@@ -16,23 +18,11 @@ namespace Content.Lavaland.Shared.Megafauna.Systems;
 public sealed partial class MegafaunaBlinkSystem : EntitySystem
 {
     [Dependency] private SharedAudioSystem _audio = default!;
+    [Dependency] private SharedPopupSystem _popup = default!;
     [Dependency] private SharedTransformSystem _xform = default!;
     [Dependency] private IGameTiming _timing = default!;
-
-    private EntityQuery<MegafaunaBlinkComponent> _blinkQuery;
-
-    public override void Initialize()
-    {
-        base.Initialize();
-        SubscribeLocalEvent<MegafaunaBlinkComponent, MegafaunaBlinkActionEvent>(OnBlinkAction);
-
-        SubscribeLocalEvent<MegafaunaBlinkInactiveComponent, MapInitEvent>(OnMapInit);
-        SubscribeLocalEvent<MegafaunaBlinkInactiveComponent, MegafaunaStartupEvent>(OnStartup);
-        SubscribeLocalEvent<MegafaunaBlinkInactiveComponent, MegafaunaShutdownEvent>(OnShutdown);
-        SubscribeLocalEvent<MegafaunaBlinkInactiveComponent, EntityTerminatingEvent>(OnDelete);
-
-        _blinkQuery = GetEntityQuery<MegafaunaBlinkComponent>();
-    }
+    [Dependency] private EntityQuery<LavalandMapComponent> _lavalandMapQuery = default!;
+    [Dependency] private EntityQuery<MegafaunaBlinkComponent> _blinkQuery = default!;
 
     public override void Update(float frameTime)
     {
@@ -57,20 +47,28 @@ public sealed partial class MegafaunaBlinkSystem : EntitySystem
         }
     }
 
+    [SubscribeLocalEvent]
     private void OnBlinkAction(Entity<MegafaunaBlinkComponent> ent, ref MegafaunaBlinkActionEvent args)
     {
         if (args.Handled
             || !args.Target.IsValid(EntityManager))
             return;
 
+        var xform = Transform(ent);
+        if (!_lavalandMapQuery.HasComp(xform.MapUid))
+        {
+            _popup.PopupEntity("The staff's power is weakened here!", ent, args.Performer);
+            return;
+        }
+
         var comp = ent.Comp;
         Blink(ent, args.Target, comp.Delay, comp.Sound);
 
-        if (comp.SpawnOnUsed != null)
-            PredictedSpawnAtPosition(comp.SpawnOnUsed.Value, Transform(ent).Coordinates);
+        if (comp.SpawnOnUsed is { } onUsed)
+            PredictedSpawnAtPosition(onUsed, xform.Coordinates);
 
-        if (comp.SpawnOnTarget != null)
-            PredictedSpawnAtPosition(comp.SpawnOnTarget.Value, args.Target);
+        if (comp.SpawnOnTarget is { } onTarget)
+            PredictedSpawnAtPosition(onTarget, args.Target);
 
         args.Handled = true;
     }
@@ -95,12 +93,14 @@ public sealed partial class MegafaunaBlinkSystem : EntitySystem
         SoundSpecifier? sound = null)
         => Blink(ent, Transform(target).Coordinates, duration, sound);
 
+    [SubscribeLocalEvent]
     private void OnMapInit(Entity<MegafaunaBlinkInactiveComponent> ent, ref MapInitEvent args)
     {
         if (ent.Comp.FixedPosition)
             ent.Comp.Marker = PredictedSpawnAtPosition(ent.Comp.MarkerId, Transform(ent).Coordinates);
     }
 
+    [SubscribeLocalEvent]
     private void OnStartup(Entity<MegafaunaBlinkInactiveComponent> ent, ref MegafaunaStartupEvent args)
     {
         if (!ent.Comp.FixedPosition
@@ -108,6 +108,7 @@ public sealed partial class MegafaunaBlinkSystem : EntitySystem
             ent.Comp.Marker = PredictedSpawnAtPosition(ent.Comp.MarkerId, Transform(ent).Coordinates);
     }
 
+    [SubscribeLocalEvent]
     private void OnShutdown(Entity<MegafaunaBlinkInactiveComponent> ent, ref MegafaunaShutdownEvent args)
     {
         if (ent.Comp.Marker == null
@@ -119,6 +120,7 @@ public sealed partial class MegafaunaBlinkSystem : EntitySystem
         ent.Comp.Marker = null;
     }
 
+    [SubscribeLocalEvent]
     private void OnDelete(Entity<MegafaunaBlinkInactiveComponent> ent, ref EntityTerminatingEvent args)
     {
         if (TerminatingOrDeleted(ent.Comp.Marker))

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -51,15 +51,17 @@
           - MachineLayer
   - type: Lathe
   - type: MaterialStorage
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 175
-      behaviors:
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MetalBreak
+  # <Trauma> - inheritance major
+  #- type: Destructible
+  #  thresholds:
+  #  - trigger:
+  #      !type:DamageTrigger
+  #      damage: 175
+  #    behaviors:
+  #    - !type:PlaySoundBehavior
+  #      sound:
+  #        collection: MetalBreak
+  # </Trauma>
   - type: WiresPanel
   - type: ActivatableUI
     key: enum.LatheUiKey.Key
@@ -156,6 +158,14 @@
     unlitIdleState: unlit
     unlitRunningState: unlit-building
     staticPacks:
+    # <Trauma>
+    - NailsStatic
+    - LatheMiscStatic
+    - MedicalVehiclesStatic
+    - GrenadeTriggersStatic
+    - TapeRecorderStatic
+    - MiscSignallersStatic
+    # </Trauma>
     - ToolsStatic
     - PartsStatic
     - AtmosStatic
@@ -170,20 +180,14 @@
     - ServiceStatic
     - PowerCellsStatic
     - ElectronicsStatic
-    # Goobstation
-    - NailsStatic
-    - LatheMiscStatic
-    - MedicalVehiclesStatic
-    - GrenadeTriggersStatic
-    - TapeRecorderStatic
-    - MiscSignallersStatic
   - type: EmagLatheRecipes
     emagStaticPacks:
+    # <Trauma>
+    - ScienceExplosives
+    # </Trauma>
     - SecurityWeaponsStatic
     - SecurityAmmoStatic
     # - SyndicateAmmoStatic # Trauma
-    # Goobstation
-    - ScienceExplosives
   - type: BlueprintReceiver
     whitelist:
       tags:


### PR DESCRIPTION
fixes #3321

other abilities are too minor to care about

:cl:
- tweak: Heirophant club no longer lets you teleport outside of lavaland.