### PR TITLE
remove melee weapon speedup from capo

### DIFF
--- a/Content.Trauma.Shared/Knowledge/Systems/MeleeKnowledgeSystem.cs
+++ b/Content.Trauma.Shared/Knowledge/Systems/MeleeKnowledgeSystem.cs
@@ -11,7 +11,6 @@ namespace Content.Trauma.Shared.Knowledge.Systems;
 public sealed partial class MeleeKnowledgeSystem : EntitySystem
 {
     [Dependency] private SharedKnowledgeSystem _knowledge = default!;
-    [Dependency] private EntityQuery<NoMartialMeleeSpeedComponent> _noSpeedQuery = default!;
 
     public override void Initialize()
     {
@@ -23,8 +22,8 @@ public sealed partial class MeleeKnowledgeSystem : EntitySystem
     [SubscribeLocalEvent]
     private void OnGetMeleeAttackRate(Entity<MeleeSpeedKnowledgeComponent> ent, ref GetMeleeAttackRateEvent args)
     {
-        if (_noSpeedQuery.HasComp(args.Weapon))
-            return;
+        if (args.Weapon != args.User)
+            return; // don't speed up actual weapons just punches
 
         var level = _knowledge.GetLevel(ent.Owner);
         args.Multipliers *= ent.Comp.Curve.GetCurve(level);

--- a/Content.Trauma.Shared/MartialArts/Components/NoMartialMeleeSpeedComponent.cs
+++ b/Content.Trauma.Shared/MartialArts/Components/NoMartialMeleeSpeedComponent.cs
@@ -1,9 +1,0 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-
-namespace Content.Trauma.Shared.MartialArts.Components;
-
-/// <summary>
-/// Put on a weapon to stop martial arts speeding up attacks made with it.
-/// </summary>
-[RegisterComponent, NetworkedComponent]
-public sealed partial class NoMartialMeleeSpeedComponent : Component;

--- a/Content.Trauma.Shared/MartialArts/MartialArtsSystem.Modifiers.cs
+++ b/Content.Trauma.Shared/MartialArts/MartialArtsSystem.Modifiers.cs
@@ -14,7 +14,6 @@ public partial class MartialArtsSystem
 {
     [Dependency] private MovementSpeedModifierSystem _speed = default!;
     [Dependency] private EntityQuery<MartialArtModifiersComponent> _query = default!;
-    [Dependency] private EntityQuery<NoMartialMeleeSpeedComponent> _noSpeedQuery = default!;
 
     private void UpdateModifiers()
     {
@@ -127,8 +126,8 @@ public partial class MartialArtsSystem
     [SubscribeLocalEvent]
     private void OnModifyAttackRate(Entity<MartialArtModifiersComponent> ent, ref GetMeleeAttackRateEvent args)
     {
-        if (_noSpeedQuery.HasComp(args.Weapon))
-            return;
+        if (args.Weapon != args.User)
+            return; // don't speed up actual weapons just punches
 
         var (mult, mod) = GetModifiers(ent, MartialArtModifierType.AttackRate, args.Weapon == args.User);
         args.Multipliers *= mult;

--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -477,7 +477,6 @@
   # <Trauma>
   - type: WeaponClass
     class: Unarmed # you are still just hitting people just really fast
-  - type: NoMartialMeleeSpeed
   # </Trauma>
   - type: Sprite
     sprite: Clothing/Hands/Gloves/northstar.rsi


### PR DESCRIPTION
fixes #4258

its slop and not justified or explained anywhere, martial arts should be martial arts not a shitty melee buff status effect

:cl:
- fix: Fixed capoeira making weapons faster.