### PR TITLE
added a weapon selector for detective

### DIFF
--- a/Resources/Locale/en-US/_Trauma/set-selector-menu.ftl/selectable-sets.ftl
+++ b/Resources/Locale/en-US/_Trauma/set-selector-menu.ftl/selectable-sets.ftl
@@ -41,3 +41,23 @@ selectable-set-syndicate-door-kicker-description =
     syndicate operative pda, web vest, chest rig, syndicate gas mask,
     syndicate jaws of death, 'bojevic' combat shotgun, shell box,
     syndicate encryption key, and two C-4.
+
+# Detective
+
+selectable-set-inspector-set-name = Inspector
+selectable-set-inspector-set-description =
+    The honorable classic.
+    Contains: Inspector, 1 speedloader.
+
+selectable-set-deckard-set-name = Deckard
+selectable-set-deckard-set-description =
+    Provides a faster rate of fire while sacrificing ammo capacity.
+    Contains: Deckard, 1 speedloader.
+
+selectable-set-pirate-set-name = Pirate Revolver
+selectable-set-pirate-set-description =
+    A blast from the past.
+    Contains: Pirate Revolver, 1 AP ammo speedloader.
+
+		
+	

--- a/Resources/Prototypes/Entities/Objects/Specific/Security/detective_set_selector.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Security/detective_set_selector.yml
@@ -1,0 +1,20 @@
+- type: entity
+  parent: [ BaseItem, BaseSetSelector ]
+  id: RevolverSelector
+  name: revolver selector
+  description: An old looking case. Reeks of alchohol and gunpowder.
+  components:
+  - type: Sprite
+    sprite: Objects/Storage/medalcase.rsi
+    state: closed
+  - type: Item
+    storedRotation: 90
+  - type: SetSelector
+    possibleSets:
+    - DetectiveInspectorSet
+    - DetectiveDeckardSet
+    - DetectivePirateSet
+    spawnedStoragePrototype: ClothingBeltHolster
+    spawnedStorageContainer: storagebase
+    approveSound:
+      collection: storageRustle

--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -41,13 +41,14 @@
     id: DetectivePDA
     #gloves: ClothingHandsGlovesForensic - Goobstation, moved to loadouts
     ears: ClothingHeadsetAltSecurityRegular # Goobstation
-    belt: ClothingBeltHolsterFilled
+    #belt: ClothingBeltHolsterFilled - Replaced by revolver selector
   storage:
     back:
     - Flash
     - ForensicPad
     - ForensicScanner
     - ClothingMaskGasSecurity # Goobstation
+    - RevolverSelector
 
 - type: chameleonOutfit
   id: DetectiveChameleonOutfit

--- a/Resources/Prototypes/_Trauma/Catalog/selectable_sets.yml
+++ b/Resources/Prototypes/_Trauma/Catalog/selectable_sets.yml
@@ -87,3 +87,36 @@
   - EncryptionKeySyndie
   - ClothingMaskGasVoiceChameleon
   - ClothingHeadsetChameleon
+
+# Detective
+
+
+- type: selectableSet
+  id: DetectiveInspectorSet
+  name: selectable-set-inspector-set-name
+  description: selectable-set-inspector-set-description
+  sprite:
+    entity: WeaponRevolverInspector
+  content:
+  - WeaponRevolverInspector
+  - SpeedLoaderMagnum
+
+- type: selectableSet
+  id: DetectiveDeckardSet
+  name: selectable-set-deckard-set-name
+  description: selectable-set-deckard-set-description
+  sprite:
+    entity: WeaponRevolverDeckard
+  content:
+  - WeaponRevolverDeckard
+  - SpeedLoaderMagnum
+  
+- type: selectableSet
+  id: DetectivePirateSet
+  name: selectable-set-pirate-set-name
+  description: selectable-set-pirate-set-description
+  sprite:
+    entity: WeaponRevolverPirate
+  content:
+  - WeaponRevolverPirate
+  - SpeedLoaderMagnumAP


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
Replaced the detective's revolver and holster with the Revolver Selector. It allows you to choose between Inspector, Deckard and the Pirate Revolver.
Upon choosing every firearm comes with a holster.

## Why / Balance
I thought that detective lacked customizability in his loadout, so I added a selector.

## Test plan
Tested it on a sandbox server by checking if the detective spawns with the box roundstart, they do.

## Media
<img width="699" height="792" alt="image" src="https://github.com/user-attachments/assets/b4694cbd-6cae-4b9f-acca-d4ae07aca71b" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: revolver selector for the detectve

