### PR TITLE
Added lathe automation to machinery

### DIFF
--- a/Resources/Prototypes/_Trauma/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Structures/Machines/lathe.yml
@@ -60,6 +60,14 @@
     - !type:AutomatedMaterialStorage
       input: AutomationSlotMaterials
       output: null
+    - !type:AutomatedPorts
+      sinks:
+      - LathePrint
+      - LatheSetRecipe
+      - LatheQuantity
+      sources:
+      - LatheCurrentRecipe
+  - type: LatheAutomation
   - type: Animateable
   - type: LightningTarget
     priority: 1


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
Added lathe automation(e.g print last recipe) to rev machinery

## Why / Balance
lets revs make more complex automated factories

## Test plan
1. spawn in any machine with the BaseRevIndustry parent (e.g industrial forge)
2. connect a button to the rev machine with a multitool
3. link: pressed>print last recipe
4. print something from the machine
5. press the button
done

## Requirements
- [X] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Changelog
:cl:
- add: Added lathe automation to revolution machines
