### PR TITLE
tweak projectile prediction

### DIFF
--- a/Content.Trauma.Client/Projectiles/PredictedProjectileSystem.cs
+++ b/Content.Trauma.Client/Projectiles/PredictedProjectileSystem.cs
@@ -13,26 +13,13 @@ public sealed partial class PredictedProjectileSystem : EntitySystem
 {
     [Dependency] private PhysicsSystem _physics = default!;
 
-    public override void Initialize()
-    {
-        base.Initialize();
-
-        SubscribeLocalEvent<ProjectileComponent, UpdateIsPredictedEvent>(OnUpdateIsPredicted);
-        SubscribeLocalEvent<DeletingProjectileEvent>(OnDeletingProjectile);
-        SubscribeNetworkEvent<ShotPredictedProjectileEvent>(OnShotPredictedProjectile);
-    }
-
+    [SubscribeLocalEvent]
     private void OnUpdateIsPredicted(Entity<ProjectileComponent> ent, ref UpdateIsPredictedEvent args)
     {
         args.IsPredicted = true;
     }
 
-    private void OnDeletingProjectile(ref DeletingProjectileEvent args)
-    {
-        RemComp<SpriteComponent>(args.Entity);
-        RemComp<PointLightComponent>(args.Entity);
-    }
-
+    [SubscribeNetworkEvent]
     private void OnShotPredictedProjectile(ShotPredictedProjectileEvent args)
     {
         var uid = GetEntity(args.Projectile);

--- a/Content.Trauma.Shared/Projectiles/DeletingProjectileEvent.cs
+++ b/Content.Trauma.Shared/Projectiles/DeletingProjectileEvent.cs
@@ -1,9 +1,0 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-
-namespace Content.Trauma.Shared.Projectiles;
-
-/// <summary>
-/// Event broadcast before deleting a projectile that has hit something.
-/// </summary>
-[ByRefEvent]
-public record struct DeletingProjectileEvent(EntityUid Entity);

--- a/Content.Trauma.Shared/Projectiles/PredictedProjectileSystem.cs
+++ b/Content.Trauma.Shared/Projectiles/PredictedProjectileSystem.cs
@@ -173,11 +173,7 @@ public sealed partial class PredictedProjectileSystem : EntitySystem
         }
 
         if (comp.DeleteOnCollide && comp.ProjectileSpent)
-        {
-            var deleteEv = new DeletingProjectileEvent(uid);
-            RaiseLocalEvent(ref deleteEv);
             PredictedQueueDel(uid);
-        }
 
         if (comp.ImpactEffect != null && TryComp(uid, out TransformComponent? xform) && _timing.IsFirstTimePredicted)
         {


### PR DESCRIPTION
still has the jitter when receiving servers projectile but its better
fixes #4282

:cl:
- fix: Fixed xeno missiles going invisible shortly after being shot.