### PR TITLE
fix id cards jobs

### DIFF
--- a/Content.Client/Access/UI/IdCardConsoleWindow.xaml
+++ b/Content.Client/Access/UI/IdCardConsoleWindow.xaml
@@ -1,17 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2021 Visne <39844191+Visne@users.noreply.github.com>
-SPDX-FileCopyrightText: 2022 Flipp Syder <76629141+vulppine@users.noreply.github.com>
-SPDX-FileCopyrightText: 2022 Leon Friedrich <60421075+ElectroJr@users.noreply.github.com>
-SPDX-FileCopyrightText: 2022 Paul Ritter <ritter.paul1@googlemail.com>
-SPDX-FileCopyrightText: 2022 metalgearsloth <comedian_vs_clown@hotmail.com>
-SPDX-FileCopyrightText: 2022 wrexbe <81056464+wrexbe@users.noreply.github.com>
-SPDX-FileCopyrightText: 2024 c4llv07e <38111072+c4llv07e@users.noreply.github.com>
-SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
-SPDX-FileCopyrightText: 2025 gus <august.eymann@gmail.com>
-
-SPDX-License-Identifier: AGPL-3.0-or-later
--->
-
 <DefaultWindow xmlns="https://spacestation14.io"
             MinSize="650 290">
     <BoxContainer Orientation="Vertical">

--- a/Content.Client/Access/UI/IdCardConsoleWindow.xaml.cs
+++ b/Content.Client/Access/UI/IdCardConsoleWindow.xaml.cs
@@ -29,6 +29,7 @@ namespace Content.Client.Access.UI
         private string? _lastFullName;
         private string? _lastJobTitle;
         private string? _lastJobProto;
+        private string? _newJob; // Trauma
 
         // The job that will be picked if the ID doesn't have a job on the station.
         private static ProtoId<JobPrototype> _defaultJob = "Passenger";
@@ -130,6 +131,7 @@ namespace Content.Client.Access.UI
                 return;
             }
 
+            _newJob = job.ID; // Trauma
             JobTitleLineEdit.Text = Loc.GetString(job.Name);
             args.Button.SelectId(args.Id);
 
@@ -226,16 +228,14 @@ namespace Content.Client.Access.UI
 
         private void SubmitData()
         {
-            // Don't send this if it isn't dirty.
-            var jobProtoDirty = _lastJobProto != null &&
-                                _jobPrototypeIds[JobPresetOptionButton.SelectedId] != _lastJobProto;
-
+            // <Trauma> - use dirty job id from actually changing it not that broken slop
             _owner.SubmitData(
                 FullNameLineEdit.Text,
                 JobTitleLineEdit.Text,
                 // Iterate over the buttons dictionary, filter by `Pressed`, only get key from the key/value pair
                 _accessButtons.ButtonsList.Where(x => x.Value.Pressed).Select(x => x.Key).ToList(),
-                jobProtoDirty ? _jobPrototypeIds[JobPresetOptionButton.SelectedId] : null);
+                _newJob);
+            // </Trauma>
         }
     }
 }

--- a/Content.Server/Access/Systems/PresetIdCardSystem.cs
+++ b/Content.Server/Access/Systems/PresetIdCardSystem.cs
@@ -1,3 +1,6 @@
+// <Trauma>
+using Content.Shared.Access.Components;
+// </Trauma>
 using Content.Server.Access.Components;
 using Content.Server.GameTicking;
 using Content.Server.Station.Components;
@@ -78,6 +81,7 @@ public sealed partial class PresetIdCardSystem : EntitySystem
 
         _cardSystem.TryChangeJobTitle(uid, job.LocalizedName);
         _cardSystem.TryChangeJobDepartment(uid, job);
+        Comp<IdCardComponent>(uid).JobPrototype = job; // Trauma
 
         if (ProtoMan.Resolve(job.Icon, out var jobIcon))
             _cardSystem.TryChangeJobIcon(uid, jobIcon);

--- a/Content.Trauma.Shared/Power/ApcBatteryChargerSystem.cs
+++ b/Content.Trauma.Shared/Power/ApcBatteryChargerSystem.cs
@@ -53,7 +53,7 @@ public abstract partial class ApcBatteryChargerSystem : EntitySystem
     public float CalcChargeRate(Entity<ApcBatteryChargerComponent> ent, float power)
         => Math.Clamp((power - ent.Comp.IdleLoad) * ent.Comp.Efficiency,
             0f,
-            Math.Min(1f, GetRemainingCharge(ent)));
+            Math.Max(1f, GetRemainingCharge(ent)));
 
     /// <summary>
     /// Update the battery's charge rate directly.


### PR DESCRIPTION
- replaced broken shitcode in the ui that always changed job to assistant, now it uses what you pick... crazy idea
- job preset ids actually set the job prototype!!!

## Media

sec id is... sec..?

<img width="693" height="395" alt="15:52:35" src="https://github.com/user-attachments/assets/69f667c8-66d2-4aea-8718-250dcad36f8f" />

:cl:
- fix: Fixed ID cards always having their job icon reset when changing accesses.
- fix: Fixed energy chem dispensers taking forever to recharge.