### PR TITLE
fix blob stuff

### DIFF
--- a/Content.Goobstation.Client/Blob/BlobCoreSystem.cs
+++ b/Content.Goobstation.Client/Blob/BlobCoreSystem.cs
@@ -1,7 +1,0 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-
-using Content.Goobstation.Shared.Blob;
-
-namespace Content.Goobstation.Shared.Blob;
-
-public sealed class BlobCoreSystem : SharedBlobCoreSystem;

--- a/Content.Goobstation.Client/Blob/BlobResourceSystem.cs
+++ b/Content.Goobstation.Client/Blob/BlobResourceSystem.cs
@@ -1,7 +1,0 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-
-using Content.Goobstation.Shared.Blob;
-
-namespace Content.Goobstation.Shared.Blob;
-
-public sealed class BlobResourceSystem : SharedBlobResourceSystem;

--- a/Content.Goobstation.Client/Blob/ClientBlobCoreSystem.cs
+++ b/Content.Goobstation.Client/Blob/ClientBlobCoreSystem.cs
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Goobstation.Shared.Blob;
+
+namespace Content.Goobstation.Client.Blob;
+
+public sealed class ClientBlobCoreSystem : BlobCoreSystem;

--- a/Content.Goobstation.Client/Blob/ClientBlobMobSystem.cs
+++ b/Content.Goobstation.Client/Blob/ClientBlobMobSystem.cs
@@ -8,7 +8,7 @@ using Robust.Shared.Map;
 
 namespace Content.Goobstation.Client.Blob;
 
-public sealed partial class BlobMobSystem : SharedBlobMobSystem
+public sealed partial class ClientBlobMobSystem : BlobMobSystem
 {
     [Dependency] private MeleeWeaponSystem _melee = default!;
 
@@ -22,7 +22,7 @@ public sealed partial class BlobMobSystem : SharedBlobMobSystem
         SpawnAttachedTo(HealEffect, new EntityCoordinates(ent, Vector2.Zero));
     }
 
