### PR TITLE
fix xenobio growth

### DIFF
--- a/Content.Goobstation.Shared/Xenobiology/Systems/MobGrowthSystem.cs
+++ b/Content.Goobstation.Shared/Xenobiology/Systems/MobGrowthSystem.cs
@@ -38,16 +38,17 @@ public sealed partial class MobGrowthSystem : EntitySystem
     {
         base.Update(frameTime);
 
+        var now = _timing.CurTime;
         var query = EntityQueryEnumerator<MobGrowthComponent, SatiationComponent>();
         while (query.MoveNext(out var uid, out var growth, out var satiation))
         {
-            if (_timing.CurTime < growth.NextGrowthTime)
+            if (now < growth.NextGrowthTime)
                 continue;
 
-            growth.NextGrowthTime = _timing.CurTime + growth.GrowthInterval;
+            growth.NextGrowthTime = now + growth.GrowthInterval;
 
             if (_mobState.IsDead(uid)
-                || _satiation.IsValueInRange((uid, satiation), SatiationSystem.Hunger, above: growth.HungerRequired)
+                || !_satiation.IsValueInRange((uid, satiation), SatiationSystem.Hunger, above: growth.HungerRequired)
                 || !growth.Stages.TryGetValue(growth.CurrentStage, out var currentData)
                 || string.IsNullOrEmpty(currentData.NextStage))
                 continue;

--- a/Content.Goobstation.Shared/Xenobiology/Systems/XenobiologySystem.Breeding.cs
+++ b/Content.Goobstation.Shared/Xenobiology/Systems/XenobiologySystem.Breeding.cs
@@ -11,7 +11,7 @@ namespace Content.Goobstation.Shared.Xenobiology.Systems;
 // This handles slime breeding and mutation.
 public partial class XenobiologySystem
 {
-    private List<Entity<SlimeComponent, MobGrowthComponent, SatiationComponent>> _splitting = new();
+    private List<Entity<SlimeComponent>> _splitting = new();
 
     [SubscribeLocalEvent]
     private void OnPendingSlimeMapInit(Entity<PendingSlimeSpawnComponent> ent, ref MapInitEvent args)
@@ -47,24 +47,27 @@ public partial class XenobiologySystem
         var query = EntityQueryEnumerator<SlimeComponent, MobGrowthComponent, SatiationComponent>();
         while (query.MoveNext(out var uid, out var slime, out var growthComp, out var satiation))
         {
-            if (_timing.CurTime < slime.NextUpdateTime
-                || _mob.IsDead(uid)
-                || growthComp.IsFirstStage)
+            if (_timing.CurTime < slime.NextUpdateTime)
                 continue;
 
-            _splitting.Add((uid, slime, growthComp, satiation));
             slime.NextUpdateTime = _timing.CurTime + _updateInterval;
+
+            if (_mob.IsDead(uid)
+                || growthComp.IsFirstStage) // W impossible to reuse shitcode larping as generic and reusable
+                continue;
+
+            var value = _satiation.GetValueOrNull((uid, satiation), SatiationSystem.Hunger) ?? 0f;
+            if (value > slime.MitosisHunger - slime.JitterDifference)
+                _jitter.DoJitter(uid, TimeSpan.FromSeconds(1), true);
+
+            if (value < slime.MitosisHunger)
+                continue;
+
+            _splitting.Add((uid, slime));
         }
 
         foreach (var ent in _splitting)
         {
-            var value = _satiation.GetValueOrNull((ent, ent.Comp3), SatiationSystem.Hunger) ?? 0f;
-            if (value > ent.Comp1.MitosisHunger - ent.Comp1.JitterDifference)
-                _jitter.DoJitter(ent, TimeSpan.FromSeconds(1), true);
-
-            if (value < ent.Comp1.MitosisHunger)
-                continue;
-
             DoMitosis(ent);
         }
     }

--- a/Content.Shared/Nutrition/Components/SatiationComponent.cs
+++ b/Content.Shared/Nutrition/Components/SatiationComponent.cs
@@ -37,6 +37,7 @@ public sealed partial class SatiationComponent : Component
 
     /// <inheritdoc cref="_satiations"/>
     // Hide `SatiationDictionary` from public API
+    [ViewVariables] // Trauma
     public Dictionary<ProtoId<SatiationTypePrototype>, Satiation> Satiations => _satiations.Data;
 
     /// <summary>

--- a/Resources/Prototypes/_Trauma/Body/Satiation/Hunger/slime.yml
+++ b/Resources/Prototypes/_Trauma/Body/Satiation/Hunger/slime.yml
@@ -15,4 +15,4 @@
     Peckish: 0.4
     Starving: 0.2
     Dead: 0.1
-  baseChangeRate: 0.5
+  baseChangeRate: -0.3


### PR DESCRIPTION
fixes #4277

the hunger condition shouldve been inverted, it was growing immediately
also fixed them not having to eat anyway, now feeding them eventually makes them grow and split

:cl:
- fix: Fixed xenobio slimes hunger for growing and splitting.