### PR TITLE
remove heart kidney liver slots from diona

### DIFF
--- a/Resources/Prototypes/Body/Species/diona.yml
+++ b/Resources/Prototypes/Body/Species/diona.yml
@@ -60,7 +60,6 @@
       FootRight: OrganDionaFootRight
       Brain: OrganDionaBrainNymphing
       Eyes: OrganDionaEyes
-      Tongue: OrganDionaTongue # Trauma
       Lungs: OrganDionaLungsNymphing
       Stomach: OrganDionaStomachNymphing
   - type: HumanoidProfile
@@ -73,16 +72,6 @@
   id: MobDiona
   name: Urist McPlants
   components:
-  # <Trauma>
-  - type: LanguageSpeaker
-    speaks:
-    - TauCetiBasic
-    - RootSpeak
-    understands:
-    - TauCetiBasic
-    - RootSpeak
-  - type: FoliageIgnoringVision
-  # </Trauma>
   - type: Respirator
     damage:
       types:
@@ -98,19 +87,17 @@
         prototype: DionaThirst
   - type: Damageable
     damageModifierSet: Diona
-  #- type: DamageVisuals # Shitmed
-  #  damageOverlayGroups:
-  #    Brute:
-  #      sprite: Mobs/Effects/brute_damage.rsi
-  #      color: "#cd7314"
-  #    Burn:
-  #      sprite: Mobs/Effects/burn_damage.rsi
+  - type: DamageVisuals
+    damageOverlayGroups:
+      Brute:
+        sprite: Mobs/Effects/brute_damage.rsi
+        color: "#cd7314"
+      Burn:
+        sprite: Mobs/Effects/burn_damage.rsi
   - type: Butcherable
     spawned:
       - id: FoodMeatPlant
         amount: 5
-      - id: MaterialWoodPlank1 # Trauma - Bones on butchering humanoids. I AM NO TREE IM AN ENT.
-        amount: 3
   - type: Bloodstream
     bloodReferenceSolution:
       reagents:
@@ -182,8 +169,6 @@
     allowedStates:
     - Dead
   - type: Rootable
-  - type: Viewcone
-    baseConeAngle: 360
 
 - type: entity
   parent: OrganBaseOrganic
@@ -230,7 +215,7 @@
   id: OrganDionaTorso
 
 - type: entity
-  parent: [ OrganBaseHeadBald, OrganDionaExternal ] # Trauma - bald tree
+  parent: [ OrganBaseHeadBald, OrganDionaExternal ] # Trauma - bald trees
   id: OrganDionaHead
 
 - type: entity

--- a/Resources/Prototypes/Body/Species/diona.yml
+++ b/Resources/Prototypes/Body/Species/diona.yml
@@ -87,13 +87,15 @@
         prototype: DionaThirst
   - type: Damageable
     damageModifierSet: Diona
-  - type: DamageVisuals
-    damageOverlayGroups:
-      Brute:
-        sprite: Mobs/Effects/brute_damage.rsi
-        color: "#cd7314"
-      Burn:
-        sprite: Mobs/Effects/burn_damage.rsi
+  # <Trauma>
+  #- type: DamageVisuals
+  #  damageOverlayGroups:
+  #    Brute:
+  #      sprite: Mobs/Effects/brute_damage.rsi
+  #      color: "#cd7314"
+  #    Burn:
+  #      sprite: Mobs/Effects/burn_damage.rsi
+  # </Trauma>
   - type: Butcherable
     spawned:
       - id: FoodMeatPlant

--- a/Resources/Prototypes/_Trauma/Partials/Body/Species/diona.yml
+++ b/Resources/Prototypes/_Trauma/Partials/Body/Species/diona.yml
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+- type: entity
+  id: AppearanceDiona
+  components:
+  - type: InitialBody
+    organs:
+      Tongue: OrganDionaTongue
+
+- type: entity
+  id: MobDiona
+  components:
+  - type: LanguageSpeaker
+    speaks:
+    - TauCetiBasic
+    - RootSpeak
+    understands:
+    - TauCetiBasic
+    - RootSpeak
+  - type: FoliageIgnoringVision
+  - type: Viewcone
+    baseConeAngle: 360
+  - type: Butcherable
+    spawned:
+    - id: MaterialWoodPlank1 # "bones"
+      amount: 3
+  - !Remove type: DamageVisuals
+
+- type: entity
+  id: OrganDionaTorso
+  components:
+  - type: BodyPart
+    # removed Heart, Kidneys and Liver slots its a plant
+    # cant use !Remove for slots from the base torso prototype :)
+    slots:
+    # parts
+    - Head
+    - ArmLeft
+    - ArmRight
+    - LegLeft
+    - LegRight
+    # organs
+    - Appendix
+    - Lungs
+    - Stomach

--- a/Resources/Prototypes/_Trauma/Partials/Body/Species/diona.yml
+++ b/Resources/Prototypes/_Trauma/Partials/Body/Species/diona.yml
@@ -24,7 +24,6 @@
     spawned:
     - id: MaterialWoodPlank1 # "bones"
       amount: 3
-  - !Remove type: DamageVisuals
 
 - type: entity
   id: OrganDionaTorso


### PR DESCRIPTION
fixes #4414

they werent used and adding heart is bad

:cl:
- tweak: Dionae can no longer have hearts, kidneys or livers transplanted.