### PR TITLE
Spationaut suit and helmet resistance tweaks

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -159,7 +159,7 @@
         Blunt: 0.9
         Slash: 0.9
         Piercing: 0.9
-        Radiation: 0.1
+        Radiation: 0.5 # Trauma - was 0.1
         Caustic: 0.8
   - type: Tag
     tags:

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -88,8 +88,14 @@
     lowPressureMultiplier: 1000
   - type: Armor
     modifiers:
+      # <Trauma>
       coefficients:
-        Radiation: 0.1
+        Radiation: 0.5 # was 0.1
+        Blunt: 0.9
+        Slash: 0.9
+        Piercing: 0.9
+        Caustic: 0.8
+      # </Trauma>
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8


### PR DESCRIPTION
## About the PR
Changed spationaut suit and helmet resistances

## Why / Balance
Now uses the following resistances
        Radiation: 0.5
        Blunt: 0.9
        Slash: 0.9
        Piercing: 0.9
        Caustic: 0.8

## Test plan
run local client and verify resistances

## Media
<img width="496" height="554" alt="изображение" src="https://github.com/user-attachments/assets/bb0b9ac3-4f4d-41f5-9a71-bd4b5bebd0f9" />

## Requirements
- [X] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Changelog
:cl: badjuju
- tweak: Changed spationaut suit and helmet resistances
