### PR TITLE
A Wide Variety of Rev Buffs

### DIFF
--- a/Resources/Prototypes/_Trauma/Entities/Knowledge/books.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Knowledge/books.yml
@@ -137,7 +137,6 @@
       KnowledgeWeaponsShotgun: 30
       KnowledgeWeaponsRifle: 30
       KnowledgeWeaponsHeavy: 30 # For Flamethrower/RPG
-
     experience:
       ShootingKnowledge: 5
       GunsmithingKnowledge: 5

--- a/Resources/Prototypes/_Trauma/Entities/Knowledge/books.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Knowledge/books.yml
@@ -99,11 +99,21 @@
     - state: melee
   - type: KnowledgeGrantOnUse
     skills:
-      MeleeKnowledge: 35
-      WeaponsKnowledge: 35
+      MeleeKnowledge: 30
+      WeaponsKnowledge: 50
+      KnowledgeWeaponsPolearm: 30
+      KnowledgeWeaponsShortBlade: 30
+      KnowledgeWeaponsLongBlade: 30
+      KnowledgeWeaponsBludgeon: 30
+      KnowledgeWeaponsNonLethal: 30 # For Rev Mace
     experience:
       MeleeKnowledge: 15
       WeaponsKnowledge: 15
+      KnowledgeWeaponsPolearm: 15
+      KnowledgeWeaponsShortBlade: 15
+      KnowledgeWeaponsLongBlade: 15
+      KnowledgeWeaponsBludgeon: 15
+      KnowledgeWeaponsNonLethal: 15
     doAfter: 2
 
 # Shooting
@@ -120,11 +130,22 @@
     - state: shooting
   - type: KnowledgeGrantOnUse
     skills:
-      ShootingKnowledge: 35
-      WeaponsKnowledge: 35
+      ShootingKnowledge: 30
+      GunsmithingKnowledge: 30
+      KnowledgeWeaponsPistol: 30
+      KnowledgeWeaponsSMG: 30
+      KnowledgeWeaponsShotgun: 30
+      KnowledgeWeaponsRifle: 30
+      KnowledgeWeaponsHeavy: 30 # For Flamethrower/RPG
+
     experience:
       ShootingKnowledge: 5
-      WeaponsKnowledge: 4
+      GunsmithingKnowledge: 5
+      KnowledgeWeaponsPistol: 5
+      KnowledgeWeaponsSMG: 5
+      KnowledgeWeaponsShotgun: 5
+      KnowledgeWeaponsRifle: 5
+      KnowledgeWeaponsHeavy: 5
     doAfter: 2
 
 # Magic

--- a/Resources/Prototypes/_Trauma/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -26,7 +26,7 @@
     sprite: _Trauma/Objects/Weapons/Guns/Shotguns/devastator.rsi
   - type: GunRequiresWield # ah yes let me one-hand the quad barrel shotgun
   - type: Gun
-    fireRate: 1 # Was 4 but I nerfed it a bit because it felt fucky at 4
+    fireRate: 1.5 # Was 1 but why make a devastator when it has the same firerate as an enforcer
   - type: GunSpreadModifier
     spread: 1.5 # Was 2 but I wanted it to be more useful at range... still shit though.
   - type: BallisticAmmoProvider

--- a/Resources/Prototypes/_Trauma/Recipes/Crafting/Graphs/Revs/rev_weapons.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Crafting/Graphs/Revs/rev_weapons.yml
@@ -122,16 +122,16 @@
         icon:
           sprite: Objects/Misc/modular_receiver.rsi
           state: icon
-      - tool: Welding
-        doAfter: 1
       - tool: Screwing
         doAfter: 1
     - to: resistance
       steps:
-      - tool: Welding
+      - tool: Screwing
         doAfter: 1
       - material: RevBolt
+        amount: 2
       - material: RevNut
+        amount: 2
       - tool: Anchoring
         doAfter: 1
       - material: RevGunParts
@@ -140,11 +140,9 @@
         icon:
           sprite: Objects/Misc/modular_receiver.rsi
           state: icon
-      - material: RevBolt
-      - material: RevNut
       - tool: Anchoring
         doAfter: 1
-      - tool: Welding
+      - tool: Screwing
     - to: RPG2
       steps:
       - tool: Hammering
@@ -312,11 +310,7 @@
         doAfter: 1
       - tool: Hammering
         doAfter: 0.5
-      - tool: Hammering
-        doAfter: 0.5
-      - tool: Hammering
-        doAfter: 0.5
-      - tool: Slicing
+      - tool: Screwing
         doAfter: 1
     - to: Proletariat
       steps:
@@ -334,7 +328,7 @@
       - tool: Hammering
         doAfter: 0.5
       - material: RevGunParts
-        amount: 5
+        amount: 3
         doAfter: 1
       - tool: Screwing
         doAfter: 1
@@ -355,8 +349,6 @@
         doAfter: 1
       - material: WoodPlank
         amount: 5
-        doAfter: 1
-      - tool: Screwing
         doAfter: 1
       - tool: Screwing
         doAfter: 1

--- a/Resources/Prototypes/_Trauma/Recipes/Lathes/Packs/revrecipepacks.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Lathes/Packs/revrecipepacks.yml
@@ -66,6 +66,8 @@
   - RevTurretMagazine
   - RevTurretMagazineHeavy
   - RevSMGMagazine
