### PR TITLE
Decapoid claw unarmed scaling

### DIFF
--- a/Resources/Prototypes/_Imp/Entities/Objects/Decapoid/decapoid_items.yml
+++ b/Resources/Prototypes/_Imp/Entities/Objects/Decapoid/decapoid_items.yml
@@ -8,7 +8,7 @@
   description: A large claw. Not very good for fine manipulation, but very strong and very sharp.
   components:
   - type: WeaponClass
-  - class: Unarmed  #Trauma: Added skill scaling
+    class: Unarmed  #Trauma: Added skill scaling
   - type: Sprite
     sprite: _Impstation/Objects/Decapoid/claw.rsi
     state: icon

--- a/Resources/Prototypes/_Imp/Entities/Objects/Decapoid/decapoid_items.yml
+++ b/Resources/Prototypes/_Imp/Entities/Objects/Decapoid/decapoid_items.yml
@@ -8,7 +8,7 @@
   description: A large claw. Not very good for fine manipulation, but very strong and very sharp.
   components:
   - type: WeaponClass
-    class: Unarmed  #Trauma: Added skill scaling
+    class: Unarmed
   - type: Sprite
     sprite: _Impstation/Objects/Decapoid/claw.rsi
     state: icon

--- a/Resources/Prototypes/_Imp/Entities/Objects/Decapoid/decapoid_items.yml
+++ b/Resources/Prototypes/_Imp/Entities/Objects/Decapoid/decapoid_items.yml
@@ -7,6 +7,8 @@
   suffix: Unremoveable
   description: A large claw. Not very good for fine manipulation, but very strong and very sharp.
   components:
+  - type: WeaponClass
+  - class: Unarmed  #Trauma: Added skill scaling
   - type: Sprite
     sprite: _Impstation/Objects/Decapoid/claw.rsi
     state: icon


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->
I added unarmed scaling to the decapoid claw
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Its there hand and doesn't make much sense that it doesn't scale.
## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
I boot up my dev environment spawned in decapoid and inspected the claw before and after using an unarmed skill chip.
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="687" height="218" alt="image" src="https://github.com/user-attachments/assets/0116068d-c4c1-4cc3-b4e0-62a7746f9531" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- tweak: Added unarmed scaling to decapoid claw