### PR TITLE
holosign fix and cleanup

### DIFF
--- a/Content.Goobstation.Common/Religion/NullrodEvents.cs
+++ b/Content.Goobstation.Common/Religion/NullrodEvents.cs
@@ -2,17 +2,8 @@
 
 namespace Content.Goobstation.Common.Religion;
 
-public sealed class TouchSpellDenialRelayEvent : CancellableEntityEventArgs;
-
-public sealed class BeforeCastTouchSpellEvent(EntityUid target, bool doEffects = true) : CancellableEntityEventArgs
-{
-    /// <summary>
-    /// The target of the event, to check if they meet the requirements for casting.
-    /// </summary>
-    public EntityUid? Target = target;
-
-    public bool DoEffects = doEffects;
-}
+[ByRefEvent]
+public record struct BeforeCastTouchSpellEvent(EntityUid Target, bool DoEffects = true, bool Cancelled = false);
 
 [ByRefEvent]
 public record struct UserShouldTakeHolyEvent(EntityUid Target, bool WeakToHoly = false, bool ShouldTakeHoly = false);

--- a/Content.Goobstation.Shared/Religion/DivineInterventionSystem.cs
+++ b/Content.Goobstation.Shared/Religion/DivineInterventionSystem.cs
@@ -89,32 +89,17 @@ public sealed partial class DivineInterventionSystem : EntitySystem
     /// Handles EntityTargetActionEvent spells.
     /// </summary>
     [SubscribeLocalEvent]
-    private void OnTouchSpellAttempt(BeforeCastTouchSpellEvent args)
+    private void OnTouchSpellAttempt(ref BeforeCastTouchSpellEvent args)
     {
-        if (args.Target is not { } target)
-            return;
-
+        var target = args.Target;
         if (ShouldDeny(target, out var denyingItem)
             && denyingItem != null
             && Exists(denyingItem.Value))
         {
-            args.Cancel();
+            args.Cancelled = true;
             if (args.DoEffects)
                 DenialEffects(denyingItem.Value, target);
         }
-    }
-
-    /// <summary>
-    /// Relays whether a spell denial took place - especially useful for working between Core & GoobMod
-    /// </summary>
-    [SubscribeLocalEvent]
-    private void OnTouchSpellDenied(EntityUid uid, DivineInterventionComponent comp, TouchSpellDenialRelayEvent args)
-    {
-        var ev = new BeforeCastTouchSpellEvent(uid);
-        RaiseLocalEvent(uid, ev, true);
-
-        if (ev.Cancelled)
-            args.Cancel();
     }
 
     /// <summary>
@@ -123,13 +108,10 @@ public sealed partial class DivineInterventionSystem : EntitySystem
     public bool TouchSpellDenied(EntityUid uid, bool doEffects = true)
     {
         var ev = new BeforeCastTouchSpellEvent(uid, doEffects);
-        RaiseLocalEvent(uid, ev, true);
+        RaiseLocalEvent(uid, ref ev, true);
 
         return ev.Cancelled;
     }
 
     #endregion
-
-
-
 }

--- a/Content.Shared/Holosign/HolosignSystem.Trauma.cs
+++ b/Content.Shared/Holosign/HolosignSystem.Trauma.cs
@@ -8,7 +8,7 @@ using Content.Shared.Physics;
 using Content.Shared.Tag;
 using Content.Trauma.Common.Heretic;
 using Robust.Shared.Map;
-using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics;
 using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Holosign;
@@ -23,11 +23,11 @@ public sealed partial class HolosignSystem
     [Dependency] private SharedTransformSystem _transform = default!;
     [Dependency] private TagSystem _tag = default!;
     [Dependency] private SharedChargesSystem _charges = default!;
-    [Dependency] private EntityQuery<PhysicsComponent> _physicsQuery = default!;
+    [Dependency] private EntityQuery<FixturesComponent> _fixturesQuery = default!;
 
     public static readonly ProtoId<TagPrototype> HolosignTag = "Holosign";
 
