### PR TITLE
only add abductor gland task if the subject has a heart slot

### DIFF
--- a/Content.Trauma.Shared/Abductor/AbductorTaskSystem.cs
+++ b/Content.Trauma.Shared/Abductor/AbductorTaskSystem.cs
@@ -32,13 +32,10 @@ public sealed partial class AbductorTaskSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<AbductorSubjectComponent, MapInitEvent>(OnMapInit);
-
-        SubscribeLocalEvent<PrototypesReloadedEventArgs>(OnPrototypesReloaded);
-
         LoadPrototypes();
     }
 
+    [SubscribeLocalEvent]
     private void OnMapInit(Entity<AbductorSubjectComponent> ent, ref MapInitEvent args)
     {
         if (ent.Comp.Tasks.Count > 0)
@@ -46,10 +43,12 @@ public sealed partial class AbductorTaskSystem : EntitySystem
 
         var count = _random.Next(MinTasks, MaxTasks);
         ent.Comp.Tasks = PickTasks(ent, count);
-        ent.Comp.Tasks.Add(FinalTask);
+        if (CanAddTask(ent, ProtoMan.Index(FinalTask)))
+            ent.Comp.Tasks.Add(FinalTask);
         DirtyField(ent, ent.Comp, nameof(AbductorSubjectComponent.Tasks));
     }
 
+    [SubscribeLocalEvent]
     private void OnPrototypesReloaded(PrototypesReloadedEventArgs args)
     {
         if (args.WasModified<AbductorTaskPrototype>())
@@ -77,10 +76,7 @@ public sealed partial class AbductorTaskSystem : EntitySystem
         _validTasks.Clear();
         foreach (var task in AllTasks)
         {
-            if (!_random.Prob(task.Chance))
-                continue;
-
-            if (_conditions.TryConditions(target, task.Valid))
+            if (CanAddTask(target, task))
                 _validTasks.Add(task);
         }
 
@@ -91,6 +87,13 @@ public sealed partial class AbductorTaskSystem : EntitySystem
         }
         return picked;
     }
+
+    /// <summary>
+    /// Returns true if a task can be given for a subject.
+    /// </summary>
+    public bool CanAddTask(EntityUid target, AbductorTaskPrototype task)
+        => _random.Prob(task.Chance) &&
+            _conditions.TryConditions(target, task.Valid);
 
     /// <summary>
     /// Returns true if a task is currently complete for a subject.

--- a/Resources/Prototypes/_Trauma/Abductor/tasks.yml
+++ b/Resources/Prototypes/_Trauma/Abductor/tasks.yml
@@ -5,6 +5,11 @@
 - type: abductorTask
   id: InstallGland
   random: false # always given at the end
+  valid:
+  # some species have no heart slot
+  - !type:HasOrganSlot
+    organ: Heart
+    partType: Torso
   completed:
   - !type:HasOrgan
     organCategory: Heart


### PR DESCRIPTION
also fix bad rng for shitcode tag restriction

## Media

urist
<img width="898" height="354" alt="17:53:27" src="https://github.com/user-attachments/assets/87f59bfe-72fb-44c3-a4d7-09e2f3594748" />


tree
<img width="886" height="501" alt="18:01:43" src="https://github.com/user-attachments/assets/d1f2cf9a-e87a-4480-a921-e65017b1d9ff" />


## Changelog

:cl:
- tweak: Abductors no longer get a gland task for slimes or diona since they have no heart slot.