### PR TITLE
Kitchen power and Inventory Changes

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chefvend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chefvend.yml
@@ -18,7 +18,7 @@
     ReagentContainerOliveoil: 2
     ReagentContainerMayo: 1
     VariantCubeBox: 1
-    FoodContainerEgg: 1
+    FoodContainerEgg: 3 # Trauma - Was 1, Ranchers are stealing all the eggs
     DrinkMilkCarton: 2
     DrinkSoyMilkCarton: 1
     FoodButter: 3
@@ -33,7 +33,7 @@
     WeaponCroissant: 3
     WeaponBaguette: 2
   # <Trauma>
-    Machete: 1
     HumanCube: 1
     GingerbreadCube: 1
+    SpaceCarpCube: 1
   # </Trauma>

--- a/Resources/Prototypes/Entities/Structures/Machines/hotplate.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/hotplate.yml
@@ -31,7 +31,7 @@
         sound:
           collection: MetalBreak
   - type: ApcPowerReceiver
-    powerLoad: 300
+    powerLoad: 150 # Trauma - Was 300, to stop APCs overloading
 
 - type: entity
   parent: BaseHeaterMachine

--- a/Resources/Prototypes/Entities/Structures/Machines/microwave.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/microwave.yml
@@ -102,7 +102,7 @@
     powerLoad: 5
   - type: PowerState
     idlePowerDraw: 5
-    workingPowerDraw: 1000
+    workingPowerDraw: 700 # Trauma - Was 1000, to stop APCs overloading
   - type: Machine
     board: MicrowaveMachineCircuitboard
   - type: ContainerContainer


### PR DESCRIPTION
## About the PR
Changed ChefVend inventory, reduced overall power consumption in the Kitchen
## Why / Balance
Kitchen APC's constantly overloading cos everything was sucking so much power. Swapped a Machete for a Carp Cube in emagged ChefVend cos do chefs really need another melee weapon? Seems more in theme
## Test plan
Booted up dev environment, spawned a kitchens worth of machines, set everything running at once. Emagged a ChefVend to make sure the inventories were correct.
## Media


## Requirements

- [X] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Changelog
- tweak: Power consumption of machines in kitchen reduced
- tweak: Changed inventory of ChefVend and emagged version