### PR TITLE
make sparks better

### DIFF
--- a/Content.Trauma.Client/Spawners/TimedClientDespawnComponent.cs
+++ b/Content.Trauma.Client/Spawners/TimedClientDespawnComponent.cs
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Content.Trauma.Client.Spawners;
+
+/// <summary>
+/// Timed despawn that updates inside prediction properly for deletion of clientside entities.
+/// Does nothing for networked entities.
+/// </summary>
+[RegisterComponent]
+[AutoGenerateComponentPause]
+public sealed partial class TimedClientDespawnComponent : Component
+{
+    [DataField(required: true)]
+    public TimeSpan Lifetime;
+
+    [ViewVariables, AutoPausedField]
+    public TimeSpan NextDespawn;
+}

--- a/Content.Trauma.Client/Spawners/TimedClientDespawnSystem.cs
+++ b/Content.Trauma.Client/Spawners/TimedClientDespawnSystem.cs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Robust.Shared.Timing;
+
+namespace Content.Trauma.Client.Spawners;
+
+public sealed partial class TimedClientDespawnSystem : EntitySystem
+{
+    [Dependency] private IGameTiming _timing = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        UpdatesOutsidePrediction = true;
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var now = _timing.CurTime;
+        var query = EntityQueryEnumerator<TimedClientDespawnComponent>();
+        foreach (var ent in query)
+        {
+            if (now < ent.Comp.NextDespawn)
+                continue;
+
+            if (IsClientSide(ent))
+                QueueDel(ent);
+            else
+                RemCompDeferred(ent, ent.Comp); // bad chuddy
+        }
+    }
+
+    [SubscribeLocalEvent]
+    private void OnInit(Entity<TimedClientDespawnComponent> ent, ref ComponentInit args)
+    {
+        ent.Comp.NextDespawn = _timing.CurTime + ent.Comp.Lifetime;
+    }
+}

--- a/Content.Trauma.Common/Effects/CommonSparksSystem.cs
+++ b/Content.Trauma.Common/Effects/CommonSparksSystem.cs
@@ -6,21 +6,26 @@ namespace Content.Trauma.Common.Effects;
 
 public abstract class CommonSparksSystem : EntitySystem
 {
+    public const int MinSparks = 1;
+    public const int MaxSparks = 3;
+    public const float MinVelocity = 0.5f;
+    public const float MaxVelocity = 2f;
+
     public abstract void DoSparks(EntityCoordinates coords,
         EntityUid? user = null,
-        int minSparks = 1,
-        int maxSparks = 3,
-        float minVelocity = 1f,
-        float maxVelocity = 4f,
+        int minSparks = MinSparks,
+        int maxSparks = MaxSparks,
+        float minVelocity = MinVelocity,
+        float maxVelocity = MaxVelocity,
         bool playSound = true,
         EntityUid? source = null);
 
     public void DoSparks(EntityUid uid,
         EntityUid? user = null,
-        int minSparks = 1,
-        int maxSparks = 3,
-        float minVelocity = 1f,
-        float maxVelocity = 4f,
+        int minSparks = MinSparks,
+        int maxSparks = MaxSparks,
+        float minVelocity = MinVelocity,
+        float maxVelocity = MaxVelocity,
         bool playSound = true,
         EntityUid? source = null)
     {

--- a/Content.Trauma.Server/Entry/EntryPoint.cs
+++ b/Content.Trauma.Server/Entry/EntryPoint.cs
@@ -32,5 +32,6 @@ public sealed partial class EntryPoint : GameServer
         "ShowSpriteLayerStatusEffect",
         "AnimatedEmotesBlacklist",
         "PredictedPhysicsEffect",
+        "TimedClientDespawn",
     ];
 }

--- a/Content.Trauma.Shared/Effects/SparksSystem.cs
+++ b/Content.Trauma.Shared/Effects/SparksSystem.cs
@@ -16,10 +16,10 @@ public sealed partial class SparksSystem : CommonSparksSystem
 
     public override void DoSparks(EntityCoordinates coords,
         EntityUid? user = null,
-        int minSparks = 1,
-        int maxSparks = 3,
-        float minVelocity = 1f,
-        float maxVelocity = 4f,
+        int minSparks = MinSparks,
+        int maxSparks = MaxSparks,
+        float minVelocity = MinVelocity,
+        float maxVelocity = MaxVelocity,
         bool playSound = true,
         EntityUid? source = null)
     {

--- a/Content.Trauma.Shared/EntityEffects/Sparks.cs
+++ b/Content.Trauma.Shared/EntityEffects/Sparks.cs
@@ -11,13 +11,13 @@ namespace Content.Trauma.Shared.EntityEffects;
 [DataRecord]
 public sealed partial class Sparks : EntityEffectBase<Sparks>
 {
-    public int MinSparks = 1;
+    public int MinSparks = SparksSystem.MinSparks;
 
-    public int MaxSparks = 3;
+    public int MaxSparks = SparksSystem.MaxSparks;
 
-    public float MinVelocity = 1f;
+    public float MinVelocity = SparksSystem.MinVelocity;
 
-    public float MaxVelocity = 4f;
+    public float MaxVelocity = SparksSystem.MaxVelocity;
 
     public bool PlaySound = true;
 }

--- a/Resources/Prototypes/_Goobstation/Wizard/effects.yml
+++ b/Resources/Prototypes/_Goobstation/Wizard/effects.yml
@@ -190,7 +190,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: PredictedPhysicsEffect
-  - type: TimedDespawn
+  - type: TimedClientDespawn
     lifetime: 1
   - type: Sprite
     drawdepth: Effects


### PR DESCRIPTION
- halved the velocity range since clientside physics seems very sus and goes much faster than expected
- replaced timed despawn with a better impl for clientside entities

:cl:
- tweak: Sparks dont fly as fast and generally look better.