-    [SubscribeLocalEvent, SubscribeNetworkEvent]
+    [EventSubscription]
     private void OnBlobAttack(BlobAttackEvent ev)
     {
         if (!TryGetEntity(ev.BlobEntity, out var user))

--- a/Content.Goobstation.Client/Blob/ClientBlobObserverSystem.cs
+++ b/Content.Goobstation.Client/Blob/ClientBlobObserverSystem.cs
@@ -10,7 +10,7 @@ using Robust.Shared.Player;
 
 namespace Content.Goobstation.Client.Blob;
 
-public sealed partial class BlobObserverSystem : SharedBlobObserverSystem
+public sealed partial class ClientBlobObserverSystem : BlobObserverSystem
 {
     [Dependency] private ILightManager _light = default!;
 

--- a/Content.Goobstation.Client/Blob/ClientBlobResourceSystem.cs
+++ b/Content.Goobstation.Client/Blob/ClientBlobResourceSystem.cs
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Goobstation.Shared.Blob;
+
+namespace Content.Goobstation.Client.Blob;
+
+public sealed class ClientBlobResourceSystem : BlobResourceSystem;

--- a/Content.Goobstation.Client/Blob/ClientBlobbernautSystem.cs
+++ b/Content.Goobstation.Client/Blob/ClientBlobbernautSystem.cs
@@ -6,7 +6,7 @@ using Content.Goobstation.Shared.Blob.Components;
 
 namespace Content.Goobstation.Client.Blob;
 
-public sealed partial class BlobbernautSystem : SharedBlobbernautSystem;
+public sealed partial class ClientBlobbernautSystem : BlobbernautSystem;
 
 public sealed partial class BlobbernautVisualizerSystem : VisualizerSystem<BlobbernautComponent>
 {

--- a/Content.Goobstation.Server/Blob/BlobObserverMover.cs
+++ b/Content.Goobstation.Server/Blob/BlobObserverMover.cs
@@ -2,6 +2,7 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using Content.Goobstation.Shared.Blob;
 using Content.Goobstation.Shared.Blob.Components;
 using Content.Shared.ActionBlocker;
 using Robust.Shared.CPUJob.JobQueues;

--- a/Content.Goobstation.Server/Blob/BlobPodZombifyOperator.cs
+++ b/Content.Goobstation.Server/Blob/BlobPodZombifyOperator.cs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-using Content.Goobstation.Server.Blob.NPC.BlobPod;
 using Content.Goobstation.Shared.Blob.Components;
+using Content.Goobstation.Shared.Blob.NPC.BlobPod;
 using Content.Server.NPC;
 using Content.Server.NPC.HTN;
 using Content.Server.NPC.HTN.PrimitiveTasks;

--- a/Content.Goobstation.Server/Blob/BlobbernautSystem.cs
+++ b/Content.Goobstation.Server/Blob/BlobbernautSystem.cs
@@ -12,11 +12,11 @@ using Robust.Shared.Timing;
 
 namespace Content.Goobstation.Server.Blob;
 
-public sealed partial class BlobbernautSystem : SharedBlobbernautSystem
+public sealed partial class ServerBlobbernautSystem : BlobbernautSystem
 {
+    [Dependency] private DamageableSystem _damage = default!;
     [Dependency] private EntityLookupSystem _lookup = default!;
     [Dependency] private IGameTiming _timing = default!;
-    [Dependency] private DamageableSystem _damage = default!;
     [Dependency] private MobStateSystem _mob = default!;
     [Dependency] private SharedPopupSystem _popup = default!;
     [Dependency] private SharedTransformSystem _transform = default!;

--- a/Content.Goobstation.Server/Blob/GameTicking/BlobRuleComponent.cs
+++ b/Content.Goobstation.Server/Blob/GameTicking/BlobRuleComponent.cs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+using Content.Goobstation.Shared.Blob;
 using Content.Server.GameTicking.Rules;
 using Content.Shared.Mind;
 using Robust.Shared.Audio;

--- a/Content.Goobstation.Server/Blob/NPC/BlobPod/ServerBlobPodSystem.cs
+++ b/Content.Goobstation.Server/Blob/NPC/BlobPod/ServerBlobPodSystem.cs
@@ -22,17 +22,17 @@ using Robust.Shared.Player;
 
 namespace Content.Goobstation.Server.Blob.NPC.BlobPod;
 
-public sealed partial class BlobPodSystem : SharedBlobPodSystem
+public sealed partial class ServerBlobPodSystem : BlobPodSystem
 {
-    [Dependency] private SharedDoAfterSystem _doAfter = default!;
-    [Dependency] private MobStateSystem _mobs = default!;
     [Dependency] private ActionBlockerSystem _blocker = default!;
-    [Dependency] private SharedPopupSystem _popup = default!;
-    [Dependency] private SharedAudioSystem _audio = default!;
-    [Dependency] private InventorySystem _inventory = default!;
     [Dependency] private DamageableSystem _damage = default!;
+    [Dependency] private InventorySystem _inventory = default!;
     [Dependency] private NPCSystem _npc = default!;
+    [Dependency] private MobStateSystem _mobs = default!;
+    [Dependency] private SharedAudioSystem _audio = default!;
+    [Dependency] private SharedDoAfterSystem _doAfter = default!;
     [Dependency] private SharedMoverController _mover = default!;
+    [Dependency] private SharedPopupSystem _popup = default!;
 
     [SubscribeLocalEvent]
     private void OnBeforeDamageChanged(Entity<BlobPodComponent> ent, ref BeforeDamageChangedEvent args)

--- a/Content.Goobstation.Server/Blob/ServerBlobCarrierSystem.cs
+++ b/Content.Goobstation.Server/Blob/ServerBlobCarrierSystem.cs
@@ -18,14 +18,14 @@ using Robust.Shared.Player;
 
 namespace Content.Goobstation.Server.Blob;
 
-public sealed partial class BlobCarrierSystem : SharedBlobCarrierSystem
+public sealed partial class ServerBlobCarrierSystem : BlobCarrierSystem
 {
-    [Dependency] private BlobObserverSystem _observer = default!;
-    [Dependency] private MindSystem _mind = default!;
-    [Dependency] private GhostRoleSystem _ghost = default!;
-    [Dependency] private GibbingSystem _gibbing = default!;
     [Dependency] private ActionsSystem _action = default!;
     [Dependency] private CommonLanguageSystem _language = default!;
+    [Dependency] private GhostRoleSystem _ghost = default!;
+    [Dependency] private GibbingSystem _gibbing = default!;
+    [Dependency] private MindSystem _mind = default!;
+    [Dependency] private ServerBlobObserverSystem _observer = default!;
 
     private static readonly EntProtoId ActionTransformToBlob = "ActionTransformToBlob";
 

--- a/Content.Goobstation.Server/Blob/ServerBlobCoreSystem.cs
+++ b/Content.Goobstation.Server/Blob/ServerBlobCoreSystem.cs
@@ -17,7 +17,7 @@ using System.Threading.Tasks;
 
 namespace Content.Goobstation.Server.Blob;
 
-public sealed partial class BlobCoreSystem : SharedBlobCoreSystem
+public sealed partial class ServerBlobCoreSystem : BlobCoreSystem
 {
     [Dependency] private AlertLevelSystem _alertLevel = default!;
     [Dependency] private MetaDataSystem _meta = default!;
@@ -30,7 +30,7 @@ public sealed partial class BlobCoreSystem : SharedBlobCoreSystem
     private readonly JobQueue _killCoreJobQueue = new(KillCoreJobTime);
 
     public sealed class KillBlobCore(
-        BlobCoreSystem system,
+        ServerBlobCoreSystem system,
         EntityUid? station,
         Entity<BlobCoreComponent> ent,
         double maxTime,

--- a/Content.Goobstation.Server/Blob/ServerBlobMobSystem.cs
+++ b/Content.Goobstation.Server/Blob/ServerBlobMobSystem.cs
@@ -4,4 +4,4 @@ using Content.Goobstation.Shared.Blob;
 
 namespace Content.Goobstation.Server.Blob;
 
-public sealed partial class BlobMobSystem : SharedBlobMobSystem;
+public sealed partial class ServerBlobMobSystem : BlobMobSystem;

--- a/Content.Goobstation.Server/Blob/ServerBlobObserverSystem.cs
+++ b/Content.Goobstation.Server/Blob/ServerBlobObserverSystem.cs
@@ -15,7 +15,7 @@ using System.Linq;
 
 namespace Content.Goobstation.Server.Blob;
 
-public sealed partial class BlobObserverSystem : SharedBlobObserverSystem
+public sealed partial class ServerBlobObserverSystem : BlobObserverSystem
 {
     [Dependency] private GameTicker _ticker = default!;
     [Dependency] private IChatManager _chat = default!;

--- a/Content.Goobstation.Server/Blob/ServerBlobResourceSystem.cs
+++ b/Content.Goobstation.Server/Blob/ServerBlobResourceSystem.cs
@@ -6,7 +6,7 @@ using Content.Server.GameTicking;
 
 namespace Content.Goobstation.Server.Blob;
 
-public sealed partial class BlobResourceSystem : SharedBlobResourceSystem
+public sealed partial class ServerBlobResourceSystem : BlobResourceSystem
 {
     /// <summary>
     /// On round end makes all the blobs resource nodes generate 100 points each pulse.

--- a/Content.Goobstation.Shared/Blob/BlobCarrierSystem.cs
+++ b/Content.Goobstation.Shared/Blob/BlobCarrierSystem.cs
@@ -6,7 +6,7 @@ using Robust.Shared.Timing;
 
 namespace Content.Goobstation.Shared.Blob;
 
-public abstract partial class SharedBlobCarrierSystem : EntitySystem
+public abstract partial class BlobCarrierSystem : EntitySystem
 {
     [Dependency] private IGameTiming _timing = default!;
     [Dependency] private SharedPopupSystem _popup = default!;

--- a/Content.Goobstation.Shared/Blob/BlobCoreActionSystem.cs
+++ b/Content.Goobstation.Shared/Blob/BlobCoreActionSystem.cs
@@ -23,16 +23,16 @@ namespace Content.Goobstation.Shared.Blob;
 
 public sealed partial class BlobCoreActionSystem : EntitySystem
 {
+    [Dependency] private BlobCoreSystem _core = default!;
     [Dependency] private BlobTileSystem _tile = default!;
-    [Dependency] private SharedPopupSystem _popup = default!;
     [Dependency] private IConfigurationManager _cfg = default!;
-    [Dependency] private ITileDefinitionManager _tiles = default!;
     [Dependency] private IGameTiming _timing = default!;
+    [Dependency] private ITileDefinitionManager _tiles = default!;
     [Dependency] private DamageableSystem _damage = default!;
     [Dependency] private SharedAudioSystem _audio = default!;
-    [Dependency] private SharedBlobCoreSystem _core = default!;
     [Dependency] private SharedEntityEffectsSystem _effects = default!;
     [Dependency] private SharedMapSystem _map = default!;
+    [Dependency] private SharedPopupSystem _popup = default!;
     [Dependency] private SharedTransformSystem _transform = default!;
     [Dependency] private EntityQuery<BlobTileComponent> _tileQuery = default!;
     [Dependency] private EntityQuery<BlobCoreComponent> _coreQuery = default!;
@@ -70,7 +70,7 @@ public sealed partial class BlobCoreActionSystem : EntitySystem
         #region OnTarget
         if (args.Target is { } target && !HasComp<BlobMobComponent>(target))
         {
-            if (_tileQuery.TryComp(target, out var tileComp) && tileComp.Core != null)
+            if (_tileQuery.TryComp(target, out var tileComp) && tileComp.Core == core.Owner)
                 return;
 
             if (fromTile != null && HasComp<DestructibleComponent>(target) && !HasComp<ItemComponent>(target) && !HasComp<SubFloorHideComponent>(target))

--- a/Content.Goobstation.Shared/Blob/BlobCoreSystem.cs
+++ b/Content.Goobstation.Shared/Blob/BlobCoreSystem.cs
@@ -13,7 +13,7 @@ using Robust.Shared.Map.Components;
 
 namespace Content.Goobstation.Shared.Blob;
 
-public abstract partial class SharedBlobCoreSystem : EntitySystem
+public abstract partial class BlobCoreSystem : EntitySystem
 {
     [Dependency] private AlertsSystem _alerts = default!;
     [Dependency] private BlobTileSystem _tile = default!;

--- a/Content.Goobstation.Shared/Blob/BlobFactorySystem.cs
+++ b/Content.Goobstation.Shared/Blob/BlobFactorySystem.cs
@@ -68,9 +68,7 @@ public sealed partial class BlobFactorySystem : EntitySystem
     [SubscribeLocalEvent]
     private void OnPulse(Entity<BlobFactoryComponent> ent, ref BlobSpecialPulseEvent args)
     {
-        if (!_tileQuery.TryComp(ent, out var tile) ||
-            tile.Core is not { } core ||
-            !_coreQuery.TryComp(core, out var coreComp))
+        if (!_tileQuery.TryComp(ent, out var tile))
             return;
 
         // forget dead pods
@@ -85,6 +83,7 @@ public sealed partial class BlobFactorySystem : EntitySystem
         if (ent.Comp.Accumulator < ent.Comp.AccumulateToSpawn)
         {
             ent.Comp.Accumulator++;
+            Dirty(ent);
             return;
         }
 
@@ -94,8 +93,8 @@ public sealed partial class BlobFactorySystem : EntitySystem
         ent.Comp.BlobPods.Add(pod);
         Dirty(ent);
         var blobPod = EnsureComp<BlobPodComponent>(pod);
-        blobPod.Core = core;
-        FillSmokeGas((pod, blobPod), coreComp.CurrentChem);
+        blobPod.Core = args.Core;
+        FillSmokeGas((pod, blobPod), args.Core.Comp.CurrentChem);
 
         ent.Comp.Accumulator = 0;
     }

--- a/Content.Goobstation.Shared/Blob/BlobMobSystem.cs
+++ b/Content.Goobstation.Shared/Blob/BlobMobSystem.cs
@@ -11,19 +11,12 @@ using Content.Shared.Speech;
 
 namespace Content.Goobstation.Shared.Blob;
 
-public abstract partial class SharedBlobMobSystem : EntitySystem
+public abstract partial class BlobMobSystem : EntitySystem
 {
     [Dependency] private DamageableSystem _damage = default!;
     [Dependency] private SharedPopupSystem _popup = default!;
     [Dependency] private EntityQuery<BlobTileComponent> _tileQuery = default!;
     [Dependency] private EntityQuery<BlobMobComponent> _mobQuery = default!;
-
-    public override void Initialize()
-    {
-        base.Initialize();
-
-        SubscribeLocalEvent<BlobSpeakComponent, SpeakAttemptEvent>(OnSpeakAttempt, after: [ typeof(SpeechSystem) ]);
-    }
 
     public virtual void NodePulse(Entity<BlobMobComponent> ent)
     {
@@ -40,6 +33,7 @@ public abstract partial class SharedBlobMobSystem : EntitySystem
         args.Cancel();
     }
 
+    [SubscribeLocalEvent(after: [typeof(SpeechSystem)])]
     private void OnSpeakAttempt(Entity<BlobSpeakComponent> ent, ref SpeakAttemptEvent args)
     {
         if (HasComp<BlobCarrierComponent>(ent))

--- a/Content.Goobstation.Shared/Blob/BlobNodeSystem.cs
+++ b/Content.Goobstation.Shared/Blob/BlobNodeSystem.cs
@@ -11,11 +11,11 @@ namespace Content.Goobstation.Shared.Blob;
 
 public sealed partial class BlobNodeSystem : EntitySystem
 {
+    [Dependency] private BlobCoreSystem _core = default!;
+    [Dependency] private BlobMobSystem _blobMob = default!;
     [Dependency] private EntityLookupSystem _lookup = default!;
     [Dependency] private IGameTiming _timing = default!;
     [Dependency] private MobStateSystem _mob = default!;
-    [Dependency] private SharedBlobCoreSystem _core = default!;
-    [Dependency] private SharedBlobMobSystem _blobMob = default!;
     [Dependency] private SharedMapSystem _map = default!;
     [Dependency] private EntityQuery<BlobCoreComponent> _coreQuery = default!;
     [Dependency] private EntityQuery<BlobTileComponent> _tileQuery = default!;
@@ -76,6 +76,9 @@ public sealed partial class BlobNodeSystem : EntitySystem
     public override void Update(float frameTime)
     {
         base.Update(frameTime);
+
+        if (!_timing.IsFirstTimePredicted)
+            return;
 
         var now = _timing.CurTime;
         var query = EntityQueryEnumerator<BlobNodeComponent>();

--- a/Content.Goobstation.Shared/Blob/BlobTileSystem.cs
+++ b/Content.Goobstation.Shared/Blob/BlobTileSystem.cs
@@ -25,11 +25,11 @@ namespace Content.Goobstation.Shared.Blob;
 
 public sealed partial class BlobTileSystem : EntitySystem
 {
+    [Dependency] private BlobCoreSystem _core = default!;
     [Dependency] private DamageableSystem _damage = default!;
     [Dependency] private IGameTiming _timing = default!;
     [Dependency] private INetManager _net = default!;
     [Dependency] private SharedAudioSystem _audio = default!;
-    [Dependency] private SharedBlobCoreSystem _core = default!;
     [Dependency] private SharedEntityEffectsSystem _effects = default!;
     [Dependency] private SharedMapSystem _map = default!;
     [Dependency] private SharedTransformSystem _transform = default!;
@@ -51,7 +51,7 @@ public sealed partial class BlobTileSystem : EntitySystem
         if (ent.Comp.Core == null || observer.Core is not { } core)
             return;
 
-        if (Transform(ent).Anchored)
+        if (!Transform(ent).Anchored)
             return;
 
         var current = ProtoMan.Index(ent.Comp.Tile);
@@ -188,7 +188,10 @@ public sealed partial class BlobTileSystem : EntitySystem
             foreach (var uid in _map.GetAnchoredEntities(gridUid, grid, innerTile.GridIndices))
             {
                 if (_tileQuery.HasComp(uid))
+                {
                     spawn = false;
+                    continue;
+                }
 
                 if (!HasComp<DestructibleComponent>(uid))
                     continue;

--- a/Content.Goobstation.Shared/Blob/BlobbernautSystem.cs
+++ b/Content.Goobstation.Shared/Blob/BlobbernautSystem.cs
@@ -8,7 +8,7 @@ using System.Linq;
 
 namespace Content.Goobstation.Shared.Blob;
 
-public abstract partial class SharedBlobbernautSystem : EntitySystem
+public abstract partial class BlobbernautSystem : EntitySystem
 {
     [Dependency] private SharedEntityEffectsSystem _effects = default!;
 

--- a/Content.Goobstation.Shared/Blob/Components/BlobFactoryComponent.cs
+++ b/Content.Goobstation.Shared/Blob/Components/BlobFactoryComponent.cs
@@ -27,7 +27,7 @@ public sealed partial class BlobFactoryComponent : Component
     [DataField, AutoNetworkedField]
     public List<EntityUid> BlobPods = new ();
 
-    [DataField]
+    [DataField, AutoNetworkedField]
     public int Accumulator = 0;
 
     [DataField]

--- a/Content.Goobstation.Shared/Blob/NPC/BlobPod/BlobPodSystem.cs
+++ b/Content.Goobstation.Shared/Blob/NPC/BlobPod/BlobPodSystem.cs
@@ -14,7 +14,7 @@ using Content.Shared.Verbs;
 
 namespace Content.Goobstation.Shared.Blob.NPC.BlobPod;
 
-public abstract partial class SharedBlobPodSystem : EntitySystem
+public abstract partial class BlobPodSystem : EntitySystem
 {
     [Dependency] private MobStateSystem _mob = default!;
     [Dependency] private SharedEntityEffectsSystem _effects = default!;

--- a/Content.Goobstation.Shared/Blob/SharedBlobObserverSystem.cs
+++ b/Content.Goobstation.Shared/Blob/SharedBlobObserverSystem.cs
@@ -15,14 +15,14 @@ using Robust.Shared.Player;
 
 namespace Content.Goobstation.Shared.Blob;
 
-public abstract partial class SharedBlobObserverSystem : EntitySystem
+public abstract partial class BlobObserverSystem : EntitySystem
 {
     [Dependency] private ActionBlockerSystem _blocker = default!;
+    [Dependency] private BlobCoreSystem _core = default!;
     [Dependency] private BlobFactorySystem _factory = default!;
     [Dependency] private BlobNodeSystem _node = default!;
     [Dependency] private EntityLookupSystem _lookup = default!;
     [Dependency] private SharedActionsSystem _action = default!;
-    [Dependency] private SharedBlobCoreSystem _core = default!;
     [Dependency] private SharedHandsSystem _hands = default!;
     [Dependency] private SharedMapSystem _map = default!;
     [Dependency] private SharedPopupSystem _popup = default!;

--- a/Content.Goobstation.Shared/Blob/SharedBlobResourceSystem.cs
+++ b/Content.Goobstation.Shared/Blob/SharedBlobResourceSystem.cs
@@ -5,9 +5,9 @@ using Content.Shared.Popups;
 
 namespace Content.Goobstation.Shared.Blob;
 
-public abstract partial class SharedBlobResourceSystem : EntitySystem
+public abstract partial class BlobResourceSystem : EntitySystem
 {
-    [Dependency] private SharedBlobCoreSystem _core = default!;
+    [Dependency] private BlobCoreSystem _core = default!;
     [Dependency] private SharedPopupSystem _popup = default!;
 
     [SubscribeLocalEvent]

--- a/Content.Trauma.Client/Sprite/SpriteVisibilitySystem.cs
+++ b/Content.Trauma.Client/Sprite/SpriteVisibilitySystem.cs
@@ -9,14 +9,9 @@ public sealed partial class SpriteVisibilitySystem : CommonSpriteVisibilitySyste
 {
     [Dependency] private SpriteSystem _sprite = default!;
     [Dependency] private EntityQuery<SpriteComponent> _spriteQuery = default!;
+    [Dependency] private EntityQuery<SpriteVisibilityComponent> _query = default!;
 
-    public override void Initialize()
-    {
-        base.Initialize();
-
-        SubscribeLocalEvent<SpriteVisibilityComponent, ComponentStartup>(OnStartup);
-    }
-
+    [SubscribeLocalEvent]
     private void OnStartup(Entity<SpriteVisibilityComponent> ent, ref ComponentStartup args)
     {
         if (!_spriteQuery.TryComp(ent, out var comp) || comp.Color.A >= 1f)
@@ -38,17 +33,22 @@ public sealed partial class SpriteVisibilitySystem : CommonSpriteVisibilitySyste
 
     private void AddVisibilityModifier(Entity<SpriteComponent> ent, string key, float modifier)
     {
+        modifier = MathF.Max(modifier, 0f);
+
         var comp = EnsureComp<SpriteVisibilityComponent>(ent);
-        comp.VisibilityModifiers[key] = MathF.Max(modifier, 0f);
+        if (comp.VisibilityModifiers.TryGetValue(key, out var old) && old == modifier)
+            return;
+
+        comp.VisibilityModifiers[key] = modifier;
         ReCalculateSpriteVisibility((ent, ent.Comp, comp));
     }
 
     private void RemoveVisibilityModifier(Entity<SpriteComponent?, SpriteVisibilityComponent?> ent, string key)
     {
-        if (!Resolve(ent, ref ent.Comp1))
+        if (!_spriteQuery.Resolve(ent, ref ent.Comp1))
             return;
 
-        if (!Resolve(ent, ref ent.Comp2, false))
+        if (!_query.Resolve(ent, ref ent.Comp2, false))
         {
             SetSpriteVisibility(ent!, 1f);
             return;
@@ -88,4 +88,7 @@ public sealed partial class SpriteVisibilitySystem : CommonSpriteVisibilitySyste
         var visibility = ent.Comp2.VisibilityModifiers.Values.Aggregate(1f, (x, y) => x * y);
         SetSpriteVisibility(ent, visibility);
     }
+
+    public float GetModifier(SpriteVisibilityComponent comp)
+        => comp.VisibilityModifiers.Values.Aggregate(1f, (x, y) => x * y);
 }

--- a/Content.Trauma.Client/Viewcone/Overlays/ViewconeSetAlphaOverlay.cs
+++ b/Content.Trauma.Client/Viewcone/Overlays/ViewconeSetAlphaOverlay.cs
@@ -30,6 +30,7 @@ public sealed partial class ViewconeSetAlphaOverlay : Overlay
 
     private readonly EntityQuery<HumanoidProfileComponent> _humanoidQuery;
     private readonly EntityQuery<SpriteComponent> _spriteQuery;
+    private readonly EntityQuery<ViewconeComponent> _query;
     private readonly EntityQuery<ViewconeOccludedComponent> _occludedQuery;
 
     public override OverlaySpace Space => OverlaySpace.WorldSpaceBelowEntities;
@@ -52,6 +53,7 @@ public sealed partial class ViewconeSetAlphaOverlay : Overlay
 
         _humanoidQuery = _ent.GetEntityQuery<HumanoidProfileComponent>();
         _spriteQuery = _ent.GetEntityQuery<SpriteComponent>();
+        _query = _ent.GetEntityQuery<ViewconeComponent>();
         _occludedQuery = _ent.GetEntityQuery<ViewconeOccludedComponent>();
     }
 
@@ -65,11 +67,14 @@ public sealed partial class ViewconeSetAlphaOverlay : Overlay
 
         // This is really stupid but there isn't another way to reverse an eye entity from just an IEye afaict
         // It's not really inefficient though. theres only at most a few of these inside PVS anyway
-        var enumerator = _ent.AllEntityQueryEnumerator<LerpingEyeComponent, EyeComponent, ViewconeComponent>();
-        while (enumerator.MoveNext(out var uid, out _, out var eye, out var viewcone))
+        var enumerator = _ent.AllEntityQueryEnumerator<LerpingEyeComponent, EyeComponent>();
+        while (enumerator.MoveNext(out var uid, out _, out var eye))
         {
             if (args.Viewport.Eye != eye.Eye)
                 continue;
+
+            if (!_query.TryComp(uid, out var viewcone))
+                return false;
 
             _nextEye = (uid, eye, viewcone);
             break;
@@ -80,10 +85,10 @@ public sealed partial class ViewconeSetAlphaOverlay : Overlay
 
     protected override void Draw(in OverlayDrawArgs args)
     {
-        if (_nextEye == null)
+        if (_nextEye is not { } nextEye)
             return;
 
-        var (ent, eye, cone) = _nextEye.Value;
+        var (ent, eye, cone) = nextEye;
 
         var eyeTransform = _ent.GetComponent<TransformComponent>(ent);
         var eyePos = _xform.GetWorldPosition(eyeTransform);
@@ -93,6 +98,7 @@ public sealed partial class ViewconeSetAlphaOverlay : Overlay
         // !! Thank You Bhijn God (TYBG) for 95% of the rest of this methods code !!
         // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
         var radConeAngle = MathHelper.DegreesToRadians(cone.CurrentConeAngle);
+        var enabled = cone.CurrentConeAngle < 360f; // dont have feather jank with full vision arc
         var halfAngle = radConeAngle * 0.5f;
         var radConeFeather = MathHelper.DegreesToRadians(cone.ConeFeather);
 
@@ -132,9 +138,13 @@ public sealed partial class ViewconeSetAlphaOverlay : Overlay
             var angleDist = Math.Abs(Angle.ShortestDistance(dist.ToWorldAngle(), eyeRot).Theta);
 
             // calculate opacity for the actual entity first
-            var angleAlpha = (float) Math.Clamp((angleDist - halfAngle) + (radConeFeather * 0.5f), 0f, radConeFeather) / radConeFeather;
-            var distAlpha = Math.Clamp((distLength - cone.ConeIgnoreRadius) + (cone.ConeIgnoreFeather * 0.5f), 0f, cone.ConeIgnoreFeather) / cone.ConeIgnoreFeather;
-            var targetAlpha = 1f - Math.Min(angleAlpha, distAlpha);
+            var targetAlpha = 1f;
+            if (enabled)
+            {
+                var angleAlpha = (float) Math.Clamp((angleDist - halfAngle) + (radConeFeather * 0.5f), 0f, radConeFeather) / radConeFeather;
+                var distAlpha = Math.Clamp((distLength - cone.ConeIgnoreRadius) + (cone.ConeIgnoreFeather * 0.5f), 0f, cone.ConeIgnoreFeather) / cone.ConeIgnoreFeather;
+                targetAlpha = 1f - Math.Min(angleAlpha, distAlpha);
+            }
 
             // simplified logic for effects that dont spawn memories or anything likely stealthed
             if (!comp.UseMemory || ((!sprite.Visible || sprite.Color.A < 0.4) && !_occludedQuery.HasComp(uid)))

--- a/Content.Trauma.Client/Viewcone/ViewconeOverlaySystem.cs
+++ b/Content.Trauma.Client/Viewcone/ViewconeOverlaySystem.cs
@@ -6,10 +6,10 @@ using Content.Shared.CCVar;
 using Content.Shared.MouseRotator;
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Movement.Pulling.Events;
+using Content.Trauma.Client.Sprite;
 using Content.Trauma.Client.Viewcone.Overlays;
 using Content.Trauma.Common.CCVar;
 using Content.Trauma.Common.Popups;
-using Content.Trauma.Common.Sprite;
 using Content.Trauma.Shared.Viewcone;
 using Content.Trauma.Shared.Viewcone.Components;
 using Robust.Client.Input;
@@ -35,7 +35,7 @@ public sealed partial class ViewconeOverlaySystem : EntitySystem
     [Dependency] private IOverlayManager _overlay = default!;
     [Dependency] private SharedTransformSystem _xform = default!;
     [Dependency] private ViewconeAngleSystem _angle = default!;
-    [Dependency] private CommonSpriteVisibilitySystem _spriteVis = default!;
+    [Dependency] private SpriteVisibilitySystem _spriteVis = default!;
     [Dependency] private EntityQuery<MouseRotatorComponent> _rotatorQuery = default!;
 
     private ViewconeConeOverlay _coneOverlay = default!;
@@ -53,20 +53,6 @@ public sealed partial class ViewconeOverlaySystem : EntitySystem
     public override void Initialize()
     {
         base.Initialize();
-
-        SubscribeLocalEvent<ViewconeComponent, ComponentInit>(OnInit);
-        SubscribeLocalEvent<ViewconeComponent, ComponentShutdown>(OnShutdown);
-        SubscribeLocalEvent<ViewconeComponent, ShowPopupAttemptEvent>(OnShowPopupAttempt);
-
-        SubscribeLocalEvent<ViewconeComponent, LocalPlayerAttachedEvent>(OnPlayerAttached);
-        SubscribeLocalEvent<ViewconeComponent, LocalPlayerDetachedEvent>(OnPlayerDetached);
-
-        SubscribeLocalEvent<ViewconeOccludableComponent, ComponentInit>(OnOccludableInit);
-        SubscribeLocalEvent<ViewconeOccludableComponent, ComponentShutdown>(OnOccludableShutdown);
-        SubscribeLocalEvent<ViewconeOccludableComponent, EntParentChangedMessage>(OnOccludableParentChanged);
-
-        SubscribeLocalEvent<PullableComponent, ViewconeOverrideEvent>(OnPullableOverride);
-        SubscribeLocalEvent<TailedEntitySegmentComponent, ViewconeOverrideEvent>(OnTailedOverride);
 
         _coneOverlay = new();
         _setAlphaOverlay = new();
@@ -182,6 +168,7 @@ public sealed partial class ViewconeOverlaySystem : EntitySystem
         return angleDist < MathHelper.DegreesToRadians(ent.Comp.CurrentConeAngle) * 0.5f;
     }
 
+    [SubscribeLocalEvent]
     private void OnPullableOverride(Entity<PullableComponent> ent, ref ViewconeOverrideEvent args)
     {
         if (ent.Comp.Puller != _player.LocalEntity)
@@ -190,6 +177,7 @@ public sealed partial class ViewconeOverlaySystem : EntitySystem
         args.Override = true;
     }
 
+    [SubscribeLocalEvent]
     private void OnTailedOverride(Entity<TailedEntitySegmentComponent> ent, ref ViewconeOverrideEvent args)
     {
         if (ent.Comp.Head != _player.LocalEntity)
@@ -198,27 +186,32 @@ public sealed partial class ViewconeOverlaySystem : EntitySystem
         args.Override = true;
     }
 
+    [SubscribeLocalEvent]
     private void OnPlayerAttached(Entity<ViewconeComponent> ent, ref LocalPlayerAttachedEvent args)
     {
         AddOverlays();
     }
 
+    [SubscribeLocalEvent]
     private void OnPlayerDetached(Entity<ViewconeComponent> ent, ref LocalPlayerDetachedEvent args)
     {
         RemoveOverlays();
     }
 
+    [SubscribeLocalEvent]
     private void OnInit(Entity<ViewconeComponent> ent, ref ComponentInit args)
     {
         if (ent.Owner == _player.LocalEntity)
             AddOverlays();
     }
 
+    [SubscribeLocalEvent]
     private void OnShowPopupAttempt(Entity<ViewconeComponent> ent, ref ShowPopupAttemptEvent args)
     {
         args.Cancelled |= !IsVisible(ent, args.ViewerPos, args.WorldPos);
     }
 
+    [SubscribeLocalEvent]
     private void OnShutdown(Entity<ViewconeComponent> ent, ref ComponentShutdown args)
     {
         if (ent.Owner == _player.LocalEntity)
@@ -244,35 +237,33 @@ public sealed partial class ViewconeOverlaySystem : EntitySystem
         _overlay.RemoveOverlay(_coneOverlay);
         _overlay.RemoveOverlay(_setAlphaOverlay);
 
-        // hide memories
+        // hide memories and reset everythings opacity
         var query = EntityQueryEnumerator<ViewconeOccludableComponent>();
-        while (query.MoveNext(out var comp))
+        while (query.MoveNext(out var uid, out var comp))
         {
             if (comp.Memory is { } memory && !TerminatingOrDeleted(memory))
                 SetAlpha(memory, 0f);
-        }
 
-        // reset everythings opacity
-        var query2 = EntityQueryEnumerator<ViewconeOccludedComponent>();
-        while (query2.MoveNext(out var uid, out var comp))
-        {
             SetAlpha(uid, 1f);
-            RemCompDeferred(uid, comp);
+            RemCompDeferred<ViewconeOccludedComponent>(uid);
         }
     }
 
+    [SubscribeLocalEvent]
     private void OnOccludableInit(Entity<ViewconeOccludableComponent> ent, ref ComponentInit args)
     {
         if (ent.Comp.Inverted)
             SetAlpha(ent, 0f); // wait for overlay to maybe show effects next frame
     }
 
+    [SubscribeLocalEvent]
     private void OnOccludableShutdown(Entity<ViewconeOccludableComponent> ent, ref ComponentShutdown args)
     {
         if (ent.Comp.Memory is { } memory && !TerminatingOrDeleted(memory))
             Del(memory);
     }
 
+    [SubscribeLocalEvent]
     private void OnOccludableParentChanged(Entity<ViewconeOccludableComponent> ent, ref EntParentChangedMessage args)
     {
         if (ent.Comp.Memory is not { } memory ||

--- a/Resources/Prototypes/_Goobstation/Blob/blob_mobs.yml
+++ b/Resources/Prototypes/_Goobstation/Blob/blob_mobs.yml
@@ -8,119 +8,115 @@
   parent: SimpleSpaceMobBase
   categories: [ HideSpawnMenu ]
   components:
-    - type: ZombieImmune
-    - type: TriggerOnMobstateChange
-      mobState:
-        - Dead
-    - type: SmokeOnTrigger
-      duration: 5
-      spreadAmount: 20
-      solution:
-        reagents:
-          - ReagentId: TearGas
-            Quantity: 3
-    - type: Damageable
-      damageModifierSet: BlobMob
-    - type: Injurable
-      damageContainer: Blob
-    - type: Clothing
-      quickEquip: false
-      sprite: _Goobstation/Blob/Mobs/blob_mobs.rsi
-      equippedPrefix: blobPod
-      slots:
-        - HEAD
-    - type: Tag
-      tags:
-      - HidesHair
-    - type: CollectiveMind
-      defaultChannel: Blobmind
-      channels:
-      - Blobmind
-    - type: IngestionBlocker
-    - type: IdentityBlocker
-    - type: BlobPod
-    - type: DoAfter
-    - type: Physics
-      bodyType: KinematicController
-    - type: InteractionOutline
-    - type: Actions
-    - type: Alerts
-    - type: InputMover
-    - type: Examiner
-    - type: MobMover
-    - type: HTN
-      rootTask:
-        task: BlobPodCompound
-      blackboard:
-        NavBlob: !type:Bool
-          true
-    - type: BlobMob
-    # - type: BlobSpeak
-    # Einstein Engines - Language begin
-    - type: LanguageSpeaker
-      speaks:
-      - Blob
-      understands:
-      - Blob
-    # Einstein Engines - Language end
-    - type: CombatMode
-    - type: NpcFactionMember
-      factions:
-        - Blob
-    - type: MeleeWeapon
-      hidden: true
-      soundHit:
-        path: /Audio/Effects/bite.ogg
-      angle: 0
-      animation: WeaponArcSmash
-      damage:
-        types:
-          Blunt: 8
-    - type: DamageStateVisuals
-      states:
-        Alive:
-          Base: blobpod
-    - type: Fixtures
-      fixtures:
-        fix1:
-          shape:
-            !type:PhysShapeCircle
-            radius: 0.25
-          density: 10
-          mask:
-            - FlyingBlobMobMask
-          layer:
-            - FlyingBlobMobLayer
-    - type: Destructible
-      thresholds:
-        - trigger:
-            !type:DamageTrigger
-            damage: 50
-          behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
-    - type: MobThresholds
-      thresholds:
-        0: Alive
-        20: Dead
-    - type: MovementSpeedModifier
-      baseWalkSpeed: 3
-      baseSprintSpeed: 4
-    - type: Sprite
-      drawdepth: Mobs
-      sprite: _Goobstation/Blob/Mobs/blob_mobs.rsi
-      state: blobpod
-    - type: GuideHelp
-      guides:
-      - Blob
-    - type: MovementIgnoreGravity
-    - type: Bloodstream
-      maxBleedAmount: 0 # no bleeding
-      bloodReferenceSolution:
-        reagents:
-        - ReagentId: Blood
-          Quantity: 50
-      bleedReductionAmount: 30
+  - type: ZombieImmune
+  - type: TriggerOnMobstateChange
+    mobState:
+    - Dead
+  - type: SmokeOnTrigger
+    duration: 5
+    spreadAmount: 20
+    solution:
+      reagents:
+      - ReagentId: TearGas
+        Quantity: 3
+  - type: Damageable
+    damageModifierSet: BlobMob
+  - type: Injurable
+    damageContainer: Blob
+  - type: Clothing
+    quickEquip: false
+    sprite: _Goobstation/Blob/Mobs/blob_mobs.rsi
+    equippedPrefix: blobPod
+    slots:
+    - HEAD
+  - type: Tag
+    tags:
+    - HidesHair
+  - type: CollectiveMind
+    defaultChannel: Blobmind
+    channels:
+    - Blobmind
+  - type: IngestionBlocker
+  - type: IdentityBlocker
+  - type: BlobPod
+  - type: DoAfter
+  - type: Physics
+    bodyType: KinematicController
+  - type: InteractionOutline
+  - type: Actions
+  - type: Alerts
+  - type: InputMover
+  - type: Examiner
+  - type: MobMover
+  - type: HTN
+    rootTask:
+      task: BlobPodCompound
+    blackboard:
+      NavBlob: !type:Bool
+        true
+  - type: BlobMob
+  - type: LanguageSpeaker
+    speaks:
+    - Blob
+    understands:
+    - Blob
+  - type: CombatMode
+  - type: NpcFactionMember
+    factions:
+    - Blob
+  - type: MeleeWeapon
+    hidden: true
+    soundHit:
+      path: /Audio/Effects/bite.ogg
+    angle: 0
+    animation: WeaponArcSmash
+    damage:
+      types:
+        Blunt: 8
+  - type: DamageStateVisuals
+    states:
+      Alive:
+        Base: blobpod
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.25
+        density: 10
+        mask:
+        - FlyingBlobMobMask
+        layer:
+        - FlyingBlobMobLayer
+  - type: Destructible
+    thresholds:
+    - trigger: !type:DamageTrigger
+        damage: 50
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+  - type: MobThresholds
+    thresholds:
+      0: Alive
+      20: Dead
+  - type: MovementSpeedModifier
+    baseWalkSpeed: 3
+    baseSprintSpeed: 4
+  - type: Sprite
+    drawdepth: Mobs
+    sprite: _Goobstation/Blob/Mobs/blob_mobs.rsi
+    state: blobpod
+  - type: GuideHelp
+    guides:
+    - Blob
+  - type: MovementIgnoreGravity
+  - type: Bloodstream
+    maxBleedAmount: 0 # no bleeding
+    bloodReferenceSolution:
+      reagents:
+      - ReagentId: Blood
+        Quantity: 50
+    bleedReductionAmount: 30
 
 # Blobbernaut
 - type: entity
@@ -130,113 +126,110 @@
   description: Juggernaut, but blob! when the station crew shows full hatred of you, with the help of such strong men you can organize a blitzkriek if you tell them the plan in advance.
   categories: [ HideSpawnMenu ]
   components:
-    - type: ZombieImmune
-    - type: Damageable
-      damageModifierSet: BlobBlobbernaut
-    - type: Injurable
-      damageContainer: Blob
-    - type: Tag
-      tags:
-      - Blobbernaut
-    - type: CollectiveMind
-      defaultChannel: Blobmind
-      channels:
-      - Blobmind
-    - type: GhostRole
-      name: ghost-role-information-blobbernaut-name
-      description: ghost-role-information-blobbernaut-description
-      rules: You are an antagonist, defend your blob core!
-      mindRoles:
-      - MindRoleGhostRoleTeamAntagonist
-      raffle:
-        settings: short
-    - type: GhostTakeoverAvailable
-    - type: Blobbernaut
-    - type: Physics
-    - type: InputMover
-    - type: MobMover
-    - type: BlobMob
-    # - type: BlobSpeak
-    # Einstein Engines - Language begin
-    - type: LanguageSpeaker
-      speaks:
+  - type: ZombieImmune
+  - type: Damageable
+    damageModifierSet: BlobBlobbernaut
+  - type: Injurable
+    damageContainer: Blob
+  - type: Tag
+    tags:
+    - Blobbernaut
+  - type: CollectiveMind
+    defaultChannel: Blobmind
+    channels:
+    - Blobmind
+  - type: GhostRole
+    name: ghost-role-information-blobbernaut-name
+    description: ghost-role-information-blobbernaut-description
+    rules: You are an antagonist, defend your blob core!
+    mindRoles:
+    - MindRoleGhostRoleTeamAntagonist
+    raffle:
+      settings: short
+  - type: GhostTakeoverAvailable
+  - type: Blobbernaut
+  - type: Physics
+  - type: InputMover
+  - type: MobMover
+  - type: BlobMob
+  - type: LanguageSpeaker
+    speaks:
+    - Blob
+    understands:
+    - Blob
+  - type: CombatMode
+  - type: HTN
+    rootTask:
+      task: SimpleHostileCompound
+    blackboard:
+      NavSmash: !type:Bool
+        true
+  - type: NpcFactionMember
+    factions:
       - Blob
-      understands:
-      - Blob
-    # Einstein Engines - Language end
-    - type: CombatMode
-    - type: HTN
-      rootTask:
-        task: SimpleHostileCompound
-      blackboard:
-        NavSmash: !type:Bool
-          true
-    - type: NpcFactionMember
-      factions:
-        - Blob
-    - type: MobState
-      allowedStates:
-        - Alive
-        - Dead
-    - type: MeleeWeapon
-      hidden: true
-      soundHit:
-        path: /Audio/Effects/bite.ogg
-      angle: 0
-      animation: WeaponArcSmash
-      damage:
-        types:
-          Blunt: 15
-          Structural: 50
-    - type: DamageStateVisuals
-      states:
-        Alive:
-          Base: blobbernaut
-        Dead:
-          Base: blobbernaut_dead
-    - type: Fixtures
-      fixtures:
-        fix1:
-          shape:
-            !type:PhysShapeCircle
-            radius: 0.35
-          density: 200
-          mask:
-            - BlobMobMask
-          layer:
-            - BlobMobLayer
-    - type: MobThresholds
-      thresholds:
-        0: Alive
-        200: Dead
-    - type: MovementSpeedModifier
-      baseWalkSpeed: 2.5
-      baseSprintSpeed: 3
-    - type: Sprite
-      sprite: _Goobstation/Blob/Mobs/blob_mobs.rsi
-      drawdepth: Mobs
-      layers:
-        - map: [ "enum.DamageStateVisualLayers.Base" ]
-          state: blobbernaut
-        - map: [ "enum.DamageStateVisualLayers.BaseUnshaded" ]
-          state: nautdamage
-          shader: unshaded
-    - type: AnimatedEmotes
-      flexState: blobbernaut_flex
-      flexDefaultState: blobbernaut
-      flexDamageState: blobbernaut_flex_damage
-      flexDefaultDamageState: nautdamage
-    - type: GuideHelp
-      guides:
-      - Blob
-    - type: Bloodstream
-      maxBleedAmount: 0 # no bleeding
-      bloodReferenceSolution:
-        reagents:
-        - ReagentId: Blood
-          Quantity: 300
-      bleedReductionAmount: 30
-    - type: MovementIgnoreGravity
+  - type: MobState
+    allowedStates:
+      - Alive
+      - Dead
+  - type: MeleeWeapon
+    hidden: true
+    soundHit:
+      path: /Audio/Effects/bite.ogg
+    angle: 0
+    animation: WeaponArcSmash
+    damage:
+      types:
+        Blunt: 15
+        Structural: 50
+  - type: DamageStateVisuals
+    states:
+      Alive:
+        Base: blobbernaut
+      Dead:
+        Base: blobbernaut_dead
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.35
+        density: 200
+        mask:
+          - BlobMobMask
+        layer:
+          - BlobMobLayer
+  - type: MobThresholds
+    thresholds:
+      0: Alive
+      200: Dead
+  - type: MovementSpeedModifier
+    baseWalkSpeed: 2.5
+    baseSprintSpeed: 3
+  - type: Sprite
+    sprite: _Goobstation/Blob/Mobs/blob_mobs.rsi
+    drawdepth: Mobs
+    layers:
+      - map: [ "enum.DamageStateVisualLayers.Base" ]
+        state: blobbernaut
+      - map: [ "enum.DamageStateVisualLayers.BaseUnshaded" ]
+        state: nautdamage
+        shader: unshaded
+  - type: AnimatedEmotes
+    flexState: blobbernaut_flex
+    flexDefaultState: blobbernaut
+    flexDamageState: blobbernaut_flex_damage
+    flexDefaultDamageState: nautdamage
+  - type: GuideHelp
+    guides:
+    - Blob
+  - type: Bloodstream
+    maxBleedAmount: 0 # no bleeding
+    bloodReferenceSolution:
+      reagents:
+      - ReagentId: Blood
+        Quantity: 300
+    bleedReductionAmount: 30
+  - type: MovementIgnoreGravity
 
 # Observer
 - type: entity
@@ -245,70 +238,68 @@
   categories: [ HideSpawnMenu ]
   save: false
   components:
-    - type: UserInterface
-      interfaces:
-        enum.BlobChemSwapUiKey.Key:
-          type: BlobChemSwapBoundUserInterface
-    - type: Actions
-    - type: Alerts
-    # Einstein Engines - Language begin
-    - type: LanguageSpeaker
-      currentLanguage: Blob
-      speaks:
-      - Blob
-      understands:
-      - Blob
-      - Xeno
-      - TauCetiBasic
-    # Einstein Engines - Language end
-    - type: Hands
-      showInHands: true
-    - type: BlobObserver
-    - type: Visibility
-      layer: 2
-    - type: ContentEye
-    - type: MindContainer
-    - type: Clickable
-    - type: InteractionOutline
-    - type: Physics
-      bodyType: KinematicController
-      fixedRotation: true
-    - type: GhostRole
-      name: ghost-role-information-blob-name
-      description: ghost-role-information-blob-description
-      rules: You are an antagonist, destroy the station!
-      mindRoles:
-      - MindRoleGhostRoleSoloAntagonist
-    - type: GhostTakeoverAvailable
-    - type: Fixtures
-      fixtures:
-        fix1:
-          shape:
-            !type:PhysShapeCircle
-            radius: 0.35
-          density: 15
-    - type: InputMover
-    - type: Appearance
-    - type: Eye
-      drawFov: false
-    - type: Input
-      context: "ghost"
-    - type: Examiner
-      skipChecks: true
-    - type: Sprite
-      sprite: _Goobstation/Blob/Mobs/blob_mobs.rsi
-      color: "#fc8403"
-      state: marker
-      noRot: true
-      drawdepth: Ghosts
-    - type: MovementSpeedModifier
-      baseSprintSpeed: 8
-      baseWalkSpeed: 15
-    - type: MovementIgnoreGravity
-    - type: Tag
-      tags:
-      - BypassInteractionRangeChecks
-    - type: CollectiveMind
-      defaultChannel: Blobmind
-      channels:
-      - Blobmind
+  - type: UserInterface
+    interfaces:
+      enum.BlobChemSwapUiKey.Key:
+        type: BlobChemSwapBoundUserInterface
+  - type: Actions
+  - type: Alerts
+  - type: LanguageSpeaker
+    currentLanguage: Blob
+    speaks:
+    - Blob
+    understands:
+    - Blob
+    - Xeno
+    - TauCetiBasic
+  - type: Hands
+    showInHands: true
+  - type: BlobObserver
+  - type: Visibility
+    layer: 2
+  - type: ContentEye
+  - type: MindContainer
+  - type: Clickable
+  - type: InteractionOutline
+  - type: Physics
+    bodyType: KinematicController
+    fixedRotation: true
+  - type: GhostRole
+    name: ghost-role-information-blob-name
+    description: ghost-role-information-blob-description
+    rules: You are an antagonist, destroy the station!
+    mindRoles:
+    - MindRoleGhostRoleSoloAntagonist
+  - type: GhostTakeoverAvailable
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.35
+        density: 15
+  - type: InputMover
+  - type: Appearance
+  - type: Eye
+    drawFov: false
+  - type: Input
+    context: "ghost"
+  - type: Examiner
+    skipChecks: true
+  - type: Sprite
+    sprite: _Goobstation/Blob/Mobs/blob_mobs.rsi
+    color: "#fc8403"
+    state: marker
+    noRot: true
+    drawdepth: Ghosts
+  - type: MovementSpeedModifier
+    baseSprintSpeed: 8
+    baseWalkSpeed: 15
+  - type: MovementIgnoreGravity
+  - type: Tag
+    tags:
+    - BypassInteractionRangeChecks
+  - type: CollectiveMind
+    defaultChannel: Blobmind
+    channels:
+    - Blobmind

--- a/Resources/Prototypes/_Goobstation/Blob/blob_tiles.yml
+++ b/Resources/Prototypes/_Goobstation/Blob/blob_tiles.yml
@@ -1,27 +1,27 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 - type: entity
+  parent: MarkerBase
   id: SpawnPointGhostBlob
   name: Blob
-  suffix: DONTMAP, spawner
-  parent: MarkerBase
+  categories: [DoNotMap]
   components:
-    - type: GhostRoleMobSpawner
-      prototype: CoreBlobTile
-    - type: GhostRole
-      name: ghost-role-information-blob-name
-      description: ghost-role-information-blob-description
-      rules: You are an antagonist, destroy the station!
-      mindRoles:
-      - MindRoleGhostRoleSoloAntagonist
-      raffle:
-        settings: default
-    - type: Sprite
-      sprite: Markers/jobs.rsi
-      layers:
-        - state: green
-        - sprite: _Goobstation/Blob/Mobs/blob.rsi
-          state: blob_nuke_overlay
+  - type: GhostRoleMobSpawner
+    prototype: CoreBlobTile
+  - type: GhostRole
+    name: ghost-role-information-blob-name
+    description: ghost-role-information-blob-description
+    rules: You are an antagonist, destroy the station!
+    mindRoles:
+    - MindRoleGhostRoleSoloAntagonist
+    raffle:
+      settings: default
+  - type: Sprite
+    sprite: Markers/jobs.rsi
+    layers:
+    - state: green
+    - sprite: _Goobstation/Blob/Mobs/blob.rsi
+      state: blob_nuke_overlay
 
 - type: entity
   parent: BaseBlob

--- a/Resources/Prototypes/_Trauma/Blob/chems.yml
+++ b/Resources/Prototypes/_Trauma/Blob/chems.yml
@@ -72,12 +72,12 @@
   - !type:Emp
     probability: 0.2
     rangeModifier: 3
-    energyConsumption: 50
+    energyConsumption: 2500
     duration: 3
   destructionEffects:
   - !type:Emp
     rangeModifier: 3
-    energyConsumption: 50
+    energyConsumption: 1500
     duration: 3
   damageModifiers: ElectromagneticWebBlob
 

--- a/Resources/Prototypes/_Trauma/Blob/tiles.yml
+++ b/Resources/Prototypes/_Trauma/Blob/tiles.yml
@@ -39,12 +39,14 @@
   name: "Strong Blob"
   cost: 15
   entity: StrongBlobTile
+  upgrade: Reflective
 
 - type: blobTile
   id: Normal
   name: "Blob Tile"
   cost: 6
   entity: NormalBlobTile
+  upgrade: Strong
 
 # TODO
 #- type: blobTile


### PR DESCRIPTION
fixes #4451 and some other issues

:cl:
- tweak: Buffed blob electromagnetic web EMP to actually take away more than 2% charge.
- fix: Fixed blob tiles not having strong/reflective upgrades.
- fix: Fixed mobs outside of vision being invisible if you became something without a vision cone e.g. blob.
- fix: Fixed blob node prediction being janky.