### PR TITLE
change stuff

### DIFF
--- a/Content.Client/Lathe/UI/LatheMenu.Trauma.cs
+++ b/Content.Client/Lathe/UI/LatheMenu.Trauma.cs
@@ -8,6 +8,7 @@ using Robust.Shared.Utility;
 
 namespace Content.Client.Lathe.UI;
 
+// TODO: move this shit to UI injection
 public sealed partial class LatheMenu
 {
     [Dependency] private IPlayerManager _player = default!;

--- a/Content.Client/Lathe/UI/LatheMenu.xaml
+++ b/Content.Client/Lathe/UI/LatheMenu.xaml
@@ -80,6 +80,7 @@
                         Mode="Press">
                     </Button>
                 </BoxContainer>
+                <!-- <Trauma> - wrap menu queue label in a container, add ResetQueueList. TODO: inject this -->
                 <BoxContainer
                     Orientation="Horizontal"
                     Align="Begin"
@@ -93,6 +94,7 @@
                         Mode="Press">
                     </Button>
                 </BoxContainer>
+                <!-- </Trauma> -->
                 <BoxContainer
                     Name="FabricatingContainer"
                     Orientation="Horizontal"
@@ -151,14 +153,14 @@
                     VerticalExpand="True"
                     HorizontalExpand="True">
                     <ui:MaterialStorageControl Name="MaterialsList" SizeFlagsStretchRatio="8"/>
-		            <!-- <Trauma> -->
-		            <BoxContainer Orientation="Vertical" Name="MiningPointsContainer" Visible="False">
-		                <BoxContainer Orientation="Horizontal">
-		                    <Label Name="MiningPointsLabel" HorizontalExpand="True"/>
-		                    <Button Name="MiningPointsClaimButton" Text="{Loc 'lathe-menu-mining-points-claim-button'}"/>
-		                </BoxContainer>
-		            </BoxContainer>
-		            <!-- </Trauma> -->
+                    <!-- <Trauma> -->
+                    <BoxContainer Orientation="Vertical" Name="MiningPointsContainer" Visible="False">
+                        <BoxContainer Orientation="Horizontal">
+                            <Label Name="MiningPointsLabel" HorizontalExpand="True"/>
+                            <Button Name="MiningPointsClaimButton" Text="{Loc 'lathe-menu-mining-points-claim-button'}"/>
+                        </BoxContainer>
+                    </BoxContainer>
+                    <!-- </Trauma> -->
                 </BoxContainer>
             </PanelContainer>
         </BoxContainer>

--- a/Content.Goobstation.Shared/Vehicles/SharedVehicleSystem.cs
+++ b/Content.Goobstation.Shared/Vehicles/SharedVehicleSystem.cs
@@ -11,8 +11,6 @@ using Content.Shared.Hands;
 using Content.Shared.Inventory.VirtualItem;
 using Content.Shared.Movement.Components;
 using Content.Shared.Movement.Systems;
-using Robust.Shared.Audio.Systems;
-using Robust.Shared.Containers;
 using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Destructible;
 using Content.Shared.FixedPoint;
@@ -20,12 +18,16 @@ using Content.Shared.Actions.Components;
 using Content.Shared.Interaction;
 using Content.Shared.Interaction.Components;
 using Content.Trauma.Common.TileMovement;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Containers;
+using Robust.Shared.Timing;
 
 namespace Content.Goobstation.Shared.Vehicles;
 
 public abstract partial class SharedVehicleSystem : EntitySystem
 {
     [Dependency] private DamageableSystem _damageable = default!;
+    [Dependency] private IGameTiming _timing = default!;
     [Dependency] private INetManager _net = default!;
     [Dependency] private SharedActionsSystem _actions = default!;
     [Dependency] private SharedAmbientSoundSystem _ambientSound = default!;
@@ -60,9 +62,9 @@ public abstract partial class SharedVehicleSystem : EntitySystem
     [SubscribeLocalEvent]
     private void OnInsert(EntityUid uid, VehicleComponent component, ref EntInsertedIntoContainerMessage args)
     {
-        if (HasComp<InstantActionComponent>(args.Entity)
-            || args.Container.ID != component.KeySlot
-            || component.IsBroken)
+        if (_timing.ApplyingState ||
+            args.Container.ID != component.KeySlot ||
+            component.IsBroken)
             return;
 
         component.EngineRunning = true;
@@ -78,7 +80,8 @@ public abstract partial class SharedVehicleSystem : EntitySystem
     [SubscribeLocalEvent]
     private void OnEject(EntityUid uid, VehicleComponent component, ref EntRemovedFromContainerMessage args)
     {
-        if (args.Container.ID != component.KeySlot)
+        if (_timing.ApplyingState ||
+            args.Container.ID != component.KeySlot)
             return;
         component.EngineRunning = false;
         Dirty(uid, component);

--- a/Content.Medical.Shared/Restrict/SharedRestrictSystem.cs
+++ b/Content.Medical.Shared/Restrict/SharedRestrictSystem.cs
@@ -3,6 +3,7 @@
 using Content.Shared.Interaction;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Popups;
+using Content.Shared.Random.Helpers;
 using Content.Shared.Tag;
 using Content.Shared.Weapons.Melee.Events;
 using Content.Shared.Weapons.Ranged.Events;
@@ -11,55 +12,57 @@ using Robust.Shared.Timing;
 
 namespace Content.Medical.Shared.Restrict;
 
+// TODO: kill this shit just use whitelist
 public sealed partial class SharedRestrictSystem : EntitySystem
 {
-    [Dependency] private TagSystem _tag = default!;
-    [Dependency] private IRobustRandom _random = default!;
-    [Dependency] private SharedPopupSystem _popup = default!;
     [Dependency] private IGameTiming _timing = default!;
+    [Dependency] private SharedPopupSystem _popup = default!;
+    [Dependency] private TagSystem _tag = default!;
 
-    public override void Initialize()
-    {
-        SubscribeLocalEvent<RestrictInteractionByUserTagComponent, BeforeRangedInteractEvent>(OnAttemptInteract);
-        SubscribeLocalEvent<RestrictMeleeByUserTagComponent, AttemptMeleeEvent>(OnAttemptMelee);
-        SubscribeLocalEvent<RestrictGunshotsByUserTagComponent, ShotAttemptedEvent>(OnAttemptGunshot);
-    }
-
+    [SubscribeLocalEvent]
     private void OnAttemptInteract(Entity<RestrictInteractionByUserTagComponent> ent, ref BeforeRangedInteractEvent args)
     {
-        if (!_tag.HasAllTags(args.User, ent.Comp.Contains) || _tag.HasAnyTag(args.User, ent.Comp.DoesntContain))
-        {
-            if (ent.Comp.Messages.Count != 0)
-                _popup.PopupEntity(Loc.GetString(_random.Pick(ent.Comp.Messages)), args.User);
+        if (_tag.HasAllTags(args.User, ent.Comp.Contains) && !_tag.HasAnyTag(args.User, ent.Comp.DoesntContain))
+            return;
 
-            args.Handled = true;
+        if (ent.Comp.Messages.Count != 0)
+        {
+            var rand = SharedRandomExtensions.PredictedRandom(_timing, GetNetEntity(ent));
+            _popup.PopupEntity(Loc.GetString(rand.Pick(ent.Comp.Messages)), args.User);
         }
+
+        args.Handled = true;
     }
 
+    [SubscribeLocalEvent]
     private void OnAttemptMelee(Entity<RestrictMeleeByUserTagComponent> ent, ref AttemptMeleeEvent args)
     {
-        if(!_tag.HasAllTags(args.User, ent.Comp.Contains) || _tag.HasAnyTag(args.User, ent.Comp.DoesntContain))
-        {
-            if(ent.Comp.Messages.Count != 0)
-                args.Message = Loc.GetString(_random.Pick(ent.Comp.Messages));
+        if (_tag.HasAllTags(args.User, ent.Comp.Contains) && !_tag.HasAnyTag(args.User, ent.Comp.DoesntContain))
+            return;
 
-            args.Cancelled = true;
+        if (ent.Comp.Messages.Count != 0)
+        {
+            var rand = SharedRandomExtensions.PredictedRandom(_timing, GetNetEntity(ent));
+            args.Message = Loc.GetString(rand.Pick(ent.Comp.Messages));
         }
+
+        args.Cancelled = true;
     }
 
+    [SubscribeLocalEvent]
     private void OnAttemptGunshot(Entity<RestrictGunshotsByUserTagComponent> ent, ref ShotAttemptedEvent args)
     {
-        if(!_tag.HasAllTags(args.User, ent.Comp.Contains) || _tag.HasAnyTag(args.User, ent.Comp.DoesntContain))
+        if (_tag.HasAllTags(args.User, ent.Comp.Contains) && !_tag.HasAnyTag(args.User, ent.Comp.DoesntContain))
+            return;
+
+        var now = _timing.CurTime;
+        if (ent.Comp.Messages.Count != 0 && now > ent.Comp.LastPopup + TimeSpan.FromSeconds(1))
         {
-            var time = _timing.CurTime;
-
-            if(ent.Comp.Messages.Count != 0 && time > ent.Comp.LastPopup + TimeSpan.FromSeconds(1))
-            {
-                ent.Comp.LastPopup = time;
-                _popup.PopupEntity(Loc.GetString(_random.Pick(ent.Comp.Messages)), args.User);
-            }
-
-            args.Cancel();
+            ent.Comp.LastPopup = now;
+            var rand = SharedRandomExtensions.PredictedRandom(_timing, GetNetEntity(ent));
+            _popup.PopupEntity(Loc.GetString(rand.Pick(ent.Comp.Messages)), args.User);
         }
+
+        args.Cancel();
     }
 }

--- a/Content.Shared/UserInterface/ActivatableUISystem.Trauma.cs
+++ b/Content.Shared/UserInterface/ActivatableUISystem.Trauma.cs
@@ -5,11 +5,7 @@ namespace Content.Shared.UserInterface;
 
 public sealed partial class ActivatableUISystem
 {
-    private void InitializeTrauma()
-    {
-        SubscribeLocalEvent<ActivatableUIComponent, GetVerbsEvent<AlternativeVerb>>(GetAltVerb);
-    }
-
+    [SubscribeLocalEvent]
     private void GetAltVerb(EntityUid uid, ActivatableUIComponent component, GetVerbsEvent<AlternativeVerb> args)
     {
         if (!component.AltVerb || !ShouldAddVerb(uid, component, args))

--- a/Content.Shared/UserInterface/ActivatableUISystem.cs
+++ b/Content.Shared/UserInterface/ActivatableUISystem.cs
@@ -38,7 +38,6 @@ public sealed partial class ActivatableUISystem : EntitySystem
 
         SubscribeLocalEvent<UserInterfaceComponent, OpenUiActionEvent>(OnActionPerform);
 
-        InitializeTrauma(); // Trauma
         InitializePower();
     }
 
@@ -96,7 +95,7 @@ public sealed partial class ActivatableUISystem : EntitySystem
         });
     }
 
-    private bool ShouldAddVerb<T>(EntityUid uid, ActivatableUIComponent component, GetVerbsEvent<T> args) where T : Verb
+    public bool ShouldAddVerb<T>(EntityUid uid, ActivatableUIComponent component, GetVerbsEvent<T> args) where T : Verb // Trauma - made public
     {
         if (!args.CanAccess)
             return false;
@@ -183,14 +182,16 @@ public sealed partial class ActivatableUISystem : EntitySystem
         SetCurrentSingleUser(uid, null, component);
     }
 
-    private bool InteractUI(EntityUid user, EntityUid uiEntity, ActivatableUIComponent aui)
+    public bool InteractUI(EntityUid user, EntityUid uiEntity, ActivatableUIComponent aui, Enum? key = null) // Trauma - made public, added key
     {
-        if (aui.Key == null || !_uiSystem.HasUi(uiEntity, aui.Key))
+        // <Trauma> - replace aui.Key with key, default to the comp's key
+        key ??= aui.Key;
+        if (key == null || !_uiSystem.HasUi(uiEntity, key))
             return false;
 
-        if (_uiSystem.IsUiOpen(uiEntity, aui.Key, user))
+        if (_uiSystem.IsUiOpen(uiEntity, key, user))
         {
-            _uiSystem.CloseUi(uiEntity, aui.Key, user);
+            _uiSystem.CloseUi(uiEntity, key, user);
             return true;
         }
 
@@ -223,10 +224,10 @@ public sealed partial class ActivatableUISystem : EntitySystem
             var message = Loc.GetString("machine-already-in-use", ("machine", uiEntity));
             _popupSystem.PopupEntity(message, uiEntity, user);
 
-            if (_uiSystem.IsUiOpen(uiEntity, aui.Key))
+            if (_uiSystem.IsUiOpen(uiEntity, key))
                 return true;
 
-            Log.Error($"Activatable UI has user without being opened? Entity: {ToPrettyString(uiEntity)}. User: {aui.CurrentSingleUser}, Key: {aui.Key}");
+            Log.Error($"Activatable UI has user without being opened? Entity: {ToPrettyString(uiEntity)}. User: {aui.CurrentSingleUser}, Key: {key}");
         }
 
         // If we've gotten this far, fire a cancellable event that indicates someone is about to activate this.
@@ -240,7 +241,8 @@ public sealed partial class ActivatableUISystem : EntitySystem
         RaiseLocalEvent(uiEntity, bae);
 
         SetCurrentSingleUser(uiEntity, user, aui);
-        _uiSystem.OpenUi(uiEntity, aui.Key, user);
+        _uiSystem.OpenUi(uiEntity, key, user);
+        // </Trauma>
 
         //Let the component know a user opened it so it can do whatever it needs to do
         var aae = new AfterActivatableUIOpenEvent(user);

--- a/Content.Trauma.Shared/Projectiles/ProjectileEmbedSystem.cs
+++ b/Content.Trauma.Shared/Projectiles/ProjectileEmbedSystem.cs
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Shared.Projectiles;
+
+namespace Content.Trauma.Shared.Projectiles;
+
+public sealed partial class ProjectileEmbedSystem : EntitySystem
+{
+    [Dependency] private SharedProjectileSystem _projectile = default!;
+
+    // picking up or e.g. tilegun sucking up a tile unembeds it automatically
+    [SubscribeLocalEvent]
+    private void OnInsertedIntoContainer(Entity<EmbeddableProjectileComponent> ent, ref EntGotInsertedIntoContainerMessage args)
+    {
+        _projectile.EmbedDetach(ent, ent.Comp);
+    }
+}

--- a/Content.Trauma.Shared/Projectiles/ProjectileEmbedSystem.cs
+++ b/Content.Trauma.Shared/Projectiles/ProjectileEmbedSystem.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 using Content.Shared.Projectiles;
+using Robust.Shared.Containers;
 
 namespace Content.Trauma.Shared.Projectiles;
 

--- a/Content.Trauma.Shared/UserInterface/AlternateUIComponent.cs
+++ b/Content.Trauma.Shared/UserInterface/AlternateUIComponent.cs
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Content.Trauma.Shared.UserInterface;
+
+/// <summary>
+/// Adds an alt verb to open a BUI separate from the main ActivatableUI.
+/// Shares the UI opening requirements, held items, etc.
+/// </summary>
+[RegisterComponent, NetworkedComponent, Access(typeof(AlternateUISystem))]
+public sealed partial class AlternateUIComponent : Component
+{
+    /// <summary>
+    /// The alternate UI to open when requested.
+    /// </summary>
+    [DataField(required: true)]
+    public Enum Key;
+
+    /// <summary>
+    /// The text used in the verb.
+    /// </summary>
+    [DataField(required: true)]
+    public string VerbText;
+}

--- a/Content.Trauma.Shared/UserInterface/AlternateUISystem.cs
+++ b/Content.Trauma.Shared/UserInterface/AlternateUISystem.cs
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Shared.UserInterface;
+using Content.Shared.Verbs;
+
+namespace Content.Trauma.Shared.UserInterface;
+
+public sealed partial class AlternateUISystem : EntitySystem
+{
+    [Dependency] private ActivatableUISystem _aui = default!;
+    [Dependency] private EntityQuery<ActivatableUIComponent> _auiQuery = default!;
+
+    [SubscribeLocalEvent]
+    private void OnGetVerbs(Entity<AlternateUIComponent> ent, ref GetVerbsEvent<AlternativeVerb> args)
+    {
+        var aui = _auiQuery.Comp(ent);
+        if (!_aui.ShouldAddVerb(ent, aui, args))
+            return;
+
+        var user = args.User;
+        args.Verbs.Add(new AlternativeVerb
+        {
+            Act = () => _aui.InteractUI(user, ent, aui, ent.Comp.Key),
+            Text = ent.Comp.VerbText,
+            Icon = new SpriteSpecifier.Texture(new ResPath("/Textures/Interface/VerbIcons/settings.svg.192dpi.png"))
+        });
+    }
+}

--- a/Resources/Prototypes/Entities/Clothing/Back/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/specific.yml
@@ -5,20 +5,19 @@
   description: You wear this on your back and put items into it.
   suffix: Chameleon
   components:
-  - type: Tag
-    tags: [] # ignore "WhitelistChameleon" tag
-  - type: Sprite
-    sprite: Clothing/Back/Backpacks/backpack.rsi
-  - type: ChameleonClothing
-    slot: [back]
-    default: ClothingBackpack
-  - type: UserInterface
-    interfaces:
-      enum.StorageUiKey.Key:
-        type: StorageBoundUserInterface
-      enum.ChameleonUiKey.Key:
-        type: ChameleonBoundUserInterface
-  - type: HideContrabandContent #Goobstation-Contraband detector
+    - type: Tag
+      tags: [] # ignore "WhitelistChameleon" tag
+    - type: Sprite
+      sprite: Clothing/Back/Backpacks/backpack.rsi
+    - type: ChameleonClothing
+      slot: [back]
+      default: ClothingBackpack
+    - type: UserInterface
+      interfaces:
+        enum.StorageUiKey.Key:
+          type: StorageBoundUserInterface
+        enum.ChameleonUiKey.Key:
+          type: ChameleonBoundUserInterface
 
 - type: entity
   parent: [SolutionTank, SolutionGinormous, Clothing, ClothingSlotBase]
@@ -73,12 +72,6 @@
   - type: ExaminableSolution
     solution: tank
     exactVolume: true
-  - type: PhysicalComposition #Goobstation - Recycle update
-    materialComposition:
-      Steel: 62
-      Glass: 250
-  - type: StaticPrice #Goobstation - Recycle update
-    price: 50
 
 - type: entity
   parent: ClothingBackpack

--- a/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
@@ -7,21 +7,14 @@
   - type: MagnetPickup
   - type: Sprite
     sprite: Objects/Specific/Mining/ore_bag.rsi
-    layers:
-    - state: orebag_off
-      map: [ "enum.ToggleableVisuals.Layer" ]
+    state: icon
   - type: Clothing
     sprite: Objects/Specific/Mining/ore_bag.rsi
     quickEquip: false
     slots:
     - belt
   - type: Item
-    size: Huge # DeltaV: Was Ginormous, lets it fit in conscription bag
-    inhandVisuals: #Goob fixed inhand visuals
-      left:
-      - state: inhand-left
-      right:
-      - state: inhand-right
+    size: Ginormous
   - type: Storage
     maxItemSize: Normal
     grid:
@@ -33,25 +26,6 @@
         - ArtifactFragment
         - Ore
   - type: Dumpable
-  # WHITE EDIT START
-  - type: ItemToggle
-    soundActivate:
-      collection: sparks
-      params:
-        variation: 0.250
-    soundDeactivate:
-      collection: sparks
-      params:
-        variation: 0.250
-  - type: Appearance
-  - type: GenericVisualizer
-    visuals:
-      enum.ToggleableVisuals.Enabled:
-        enum.ToggleableVisuals.Layer:
-          True: { state: orebag_on }
-          False: { state: orebag_off }
-  # WHITE EDIT END
-  - type: OreBag # Lavaland Change
 
 - type: entity
   parent: OreBag

--- a/Resources/Prototypes/Entities/Structures/Holographic/projections.yml
+++ b/Resources/Prototypes/Entities/Structures/Holographic/projections.yml
@@ -144,7 +144,7 @@
           acts: [ "Destruction" ]
 
 - type: entity
-  parent: BaseHoloSign
+  parent: BaseHoloSignNoDespawn # Trauma - no despawn
   id: XenoborgDeflectorField
   name: deflector field
   description: An energy matrix, comprised of interlocking fields that deflect projectiles. Powerful, but short-lived.
@@ -165,7 +165,7 @@
         mask:
         - FullTileMask
         layer:
-        - Opaque # Traua
+        - Opaque # Trauma
         - GlassLayer
   - type: TimedDespawn
     lifetime: 15

--- a/Resources/Prototypes/_Trauma/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Structures/Machines/lathe.yml
@@ -223,6 +223,9 @@
     color: "#ffffff"
     radius: 1.5
     energy: 5.0
+  - type: AlternateUI
+    key: enum.OreSiloUiKey.Key
+    verbText: Open Ore Silo UI
   - type: OreSilo
     range: 15
   - type: MasterSiloClient # theft

--- a/Resources/Prototypes/_Trauma/Partials/Entities/Clothing/Back/specific.yml
+++ b/Resources/Prototypes/_Trauma/Partials/Entities/Clothing/Back/specific.yml
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+- type: entity
+  id: ClothingBackpackChameleon
+  components:
+  - type: HideContrabandContent
+
+- type: entity
+  id: ClothingBackpackWaterTank
+  components:
+  - type: PhysicalComposition
+    materialComposition:
+      Steel: 62
+      Glass: 250
+  - type: StaticPrice
+    price: 50
+
+- type: entity
+  id: XenoborgMaterialBag
+  components:
+  - type: ItemToggle
+    soundActivate: &sound
+      collection: sparks
+      params:
+        variation: 0.250
+    soundDeactivate: *sound

--- a/Resources/Prototypes/_Trauma/Partials/Entities/Objects/Specific/Salvage/ore_bag.yml
+++ b/Resources/Prototypes/_Trauma/Partials/Entities/Objects/Specific/Salvage/ore_bag.yml
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+- type: entity
+  id: OreBag
+  components:
+  - type: Sprite
+    state: null
+    layers:
+    - state: orebag_off
+      map: [ "enum.ToggleableVisuals.Layer" ]
+  - type: Appearance
+  - type: GenericVisualizer
+    visuals:
+      enum.ToggleableVisuals.Enabled:
+        enum.ToggleableVisuals.Layer:
+          True: { state: orebag_on }
+          False: { state: orebag_off }
+  - type: Item
+    size: Huge # lets it fit in conscription bag
+    inhandVisuals:
+      left:
+      - state: inhand-left
+      right:
+      - state: inhand-right
+  - type: OreBag


### PR DESCRIPTION
fixes #4416
fixes #4431

## Media
<img width="508" height="116" alt="23:30:28" src="https://github.com/user-attachments/assets/8499638c-3037-46ad-b2b0-5fffdb618116" />
<img width="419" height="459" alt="23:30:36" src="https://github.com/user-attachments/assets/029ba823-349e-4303-904f-403f00913bf2" />

## Changelog
:cl:
- tweak: You can now alt-click a rev telesphere to link machines to its silo resources.
- fix: Fixed xenoborg tile gun getting broken by embedded tiles.
- fix: Xenoborgs can now toggle the magnet on their storage. 
- tweak: Xenoborg deflectors no longer despawn, you still lose them if they get destroyed.