-    private HashSet<Entity<PhysicsComponent>> _blockers = new();
+    private HashSet<Entity<FixturesComponent>> _blockers = new();
 
     private const int BlockMask = (int) (
         CollisionGroup.Impassable |
@@ -48,10 +48,10 @@ public sealed partial class HolosignSystem
         {
             foreach (var uid in _map.GetAnchoredEntities((grid, gridComp), mapCoords))
             {
-                if (!_physicsQuery.TryComp(uid, out var physics))
+                if (!_fixturesQuery.TryComp(uid, out var fixtures))
                     continue;
 
-                _blockers.Add((uid, physics));
+                _blockers.Add((uid, fixtures));
             }
         }
         else
@@ -64,8 +64,11 @@ public sealed partial class HolosignSystem
             if (_tag.HasTag(entity, HolosignTag))
                 return null; // no stacking holosigns
 
-            if ((entity.Comp.CollisionLayer & BlockMask) != 0) // overlapping with something that blocks the field
-                return null;
+            foreach (var fixture in entity.Comp.Fixtures.Values)
+            {
+                if (fixture.Hard && (fixture.CollisionLayer & BlockMask) != 0) // overlapping with something that blocks the field
+                    return null;
+            }
         }
 
         EntityUid? user = TryComp(ent, out LimitedChargesComponent? charges) ? null : args.User; // Don't show popups if it has limited charges (user is null = no popup)

--- a/Content.Shared/Magic/SharedMagicSystem.cs
+++ b/Content.Shared/Magic/SharedMagicSystem.cs
@@ -162,7 +162,7 @@ public abstract partial class SharedMagicSystem : EntitySystem
     public bool IsTouchSpellDenied(EntityUid target) // Goob edit
     {
         var ev = new BeforeCastTouchSpellEvent(target);
-        RaiseLocalEvent(target, ev, true);
+        RaiseLocalEvent(target, ref ev, true);
 
         return ev.Cancelled;
     }

--- a/Content.Trauma.Server/Heretic/Abilities/HereticAbilitySystem.Void.cs
+++ b/Content.Trauma.Server/Heretic/Abilities/HereticAbilitySystem.Void.cs
@@ -34,7 +34,7 @@ public sealed partial class HereticAbilitySystem
         args.Handled = true;
 
         var ev = new BeforeCastTouchSpellEvent(target);
-        RaiseLocalEvent(target, ev, true);
+        RaiseLocalEvent(target, ref ev, true);
         if (ev.Cancelled)
             return;
 

--- a/Content.Trauma.Server/Heretic/Systems/PathSpecific/FireBlastSystem.cs
+++ b/Content.Trauma.Server/Heretic/Systems/PathSpecific/FireBlastSystem.cs
@@ -194,7 +194,7 @@ public sealed partial class FireBlastSystem : EntitySystem
         var (target, flam, _) = result.Value;
 
         var ev = new BeforeCastTouchSpellEvent(target);
-        RaiseLocalEvent(target, ev, true);
+        RaiseLocalEvent(target, ref ev, true);
 
         var antimagic = ev.Cancelled;
 

--- a/Content.Trauma.Shared/Genetics/Abilities/MindReadActionSystem.cs
+++ b/Content.Trauma.Shared/Genetics/Abilities/MindReadActionSystem.cs
@@ -63,7 +63,7 @@ public sealed partial class MindReadActionSystem : EntitySystem
 
         // nullrod protects from mind magic idk
         var ev = new BeforeCastTouchSpellEvent(target);
