### PR TITLE
Ling no longer needs to absorb another ling

### DIFF
--- a/Resources/Prototypes/_Goobstation/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/_Goobstation/Objectives/objectiveGroups.yml
@@ -27,7 +27,7 @@
   id: ChangelingObjectiveGroupKill
   weights:
     LingKillRandomHeadObjective: 3
-    ChangelingAbsorbOtherObjective: 1 # absorb another changeling
+#    ChangelingAbsorbOtherObjective: 1 # Only 1 ling can spawn, you can't absorb another
 
 - type: weightedRandom
   id: ConctactorObjectiveGroupRansom


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->
Lings will always need to absorb 6 non lings instead of ever needing to absorb another ling.

fixes #4197

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Absorbing other lings requires multiple lings rolling, which is currently impossible on this fork.
## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
I used antag ctrl as several people to turn into a ling and check my objectives
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Lings never need to absorb other lings now