+  - RevStraightPipe
+  - RevModularReceiver
 
 - type: latheRecipePack
   id: RevBulletPressStatic

--- a/Resources/Prototypes/_Trauma/Recipes/Lathes/rev_misc.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Lathes/rev_misc.yml
@@ -46,6 +46,7 @@
     Steel: 50
     Plastic: 50
     Glass: 50
+    Gold: 50
 
 - type: latheRecipe
   id: RevTurretElectronics
@@ -84,11 +85,11 @@
   id: RevStraightPipe
   result: GasPipeStraight
   completetime: 3
-  materials :
+  materials:
     Steel: 100
 
 - type: latheRecipe
   parent: RevGunParts
   id: RevModularReceiver
-  result : ModularReceiver
+  result: ModularReceiver
   completetime: 5

--- a/Resources/Prototypes/_Trauma/Recipes/Lathes/rev_misc.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Lathes/rev_misc.yml
@@ -43,9 +43,9 @@
   result: EncryptionKeyRev
   completetime: 6
   materials:
-    Silver: 50
-    Gold: 50
     Steel: 50
+    Plastic: 50
+    Glass: 50
 
 - type: latheRecipe
   id: RevTurretElectronics
@@ -75,7 +75,20 @@
 - type: latheRecipe
   id: RevGunParts
   result: RevGunParts
-  completetime: 15
+  completetime: 10
   materials:
     Steel: 300
     Plastic: 100
+
+- type: latheRecipe
+  id: RevStraightPipe
+  result: GasPipeStraight
+  completetime: 3
+  materials :
+    Steel: 100
+
+- type: latheRecipe
+  parent: RevGunParts
+  id: RevModularReceiver
+  result : ModularReceiver
+  completetime: 5

--- a/Resources/Prototypes/_Trauma/Recipes/Lathes/rev_parts.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Lathes/rev_parts.yml
@@ -4,7 +4,7 @@
   abstract: true
   id: BaseRevComponent
   categories: [ Parts ]
-  completetime: 15
+  completetime: 12 # 5 Parts per minute instead of 4
   materials:
     Steel: 10
 

--- a/Resources/Prototypes/_Trauma/Recipes/Lathes/rev_weapons.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Lathes/rev_weapons.yml
@@ -26,6 +26,9 @@
   parent: BaseRevWeapon
   id: RevKnife
   result: RevKnifeBlade
+  completetime: 5
+  materials:
+    Steel: 250
 
 - type: latheRecipe
   parent: BaseRevWeapon


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->

Added extra parts to 3D Printer
Made most gun recipes easier to make
Buffed Devastator
And reduced print time for a variety of parts
And reduced the material cost for forged knifes and revolutionary encryption keys
Also buffed the books to give actual skills you can use as a revolutionary

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
These changes were made to make guns actually viable for revs and require them to not have to steal an autolathe to actually make guns as well as not needing a lot of welding
These changes were also made to simplify the gun rev recipes so they don't end up having 19 steps that just scares a player away from ever making them
And the revolutionary parts/gun parts change was made so they don't have to wait as long to get a decent amount of parts
The changes to the books were made so revs can actually effectively use their weapons since now a forged sword actually does 20+ damage instead of 15.9 damage if you had no skills with long blades
Devastator was buffed because it was literally worse then an enforcer which you could just buy
And forged knife's cost was reduced so it isn't 5 steel to make a knife
Made Revolutionary Encryption Keys only cost plastic, steel and glass so you don't have to rely on gold and silver to get comms up


## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
1st, I went ingame and spawned both rev books and read them until I had the proper skills associated with each book
2nd I made myself a revolutionary and looked in the crafting menu and made sure all the steps and costs were properly adjusted
3rd I spawned a 3D printer and made sure it was producing modular receivers and gas pipes, I then printed out a 3D part to make sure it only took 10 seconds
4th, Spawned an industrial forge and produced a forged knife and made sure it cost the proper amount, Then produced parts and made sure it only took 12s
5th, Spawned in a devastator and made sure it had 1.5 firerate instead of 1 firerate
6th, Spawned in a telecommunications workshop and made sure the keys only costed steel, glass and plastic


## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="571" height="408" alt="image" src="https://github.com/user-attachments/assets/6bf3b4cf-1c4f-4d9e-b1f4-c367231aec8a" />
<img width="370" height="408" alt="image" src="https://github.com/user-attachments/assets/fa4a873a-0a79-4336-9ba2-e0d8512fb227" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Wizard25671
- add: Added Modular Receivers and Straight Pipes to the 3D Printer
- tweak: Increased the variety of skills you get from the Revolutionary Melee/Revolutionary Shooting book to accommodate for all the weapons that revolutionaries can make
- tweak: Buffed the firerate on the devastator from 1.0 to 1.5
- tweak: Decreased the amount of revolutionary gun parts needed for the Proletariat from 5 to 3
- tweak: Decreased the time to print revolutionary parts
- tweak: Decreased the time to print revolutionary gun parts
- tweak: Shortened the recipes of a majority of revolutionary guns
- tweak: Removed the welding step from most revolutionary guns
- tweak: Decreased the cost of forged knifes down to 2.5 steel, They now also finish in 5 seconds
- tweak: Made Revolutionary Encryption Keys only cost plastic, steel, glass, and gold
- fix: Fixed the Revolutionary Shooting Book not giving Gunsmithing