-        RaiseLocalEvent(target, ev);
+        RaiseLocalEvent(target, ref ev);
         if (ev.Cancelled)
         {
             _popup.PopupEntity(Loc.GetString("MutationMindReader-popup-mind-protected", ("target", identity)), user, user);

--- a/Content.Trauma.Shared/Heretic/Systems/Abilities/SharedHereticAbilitySystem.cs
+++ b/Content.Trauma.Shared/Heretic/Systems/Abilities/SharedHereticAbilitySystem.cs
@@ -184,7 +184,7 @@ public abstract partial class SharedHereticAbilitySystem : EntitySystem
             if (checkNullRod)
             {
                 var ev = new BeforeCastTouchSpellEvent(look, false);
-                RaiseLocalEvent(look, ev, true);
+                RaiseLocalEvent(look, ref ev, true);
                 if (ev.Cancelled)
                     continue;
             }

--- a/Content.Trauma.Shared/Heretic/Systems/PathSpecific/Cosmos/SharedStarMarkSystem.cs
+++ b/Content.Trauma.Shared/Heretic/Systems/PathSpecific/Cosmos/SharedStarMarkSystem.cs
@@ -275,7 +275,7 @@ public abstract partial class SharedStarMarkSystem : EntitySystem
             return false;
 
         var ev = new BeforeCastTouchSpellEvent(entity, false);
-        RaiseLocalEvent(entity, ev, true);
+        RaiseLocalEvent(entity, ref ev, true);
 
         var result = !ev.Cancelled &&
                      _status.TryUpdateStatusEffectDuration(entity,

--- a/Content.Trauma.Shared/Heretic/Systems/PathSpecific/Lock/LabyrinthHandbookSystem.cs
+++ b/Content.Trauma.Shared/Heretic/Systems/PathSpecific/Lock/LabyrinthHandbookSystem.cs
@@ -12,19 +12,12 @@ public sealed partial class LabyrinthHandbookSystem : EntitySystem
 {
     [Dependency] private ExamineSystemShared _examine = default!;
     [Dependency] private SharedHereticSystem _heretic = default!;
+    [Dependency] private EntityQuery<LabyrinthWallComponent> _wallQuery = default!;
 
-    public override void Initialize()
-    {
-        base.Initialize();
-
-        SubscribeLocalEvent<LabyrinthHandbookComponent, BeforeHolosignUsedEvent>(OnBeforeHolosign);
-
-        SubscribeLocalEvent<ContainmentFieldThrowEvent>(OnThrow);
-    }
-
+    [SubscribeLocalEvent]
     private void OnThrow(ref ContainmentFieldThrowEvent args)
     {
-        if (!HasComp<LabyrinthWallComponent>(args.Field))
+        if (!_wallQuery.HasComp(args.Field))
             return;
 
         if (_heretic.IsHereticOrGhoul(args.Entity))
@@ -34,10 +27,11 @@ public sealed partial class LabyrinthHandbookSystem : EntitySystem
         }
 
         var ev = new BeforeCastTouchSpellEvent(args.Entity, false);
-        RaiseLocalEvent(args.Entity, ev, true);
+        RaiseLocalEvent(args.Entity, ref ev, true);
         args.Cancelled = ev.Cancelled;
     }
 
+    [SubscribeLocalEvent]
     private void OnBeforeHolosign(Entity<LabyrinthHandbookComponent> ent, ref BeforeHolosignUsedEvent args)
     {
         args.Handled = true;

--- a/Content.Trauma.Shared/Heretic/Systems/PathSpecific/Rust/EntropicPlumeSystem.cs
+++ b/Content.Trauma.Shared/Heretic/Systems/PathSpecific/Rust/EntropicPlumeSystem.cs
@@ -53,7 +53,7 @@ public sealed partial class EntropicPlumeSystem : EntitySystem
             return;
 
         var ev = new BeforeCastTouchSpellEvent(args.OtherEntity, false);
-        RaiseLocalEvent(args.OtherEntity, ev, true);
+        RaiseLocalEvent(args.OtherEntity, ref ev, true);
         if (ev.Cancelled)
             return;
 

--- a/Content.Trauma.Shared/Heretic/Systems/PathSpecific/Void/SharedVoidCurseSystem.cs
+++ b/Content.Trauma.Shared/Heretic/Systems/PathSpecific/Void/SharedVoidCurseSystem.cs
@@ -63,7 +63,7 @@ public abstract partial class SharedVoidCurseSystem : EntitySystem
             return false;
 
         var ev = new BeforeCastTouchSpellEvent(uid, false);
-        RaiseLocalEvent(uid, ev, true);
+        RaiseLocalEvent(uid, ref ev, true);
         if (ev.Cancelled)
             return false;
 

--- a/Content.Trauma.Shared/Heretic/Systems/TouchSpellSystem.cs
+++ b/Content.Trauma.Shared/Heretic/Systems/TouchSpellSystem.cs
@@ -133,7 +133,7 @@ public sealed partial class TouchSpellSystem : EntitySystem
         if (!ent.Comp.BypassNullrod)
         {
             var beforeEv = new BeforeCastTouchSpellEvent(target);
-            RaiseLocalEvent(target, beforeEv, true);
+            RaiseLocalEvent(target, ref beforeEv, true);
             if (beforeEv.Cancelled)
                 return true;
         }

--- a/Content.Trauma.Shared/Holosign/ChargeHolosignProjectorComponent.cs
+++ b/Content.Trauma.Shared/Holosign/ChargeHolosignProjectorComponent.cs
@@ -1,13 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-using Robust.Shared.Containers;
-
 namespace Content.Trauma.Shared.Holosign;
 
 /// <summary>
 /// A holosign projector that uses <c>LimitedCharges</c> instead of a power cell slot.
 /// If there is already a sign on the clicked tile it reclaims it for a charge instead of stacking it.
-/// Currently there is no spawning prediction so signs are spawned once in a container and moved out to allow prediction.
 /// </summary>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState, Access(typeof(ChargeHolosignSystem))]
 public sealed partial class ChargeHolosignProjectorComponent : Component
@@ -22,22 +19,13 @@ public sealed partial class ChargeHolosignProjectorComponent : Component
     /// Component on <see cref="SignProto"/> to check for duplicates.
     /// </summary>
     [DataField(required: true)]
-    public string SignComponentName;
+    public CompName SignComponentName;
 
     public Type SignComponent = default!;
 
     /// <summary>
-    /// Container to store sign entities in before they are "spawned" on use.
+    /// Active holosigns we "own".
     /// </summary>
-    [DataField]
-    public string ContainerId = "signs";
-
-    /// <summary>
-    /// Holosigns we "own".
-    /// </summary>
-    [ViewVariables, AutoNetworkedField]
+    [DataField, AutoNetworkedField]
     public List<EntityUid> Signs = new();
-
-    [ViewVariables]
-    public Container Container = default!;
 }

--- a/Content.Trauma.Shared/Holosign/ChargeHolosignSystem.cs
+++ b/Content.Trauma.Shared/Holosign/ChargeHolosignSystem.cs
@@ -8,9 +8,7 @@ using Content.Shared.Interaction;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Popups;
 using Content.Shared.Storage;
-using Robust.Shared.Containers;
 using Robust.Shared.Map;
-using Robust.Shared.Timing;
 using System.Linq;
 
 namespace Content.Trauma.Shared.Holosign;
@@ -18,59 +16,26 @@ namespace Content.Trauma.Shared.Holosign;
 public sealed partial class ChargeHolosignSystem : EntitySystem
 {
     [Dependency] private EntityLookupSystem _lookup = default!;
-    [Dependency] private IGameTiming _timing = default!;
-    [Dependency] private INetManager _net = default!;
     [Dependency] private SharedChargesSystem _charges = default!;
-    [Dependency] private SharedContainerSystem _container = default!;
     [Dependency] private SharedPopupSystem _popup = default!;
     [Dependency] private SharedTransformSystem _transform = default!;
 
     private HashSet<Entity<IComponent>> _signs = new();
 
-    public override void Initialize()
-    {
-        base.Initialize();
-
-        SubscribeLocalEvent<ChargeHolosignProjectorComponent, ComponentInit>(OnInit);
-        SubscribeLocalEvent<ChargeHolosignProjectorComponent, MapInitEvent>(OnMapInit);
-        SubscribeLocalEvent<ChargeHolosignProjectorComponent, BeforeRangedInteractEvent>(OnBeforeInteract);
-        SubscribeLocalEvent<ChargeHolosignProjectorComponent, UseInHandEvent>(OnUseInHand);
-    }
-
+    [SubscribeLocalEvent]
     private void OnInit(Entity<ChargeHolosignProjectorComponent> ent, ref ComponentInit args)
     {
         // its required, funny test is still funny
         if (string.IsNullOrEmpty(ent.Comp.SignComponentName))
             return;
 
-        ent.Comp.Container = _container.EnsureContainer<Container>(ent, ent.Comp.ContainerId);
-        ent.Comp.SignComponent = EntityManager.ComponentFactory.GetRegistration(ent.Comp.SignComponentName).Type;
+        ent.Comp.SignComponent = Factory.GetRegistration(ent.Comp.SignComponentName).Type;
     }
 
-    private void OnMapInit(Entity<ChargeHolosignProjectorComponent> ent, ref MapInitEvent args)
-    {
-        if (!TryComp<LimitedChargesComponent>(ent, out var charges))
-            return;
-
-        var containers = Comp<ContainerManagerComponent>(ent);
-        for (var i = 0; i < charges.MaxCharges; i++)
-        {
-            if (!TrySpawnInContainer(ent.Comp.SignProto, ent, ent.Comp.ContainerId, out var signUid))
-            {
-                Log.Error($"Failed to spawn sign {ent.Comp.SignProto} for {ToPrettyString(ent)}!");
-                return;
-            }
-
-            ent.Comp.Signs.Add(signUid.Value);
-        }
-
-        Dirty(ent);
-    }
-
+    [SubscribeLocalEvent]
     private void OnBeforeInteract(Entity<ChargeHolosignProjectorComponent> ent, ref BeforeRangedInteractEvent args)
     {
-        if (!_timing.IsFirstTimePredicted ||
-            args.Handled || !args.CanReach ||
+        if (args.Handled || !args.CanReach ||
             HasComp<StorageComponent>(args.Target) || // if it's a storage component like a bag, we ignore usage so it can be stored
             !TryComp<LimitedChargesComponent>(ent, out var charges))
             return;
@@ -88,79 +53,41 @@ public sealed partial class ChargeHolosignSystem : EntitySystem
         args.Handled = true;
     }
 
+    [SubscribeLocalEvent]
     private void OnUseInHand(Entity<ChargeHolosignProjectorComponent> ent, ref UseInHandEvent args)
     {
-        if (!_timing.IsFirstTimePredicted || !TryComp<LimitedChargesComponent>(ent, out var charges))
+        if (!TryComp<LimitedChargesComponent>(ent, out var charges))
             return;
 
-        // count how many holosigns we actually managed to recall
-        var count = 0;
-        var remQueue = new List<EntityUid>();
-
-        // recall all holosigns we can
+        // recall all holosigns
         foreach (var signUid in ent.Comp.Signs)
         {
-            if (TerminatingOrDeleted(signUid))
-            {
-                remQueue.Add(signUid);
-                continue;
-            }
-
-            if (ent.Comp.Container.Contains(signUid) || TryRemoveSign((ent, ent.Comp, charges), signUid, args.User, false))
-            {
-                count++;
-            }
-            else
-            {
-                // delete it if we can't recall it
-                if (_net.IsServer)
-                    QueueDel(signUid);
-                remQueue.Add(signUid);
-            }
+            PredictedQueueDel(signUid);
         }
 
-        foreach (var signUid in remQueue)
-            ent.Comp.Signs.Remove(signUid);
-
-        // spawn replacements for holosigns we couldn't recall
-        for (var i = count; i < charges.MaxCharges; i++)
-        {
-            if (!TrySpawnInContainer(ent.Comp.SignProto, ent, ent.Comp.ContainerId, out var signUid))
-            {
-                Log.Error($"Failed to spawn sign {ent.Comp.SignProto} for {ToPrettyString(ent)}!");
-                break;
-            }
-
-            _charges.AddCharges((ent, charges), 1);
-            ent.Comp.Signs.Add(signUid.Value);
-        }
-
+        ent.Comp.Signs.Clear();
         Dirty(ent);
+
+        // refill charges
+        _charges.SetCharges((ent, charges), charges.MaxCharges);
     }
 
-    public bool TryPlaceSign(Entity<ChargeHolosignProjectorComponent?, LimitedChargesComponent?> ent, EntityCoordinates coords, EntityUid user)
+    public bool TryPlaceSign(Entity<ChargeHolosignProjectorComponent, LimitedChargesComponent> ent, EntityCoordinates coords, EntityUid user)
     {
-        if (!Resolve(ent, ref ent.Comp1, ref ent.Comp2))
-            return false;
-
-        var container = ent.Comp1.Container;
-        if (container.Count == 0 || !_charges.TryUseCharge((ent, ent.Comp2)))
+        if (!_charges.TryUseCharge((ent, ent.Comp2)))
         {
             _popup.PopupEntity(Loc.GetString("charge-holoprojector-no-charges", ("item", ent)), ent, user);
             return false;
         }
 
-        var placed = container.ContainedEntities.First(); // checked Count beforehand so this won't fail
-        _transform.SetCoordinates(placed, coords);
-        _transform.AnchorEntity(placed);
+        var placed = PredictedSpawnAtPosition(ent.Comp1.SignProto, coords);
+        ent.Comp1.Signs.Add(placed);
+        Dirty(ent, ent.Comp1);
         return true;
     }
 
-    public bool TryRemoveSign(Entity<ChargeHolosignProjectorComponent?, LimitedChargesComponent?> ent, EntityUid sign, EntityUid user, bool showIdentity = true)
+    public bool TryRemoveSign(Entity<ChargeHolosignProjectorComponent, LimitedChargesComponent> ent, EntityUid sign, EntityUid user)
     {
-        if (!Resolve(ent, ref ent.Comp1, ref ent.Comp2))
-            return false;
-
         // don't overfill
         if (_charges.GetCurrentCharges((ent, ent.Comp2)) >= ent.Comp2.MaxCharges)
         {
@@ -168,19 +95,16 @@ public sealed partial class ChargeHolosignSystem : EntitySystem
             return false;
         }
 
-        if (!_container.Insert(sign, ent.Comp1.Container, force: true))
-        {
-            Log.Error($"Failed to insert holosign {ToPrettyString(sign)} back into {ToPrettyString(ent)}!");
-            return false;
-        }
+        PredictedQueueDel(sign);
+        ent.Comp1.Signs.Remove(sign);
+        Dirty(ent, ent.Comp1);
 
         _charges.AddCharges((ent, ent.Comp2), 1);
 
-        var othersStr = showIdentity ? Loc.GetString("charge-holoprojector-reclaim-others", ("sign", sign), ("user", Identity.Name(user, EntityManager)))
-                                     : Loc.GetString("charge-holoprojector-recall-others", ("sign", sign));
+        var msg = Loc.GetString("charge-holoprojector-reclaim-others", ("sign", sign), ("user", Identity.Name(user, EntityManager)));
         _popup.PopupEntity(
             Loc.GetString("charge-holoprojector-reclaim", ("sign", sign)),
-            othersStr,
+            msg,
             ent,
             user);
         return true;

--- a/Content.Trauma.Shared/Wizard/SharedSpellsSystem.cs
+++ b/Content.Trauma.Shared/Wizard/SharedSpellsSystem.cs
@@ -1265,8 +1265,7 @@ public abstract partial class SharedSpellsSystem : CommonSpellsSystem
     private bool IsTouchSpellDenied(EntityUid target)
     {
         var ev = new BeforeCastTouchSpellEvent(target);
-        RaiseLocalEvent(target, ev, true);
-
+        RaiseLocalEvent(target, ref ev, true);
         return ev.Cancelled;
     }
 

--- a/Resources/Locale/en-US/_DV/tools/charge-holoprojector.ftl
+++ b/Resources/Locale/en-US/_DV/tools/charge-holoprojector.ftl
@@ -2,4 +2,3 @@ charge-holoprojector-no-charges = {CAPITALIZE(THE($item))} is empty, reclaim an 
 charge-holoprojector-charges-full = {CAPITALIZE(THE($item))} is full, it can't reclaim more charges!
 charge-holoprojector-reclaim = You stop projecting {THE($sign)}.
 charge-holoprojector-reclaim-others = {CAPITALIZE($user)} stops projecting {THE($sign)}.
-charge-holoprojector-recall-others = {CAPITALIZE(THE($sign))} stops being projected.

--- a/Resources/Prototypes/Entities/Objects/Devices/holoprojectors.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/holoprojectors.yml
@@ -88,9 +88,6 @@
     storedRotation: -90
   - type: LimitedCharges
     maxCharges: 6 # same as it was on a medium cell
-  - type: ContainerContainer
-    containers:
-      signs: !type:Container
   - type: PhysicalComposition
     materialComposition:
       Steel: 75


### PR DESCRIPTION
fixes #4248

regular holosigns now ignore non-hard fixtures so xeno weeds dont block it

also replaced holofan prediction container hack with actual predicted spawns

:cl:
- fix: Fixed not being able to use holosigns on xeno weeds.