### PR TITLE
make chameleon mutation more reasonable

### DIFF
--- a/Resources/Prototypes/_Trauma/Genetics/Mutations/chameleon.yml
+++ b/Resources/Prototypes/_Trauma/Genetics/Mutations/chameleon.yml
@@ -15,5 +15,7 @@
     - type: Stealth
       enabledOnCrit: false
       enabledOnDeath: false
-      maxVisibility: 8 # not very powerful because it doesnt use power etc
+      maxVisibility: 2
     - type: StealthOnMove
+      movementVisibilityRate: 1 # immediately revealed
+      passiveVisibilityRate: -0.5 # adapt fairly quick when still


### PR DESCRIPTION
fixes #4331

it was taking literally a minute to go from max visbility to invisible, and let you move while invis for too long

now it will reveal you almost immediately when moving but be just a few seconds to adapt

:cl:
- tweak: Made chameleon mutation both reveal from moving and adapt while still much faster.