### PR TITLE
remove binary from pai

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/pai.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/pai.yml
@@ -34,10 +34,6 @@
     - Freespeak
     - Tradeband
     - NewKinPidgin
-  - type: CollectiveMind
-    defaultChannel: Binary
-    channels:
-    - Binary
   - type: IntellicardableMind
   # </Trauma>
   - type: Instrument


### PR DESCRIPTION
its crazy slop that ruins any kind of antag play involving ai

they still have the robot talk language to talk with borgs

:cl:
- remove: PAIs no longer get access to the binary channel.