### PR TITLE
make barricades give metal back when deconstructed

### DIFF
--- a/Resources/Prototypes/_Goobstation/Recipes/Construction/Graphs/structures/barricade_plasteel.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Construction/Graphs/structures/barricade_plasteel.yml
@@ -25,6 +25,10 @@
     entity: BarricadePlasteel
     edges:
     - to: start
+      completed:
+      - !type:GivePrototype
+        prototype: SheetPlasteel1
+        amount: 6
       conditions:
       - !type:EntityAnchored
         anchored: false
@@ -37,6 +41,10 @@
     entity: BarricadePlasteelFolding
     edges:
     - to: start
+      completed:
+      - !type:GivePrototype
+        prototype: SheetPlasteel1
+        amount: 8
       conditions:
       - !type:EntityAnchored
         anchored: false

--- a/Resources/Prototypes/_Goobstation/Recipes/Construction/Graphs/structures/barricade_steel.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Construction/Graphs/structures/barricade_steel.yml
@@ -25,6 +25,10 @@
     entity: BarricadeSteel
     edges:
     - to: start
+      completed:
+      - !type:GivePrototype
+        prototype: SheetSteel1
+        amount: 4
       conditions:
       - !type:EntityAnchored
         anchored: false
@@ -37,6 +41,10 @@
     entity: BarricadeSteelFolding
     edges:
     - to: start
+      completed:
+      - !type:GivePrototype
+        prototype: SheetSteel1
+        amount: 6
       conditions:
       - !type:EntityAnchored
         anchored: false


### PR DESCRIPTION
resolves #4297

ideally would scale down with damage but whatever

:cl:
- tweak: Deconstructing metal barricades now gives the metal back.