### PR TITLE
disable ssd sleep slop

### DIFF
--- a/Content.Shared/CCVar/CCVars.Ic.cs
+++ b/Content.Shared/CCVar/CCVars.Ic.cs
@@ -82,7 +82,7 @@ public sealed partial class CCVars
     ///     Forces SSD characters to sleep after ICSSDSleepTime seconds
     /// </summary>
     public static readonly CVarDef<bool> ICSSDSleep =
-        CVarDef.Create("ic.ssd_sleep", true, CVar.SERVER);
+        CVarDef.Create("ic.ssd_sleep", true, CVar.SERVER | CVar.REPLICATED); // Trauma - replicated it so client predicts it properly
 
     /// <summary>
     ///     Time between character getting SSD status and falling asleep

--- a/Resources/ConfigPresets/_Trauma/trauma.toml
+++ b/Resources/ConfigPresets/_Trauma/trauma.toml
@@ -31,3 +31,6 @@ explosion_damage_modifier = 0.3
 
 [biomass]
 easy_mode = false # woodchipper is actually dangerous
+
+[ic]
+ssd_sleep = false # chuddy and doesnt account for NPCs


### PR DESCRIPTION
fixes #4302

:cl:
- tweak: SSD people and NPCs no longer fall asleep after 10 minutes.