### PR TITLE
Bug Fixes in Gemini

### DIFF
--- a/Content.Goobstation.Client/Holograms/HologramVisualizerSystem.cs
+++ b/Content.Goobstation.Client/Holograms/HologramVisualizerSystem.cs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+using Content.Client.Graphics;
 using Content.Goobstation.Shared.Holograms;
 
 namespace Content.Goobstation.Client.Holograms;
@@ -21,7 +22,10 @@ public sealed partial class HologramVisualizerSystem : EntitySystem
     [SubscribeLocalEvent]
     private void OnComponentInit(Entity<HologramVisualsComponent> ent, ref ComponentInit args)
     {
-        _sprite.SetPostShader(ent.Owner, new(_shaderId, _shader));
+        _sprite.SetPostShader(ent.Owner, new(_shaderId, _shader)
+        {
+            Before = ContentPostShaderIds.BeforeOutlines,
+        });
     }
 
     [SubscribeLocalEvent]

--- a/Content.Shared/Interaction/SmartEquipSystem.cs
+++ b/Content.Shared/Interaction/SmartEquipSystem.cs
@@ -240,7 +240,9 @@ public sealed partial class SmartEquipSystem : EntitySystem
             return;
         }
 
-        _inventory.TryUnequip(uid, equipmentSlot, inventory: inventory, predicted: true, checkDoafter: true);
+        if (!_inventory.TryUnequip(uid, equipmentSlot, inventory: inventory, predicted: true, checkDoafter: true)) // Trauma - don't pickup if unequip started a doafter
+            return;
+
         _hands.TryPickup(uid, slotItem, handsComp: hands);
     }
 }

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Belt/cloneprojector.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Belt/cloneprojector.yml
@@ -118,6 +118,7 @@
     - type: Dna
     - type: Absorbable
     - type: Mutatable
+    - type: CanHostGuardian
     - type: Fingerprint
     - type: Perishable
     - type: Satiation
@@ -144,8 +145,6 @@
     clonedItemWhitelist:
       components:
       - Clothing
-    removedComponents:
-    - type: CanHostGuardian
     userBlacklist:
       components:
       - Zombie

--- a/Resources/Textures/Nyanotrasen/Shaders/holographic.swsl
+++ b/Resources/Textures/Nyanotrasen/Shaders/holographic.swsl
@@ -218,7 +218,12 @@ void fragment()
     const highp float TIME_OFFSET3 = 1298.67;
 
     highp float wrapped_hue = fract(hue);
-    highp vec4 product = texture(TEXTURE, UV);
+    highp vec4 product = zTexture(UV);
+    if (product.a <= 0.001)
+    {
+        COLOR = vec4(0.0);
+        return;
+    }
 
     // Colorize with wrapped hue
     highp vec3 hsv = rgb2hsv(product.rgb);


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->
Fixes for the Gemini holo-projector:
- Fixed holo-clones shader no longer renders as a solid square until hovered
- Smart Equip (Shift + E) no longer skips the unequip DoAfter
- holo-clones can no longer get genes (There was a bug that allowed Gemini to insert or modify genes in the scanner)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
fixes #4037
fixes #3421

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
- Spawn Gemini, clone yourself, see no square around the hologram and on hover
- Wear Gemini, press Shift + E (Smart Equip shortcut), see a DoAfter like as when removing it by mouse click
- Put the holo-clone in a medical scanner or use mutator with any gen. Should do nothing (show disallow text for mutator)

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
Nah

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Mr_Samuel
- fix: Gemini holograms no longer appear as a solid square.
- fix: Gemini holograms can no longer be mutated.
- fix: SmartEquip of Gemini no longer instantly unequips clothing with an unequip delay.
