### PR TITLE
block all radio messages in solar flares

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -402,7 +402,7 @@
     duration: 120
     maxDuration: 240
   - type: SolarFlareRule
-    onlyJamHeadsets: true
+    #onlyJamHeadsets: true # Trauma - POV: intercoms and clankers somehow bypass the radio blackout
     affectedChannels:
     - Common
     extraChannels:


### PR DESCRIPTION
fixes #4257 by killing all messages not just headsets

ipcs shouldnt be able to magically talk to eachother and intercoms etc also dont make much sense

:cl:
- tweak: Solar flares now prevent all radio sources including IPCs, intercoms and nanochat.