### PR TITLE
partially fix stealth shader order

### DIFF
--- a/Content.Client/Stealth/StealthSystem.cs
+++ b/Content.Client/Stealth/StealthSystem.cs
@@ -49,7 +49,7 @@ public sealed partial class StealthSystem : SharedStealthSystem
             {
                 GetScreenTexture = true,
                 RaiseShaderEvent = true,
-                Before = ContentPostShaderIds.BeforeOutlines,
+                After = ContentPostShaderIds.BeforeOutlines, // Trauma - run after outlines instead of before
             });
         }
         else

--- a/Content.Shared/Clothing/EntitySystems/ToggleableClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/ToggleableClothingSystem.cs
@@ -439,8 +439,7 @@ public sealed partial class ToggleableClothingSystem : EntitySystem
 
         if (toggleableComp.Container is {} container && !TerminatingOrDeleted(container.Owner))
         {
-            var succ = _containerSystem.Insert(attached.Owner, container, force: true);
-            Log.Debug($"Trying to insert {ToPrettyString(attached)} into {ToPrettyString(container.Owner)}: {succ}");
+            _containerSystem.Insert(attached.Owner, container, force: true);
         }
         // </Trauma>
     }


### PR DESCRIPTION
swapped order so now it cant doxx you via hover unless you have displacements i.e. dwarf

## Media

dwarf still fucked others are actually invisible when hovered

<img width="70" height="87" alt="13:53:06" src="https://github.com/user-attachments/assets/140fe6e9-1840-425b-bf33-98e2ee7823d2" />
<img width="67" height="74" alt="13:53:14" src="https://github.com/user-attachments/assets/f36c2f2e-7163-4e43-ac07-4836b985dc21" />

:cl:
- fix: Fixed being able to doxx invisible things by hovering them with your mouse, except for dwarves diona and vox.