### PR TITLE
fix beepsky construction

### DIFF
--- a/Content.Shared/Construction/Steps/ComponentConstructionGraphStep.cs
+++ b/Content.Shared/Construction/Steps/ComponentConstructionGraphStep.cs
@@ -5,7 +5,7 @@ namespace Content.Shared.Construction.Steps
     [DataDefinition]
     public sealed partial class ComponentConstructionGraphStep : ArbitraryInsertConstructionGraphStep
     {
-        [DataField("component")] public string Component { get; private set; } = string.Empty;
+        [DataField(required: true)] public CompName Component; // Trauma - use CompName
 
         public override bool EntityValid(EntityUid uid, IEntityManager entityManager, IComponentFactory compFactory)
         {

--- a/Content.Shared/Power/Components/ApcElectronicsComponent.cs
+++ b/Content.Shared/Power/Components/ApcElectronicsComponent.cs
@@ -1,4 +1,4 @@
-namespace Content.Server.Power.Components
+namespace Content.Shared.Power.Components // Trauma - moved to shared
 {
     /// <summary>
     /// This object is an APC electronics, used for constructing APCs

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Medical/medical_patch.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Medical/medical_patch.yml
@@ -199,7 +199,6 @@
 
 - type: constructionGraph
   id: MedicalPatchMakeshift
-  start: start
   graph:
   - node: start
     edges:
@@ -225,7 +224,6 @@
 
 - type: constructionGraph
   id: SilkPatchMakeshift
-  start: start
   graph:
   - node: start
     edges:

--- a/Resources/Prototypes/_Goobstation/Recipes/Construction/Graphs/misc/spirit_candle.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Construction/Graphs/misc/spirit_candle.yml
@@ -2,7 +2,6 @@
 
 - type: constructionGraph
   id: SpiritCandle
-  start: start
   graph:
   - node: start
     entity: OrganSkeletonPersonHead

--- a/Resources/Prototypes/_Goobstation/Recipes/Construction/Graphs/structures/reinforcedsecretdoor.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Construction/Graphs/structures/reinforcedsecretdoor.yml
@@ -2,7 +2,6 @@
 
 - type: constructionGraph
   id: ReinforcedSecretDoor
-  start: start
   graph:
   - node: start
     edges:

--- a/Resources/Prototypes/_Goobstation/Recipes/Crafting/Graphs/chemical_mixer.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Crafting/Graphs/chemical_mixer.yml
@@ -2,7 +2,6 @@
 
 - type: constructionGraph
   id: portableChemicalMixerGraph
-  start: start
   graph:
   - node: start
     edges:

--- a/Resources/Prototypes/_Goobstation/Wizard/airlock.yml
+++ b/Resources/Prototypes/_Goobstation/Wizard/airlock.yml
@@ -114,7 +114,6 @@
 # Construction
 - type: constructionGraph
   id: AirlockUranium
-  start: start
   graph:
   - node: start
     edges:

--- a/Resources/Prototypes/_Goobstation/tags.yml
+++ b/Resources/Prototypes/_Goobstation/tags.yml
@@ -516,9 +516,6 @@
   id: Steel
 
 - type: Tag
-  id: StunBaton # for heretic ritual
-
-- type: Tag
   id: SummonSimiansMaxLevelAction
 
 - type: Tag

--- a/Resources/Prototypes/_Trauma/Recipes/Construction/Graphs/Food/handmeals.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Construction/Graphs/Food/handmeals.yml
@@ -2,7 +2,6 @@
 
 - type: constructionGraph
   id: Friedeggs
-  start: start
   graph:
   - node: start
     edges:
@@ -31,7 +30,6 @@
 
 - type: constructionGraph
   id: EggToast
-  start: start
   graph:
 
   - node: start

--- a/Resources/Prototypes/_Trauma/Recipes/Construction/Graphs/Forging/anvil.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Construction/Graphs/Forging/anvil.yml
@@ -2,7 +2,6 @@
 
 - type: constructionGraph
   id: Anvil
-  start: start
   graph:
   - node: start
     entity: AnvilBottom

--- a/Resources/Prototypes/_Trauma/Recipes/Construction/Graphs/Forging/bloomery.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Construction/Graphs/Forging/bloomery.yml
@@ -2,7 +2,6 @@
 
 - type: constructionGraph
   id: BloomeryCold
-  start: start
   graph:
   - node: start
     edges:

--- a/Resources/Prototypes/_Trauma/Recipes/Construction/Graphs/Forging/charcoalforge.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Construction/Graphs/Forging/charcoalforge.yml
@@ -2,7 +2,6 @@
 
 - type: constructionGraph
   id: CharcoalForge
-  start: start
   graph:
   - node: start
     edges:

--- a/Resources/Prototypes/_Trauma/Recipes/Construction/Graphs/Forging/charcoaloven.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Construction/Graphs/Forging/charcoaloven.yml
@@ -2,7 +2,6 @@
 
 - type: constructionGraph
   id: CharcoalOven
-  start: start
   graph:
   - node: start
     edges:

--- a/Resources/Prototypes/_Trauma/Recipes/Construction/Graphs/Forging/quenchingbarrel.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Construction/Graphs/Forging/quenchingbarrel.yml
@@ -2,7 +2,6 @@
 
 - type: constructionGraph
   id: QuenchingBarrel
-  start: start
   graph:
   - node: start
     edges:

--- a/Resources/Prototypes/_Trauma/Recipes/Construction/Graphs/Machines/ED209.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Construction/Graphs/Machines/ED209.yml
@@ -2,7 +2,6 @@
 
 - type: constructionGraph
   id: ED209
-  start: start
   graph:
   - node: start
     entity: ED209Endoskeleton

--- a/Resources/Prototypes/_Trauma/Recipes/Construction/Graphs/Mechs/T45Armor.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Construction/Graphs/Mechs/T45Armor.yml
@@ -2,7 +2,6 @@
 
 - type: constructionGraph
   id: T45Armor
-  start: start
   graph:
   - node: start
     entity: PowerArmorFrame
@@ -79,7 +78,6 @@
 
 - type: constructionGraph
   id: PowerArmorFrame
-  start: start
   graph:
   - node: start
     edges:

--- a/Resources/Prototypes/_Trauma/Recipes/Construction/Graphs/enchanting.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Construction/Graphs/enchanting.yml
@@ -2,7 +2,6 @@
 
 - type: constructionGraph
   id: EnchantingRune
-  start: start
   graph:
   - node: start
     edges:
@@ -33,7 +32,6 @@
 
 - type: constructionGraph
   id: MinorSummoning
-  start: start
   graph:
   - node: start
     edges:
@@ -64,7 +62,6 @@
 
 - type: constructionGraph
   id: MediumSummoning
-  start: start
   graph:
   - node: start
     edges:
@@ -101,7 +98,6 @@
 
 - type: constructionGraph
   id: MajorSummoning
-  start: start
   graph:
   - node: start
     edges:

--- a/Resources/Prototypes/_Trauma/Recipes/Construction/Graphs/rev_buildings.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Construction/Graphs/rev_buildings.yml
@@ -2,7 +2,6 @@
 
 - type: constructionGraph
   id: RevMachine
-  start: start
   graph:
   - node: start
     edges:

--- a/Resources/Prototypes/_Trauma/Recipes/Construction/Graphs/rev_turrets.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Construction/Graphs/rev_turrets.yml
@@ -2,7 +2,6 @@
 
 - type: constructionGraph
   id: RevTurret
-  start: start
   graph:
   - node: start
     edges:

--- a/Resources/Prototypes/_Trauma/Recipes/Crafting/Graphs/Revs/rev_ammo.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Crafting/Graphs/Revs/rev_ammo.yml
@@ -79,7 +79,6 @@
 
 - type: constructionGraph
   id: RevFlamethrowerAmmo
-  start: start
   graph:
   - node: start
     edges:

--- a/Resources/Prototypes/_Trauma/Recipes/Crafting/Graphs/Revs/rev_mechs.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Crafting/Graphs/Revs/rev_mechs.yml
@@ -2,7 +2,6 @@
 
 - type: constructionGraph
   id: Killdozer
-  start: start
   graph:
   - node: start
     edges:

--- a/Resources/Prototypes/_Trauma/Recipes/Crafting/Graphs/Revs/rev_parts.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Crafting/Graphs/Revs/rev_parts.yml
@@ -3,7 +3,6 @@
 # Basic should be ~30s of doafters
 - type: constructionGraph
   id: RevParts
-  start: start
   graph:
   - node: start
     edges:

--- a/Resources/Prototypes/_Trauma/Recipes/Crafting/Graphs/Revs/rev_weapons.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Crafting/Graphs/Revs/rev_weapons.yml
@@ -3,7 +3,6 @@
 # TODO add hammering and shit as well just touching it with wood shouldn't complete it
 - type: constructionGraph
   id: RevSword
-  start: start
   graph:
   - node: start
     edges:
@@ -17,7 +16,6 @@
 
 - type: constructionGraph
   id: RevMace
-  start: start
   graph:
   - node: start
     edges:
@@ -31,7 +29,6 @@
 
 - type: constructionGraph
   id: RevKnife
-  start: start
   graph:
   - node: start
     edges:
@@ -45,7 +42,6 @@
 
 - type: constructionGraph
   id: RevPitchfork
-  start: start
   graph:
   - node: start
     edges:
@@ -59,7 +55,6 @@
 
 - type: constructionGraph
   id: RevTorch
-  start: start
   graph:
   - node: start
     edges:
@@ -99,7 +94,6 @@
 
 - type: constructionGraph
   id: RevGuns
-  start: start
   graph:
   - node: start
     edges:
@@ -382,7 +376,6 @@
 
 - type: constructionGraph
   id: RevIED
-  start: start
   graph:
   - node: start
     edges:

--- a/Resources/Prototypes/_Trauma/Recipes/Crafting/Graphs/bots.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Crafting/Graphs/bots.yml
@@ -34,7 +34,7 @@
     edges:
     - to: bot
       steps:
-      - tag: StunBaton
+      - tag: Stunbaton
         icon:
           sprite: Objects/Weapons/Melee/stunbaton.rsi
           state: stunbaton_off

--- a/Resources/Prototypes/_Trauma/Recipes/Crafting/Graphs/handles.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Crafting/Graphs/handles.yml
@@ -2,7 +2,6 @@
 
 - type: constructionGraph
   id: Handle
-  start: start
   graph:
   - node: start
     edges:

--- a/Resources/Prototypes/_Trauma/Recipes/Crafting/Graphs/wandsky.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Crafting/Graphs/wandsky.yml
@@ -7,7 +7,7 @@
     edges:
     - to: bot
       steps:
-      - tag: StunBaton
+      - tag: Stunbaton
         icon:
           sprite: Objects/Weapons/Melee/stunbaton.rsi
           state: stunbaton_off

--- a/Resources/Prototypes/_Trauma/Recipes/Crafting/Graphs/weapons.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Crafting/Graphs/weapons.yml
@@ -2,7 +2,6 @@
 
 - type: constructionGraph
   id: GaussRifleGraph
-  start: start
   graph:
   - node: start
     edges:
@@ -158,7 +157,6 @@
 
 - type: constructionGraph
   id: GaussPistolGraph
-  start: start
   graph:
   - node: start
     edges:
@@ -299,7 +297,6 @@
 
 - type: constructionGraph
   id: GaussImprovMagazineGraph
-  start: start
   graph:
 
   - node: start
@@ -328,7 +325,6 @@
 
 - type: constructionGraph
   id: GaussImprovAmmoGraph
-  start: start
   graph:
 
   - node: start
@@ -370,7 +366,6 @@
 
 - type: constructionGraph
   id: NailBoard
-  start: start
   graph:
 
     - node: start
@@ -428,7 +423,6 @@
 
 - type: constructionGraph
   id: IEDSpear
-  start: start
   graph:
   - node: start
     edges:
@@ -452,7 +446,6 @@
 
 - type: constructionGraph
   id: PipebombSpear
-  start: start
   graph:
   - node: start
     edges:
@@ -478,7 +471,6 @@
 
 - type: constructionGraph
   id: PipeShank
-  start: start
   graph:
   - node: start
     edges:
@@ -506,7 +498,6 @@
 
 - type: constructionGraph
   id: WoodenSword
-  start: start
   graph:
   - node: start
     edges:
@@ -527,7 +518,6 @@
 
 - type: constructionGraph
   id: NailSword
-  start: start
   graph:
   - node: start
     edges:
@@ -585,7 +575,6 @@
 
 - type: constructionGraph
   id: ScrapSword
-  start: start
   graph:
   - node: start
     edges:
@@ -631,7 +620,6 @@
 
 - type: constructionGraph
   id: WeldedSword
-  start: start
   graph:
   - node: start
     edges:


### PR DESCRIPTION
fixes #4298

- removed duplicate stunbaton tag from goob, they use the real tag now
- construction comp whitelist step now uses CompName
- cleaned up everything

:cl:
- fix: Fixed not being able to craft a beepsky.