### PR TITLE
add tool lock for interactor

### DIFF
--- a/Content.Goobstation.Shared/Factory/InteractorComponent.cs
+++ b/Content.Goobstation.Shared/Factory/InteractorComponent.cs
@@ -31,6 +31,12 @@ public sealed partial class InteractorComponent : Component
     public ProtoId<SinkPortPrototype> HarmModePort = "HarmMode";
 
     /// <summary>
+    /// Signal port to toggle or enable/disable <see cref="Locked"/>.
+    /// </summary>
+    [DataField]
+    public ProtoId<SinkPortPrototype> LockedPort = "ToolLocked";
+
+    /// <summary>
     /// Whether to use alt interaction, i.e. use the highest priority verb on the target entity.
     /// </summary>
     [DataField, AutoNetworkedField]
@@ -47,6 +53,13 @@ public sealed partial class InteractorComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public bool HarmMode;
+
+    /// <summary>
+    /// Prevents picking up or dropping its item in any way while locked.
+    /// Useful for interacting with storage and you don't want to insert the item.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool Locked;
 }
 
 [Serializable, NetSerializable]

--- a/Content.Goobstation.Shared/Factory/SharedInteractorSystem.cs
+++ b/Content.Goobstation.Shared/Factory/SharedInteractorSystem.cs
@@ -54,21 +54,21 @@ public abstract partial class SharedInteractorSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<InteractorComponent, ComponentInit>(OnInit);
-        SubscribeLocalEvent<InteractorComponent, ExaminedEvent>(OnExamined);
-        SubscribeLocalEvent<InteractorComponent, GetVerbsEvent<AlternativeVerb>>(OnGetVerbs);
-        SubscribeLocalEvent<InteractorComponent, DoAfterEndedEvent>(OnDoAfterEnded);
-        SubscribeLocalEvent<InteractorComponent, SignalReceivedEvent>(OnSignalReceived);
         // hand visuals
         SubscribeLocalEvent<InteractorComponent, EntInsertedIntoContainerMessage>(OnItemModified);
         SubscribeLocalEvent<InteractorComponent, EntRemovedFromContainerMessage>(OnItemModified);
+        // locking
+        SubscribeLocalEvent<InteractorComponent, ContainerIsInsertingAttemptEvent>(OnItemModifyAttempt);
+        SubscribeLocalEvent<InteractorComponent, ContainerIsRemovingAttemptEvent>(OnItemModifyAttempt);
     }
 
+    [SubscribeLocalEvent]
     private void OnInit(Entity<InteractorComponent> ent, ref ComponentInit args)
     {
         UpdateAppearance(ent);
     }
 
+    [SubscribeLocalEvent]
     private void OnExamined(Entity<InteractorComponent> ent, ref ExaminedEvent args)
     {
         if (!args.IsInDetailsRange)
@@ -79,6 +79,7 @@ public abstract partial class SharedInteractorSystem : EntitySystem
             : Loc.GetString("robotic-arm-examine-no-filter"));
     }
 
+    [SubscribeLocalEvent]
     private void OnGetVerbs(Entity<InteractorComponent> ent, ref GetVerbsEvent<AlternativeVerb> args)
     {
         if (!args.CanAccess || !args.CanInteract || !args.CanComplexInteract)
@@ -91,7 +92,8 @@ public abstract partial class SharedInteractorSystem : EntitySystem
         (string, Toggle)[] options = [
             ("alt-interact", () => SetAltInteract(ent, !ent.Comp.AltInteract)),
             ("use-in-hand", () => SetUseInHand(ent, !ent.Comp.UseInHand)),
-            ("harm-mode", () => SetHarmMode(ent, !ent.Comp.HarmMode))
+            ("harm-mode", () => SetHarmMode(ent, !ent.Comp.HarmMode)),
+            ("locked", () => SetLocked(ent, !ent.Comp.Locked))
         ];
         foreach (var (id, toggle) in options)
         {
@@ -118,6 +120,18 @@ public abstract partial class SharedInteractorSystem : EntitySystem
         UpdateAppearance(ent);
     }
 
+    private void OnItemModifyAttempt<T>(Entity<InteractorComponent> ent, ref T args) where T: ContainerAttemptEventBase
+    {
+        if (!ent.Comp.Locked ||
+            _timing.ApplyingState ||
+            TerminatingOrDeleted(ent) ||
+            args.Container.ID != ent.Comp.ToolContainerId)
+            return;
+
+        args.Cancel();
+    }
+
+    [SubscribeLocalEvent]
     private void OnDoAfterEnded(Entity<InteractorComponent> ent, ref DoAfterEndedEvent args)
     {
         UpdateToolAppearance(ent);
@@ -130,6 +144,7 @@ public abstract partial class SharedInteractorSystem : EntitySystem
             Machine.Completed(ent.Owner);
     }
 
+    [SubscribeLocalEvent]
     private void OnSignalReceived(Entity<InteractorComponent> ent, ref SignalReceivedEvent args)
     {
         var state = SignalState.Momentary;
@@ -141,6 +156,8 @@ public abstract partial class SharedInteractorSystem : EntitySystem
             current = ent.Comp.UseInHand;
         else if (args.Port == ent.Comp.HarmModePort)
             current = ent.Comp.HarmMode;
+        else if (args.Port == ent.Comp.LockedPort)
+            current = ent.Comp.Locked;
         else
             return;
 
@@ -158,6 +175,8 @@ public abstract partial class SharedInteractorSystem : EntitySystem
             SetUseInHand(ent, value);
         else if (args.Port == ent.Comp.HarmModePort)
             SetHarmMode(ent, value);
+        else if (args.Port == ent.Comp.LockedPort)
+            SetLocked(ent, value);
     }
 
     public bool IsValidTarget(Entity<InteractorComponent> ent, EntityUid target)
@@ -257,14 +276,27 @@ public abstract partial class SharedInteractorSystem : EntitySystem
     /// <summary>
     /// Set <see cref="InteractorComponent.HarmMode"> and dirty it.
     /// </summary>
-    public bool SetHarmMode(Entity<InteractorComponent> ent, bool use)
+    public bool SetHarmMode(Entity<InteractorComponent> ent, bool harm)
     {
-        if (ent.Comp.HarmMode == use)
-            return use;
+        if (ent.Comp.HarmMode == harm)
+            return harm;
 
-        ent.Comp.HarmMode = use;
+        ent.Comp.HarmMode = harm;
         Dirty(ent);
-        return use;
+        return harm;
+    }
+
+    /// <summary>
+    /// Set <see cref="InteractorComponent.Locked"> and dirty it.
+    /// </summary>
+    public bool SetLocked(Entity<InteractorComponent> ent, bool locked)
+    {
+        if (ent.Comp.Locked == locked)
+            return locked;
+
+        ent.Comp.Locked = locked;
+        Dirty(ent);
+        return locked;
     }
 
     public EntityCoordinates TargetsPosition(EntityUid uid)

--- a/Content.Goobstation.Shared/Factory/SharedInteractorSystem.cs
+++ b/Content.Goobstation.Shared/Factory/SharedInteractorSystem.cs
@@ -20,6 +20,7 @@ using Robust.Shared.Containers;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Physics.Components;
+using Robust.Shared.Timing;
 
 namespace Content.Goobstation.Shared.Factory;
 
@@ -30,6 +31,7 @@ public abstract partial class SharedInteractorSystem : EntitySystem
     [Dependency] private AutomationSystem _automation = default!;
     [Dependency] private AutomationFilterSystem _filter = default!;
     [Dependency] private EntityLookupSystem _lookup = default!;
+    [Dependency] private IGameTiming _timing = default!;
     [Dependency] private SharedAppearanceSystem _appearance = default!;
     [Dependency] private SharedInteractionSystem _interaction = default!;
     [Dependency] private SharedHandsSystem _hands = default!;

--- a/Resources/Locale/en-US/_Goobstation/machines/automation.ftl
+++ b/Resources/Locale/en-US/_Goobstation/machines/automation.ftl
@@ -75,8 +75,8 @@ signal-port-description-fax-copy = Signal port to copy a fax machine's paper.
 signal-port-name-machine-start = Start
 signal-port-description-machine-start = Signal port to start a machine once.
 
-signal-port-name-machine-autostart = Auto Start
-signal-port-description-machine-autostart = Signal port to control starting after completing automatically.
+signal-port-name-machine-repeating = Repeating
+signal-port-description-machine-repeating = Signal port to control starting after completing automatically.
 
 signal-port-name-machine-started = Started
 signal-port-description-machine-started = Signal port that gets pulsed after a machine starts.

--- a/Resources/Locale/en-US/_Trauma/factory/interactor.ftl
+++ b/Resources/Locale/en-US/_Trauma/factory/interactor.ftl
@@ -1,0 +1,5 @@
+interactor-verb-toggle-locked = Toggle Tool Lock
+interactor-verb-toggled-locked = {$enabled ->
+    [true]Locked
+    *[false]Unlocked
+} the tool slot.

--- a/Resources/Locale/en-US/_Trauma/machines/interactor.ftl
+++ b/Resources/Locale/en-US/_Trauma/machines/interactor.ftl
@@ -1,0 +1,2 @@
+signal-port-name-tool-locked = Tool Locked
+signal-port-description-tool-locked = Signal port to toggle the tool lock, or set it to a HIGH/LOW value. Prevents the tool being dropped or picked up by any means.

--- a/Resources/Prototypes/_Goobstation/DeviceLink/sink_ports.yml
+++ b/Resources/Prototypes/_Goobstation/DeviceLink/sink_ports.yml
@@ -88,8 +88,8 @@
 
 - type: sinkPort
   id: AutoStart
-  name: signal-port-name-machine-autostart
-  description: signal-port-description-machine-autostart
+  name: signal-port-name-machine-repeating
+  description: signal-port-description-machine-repeating
 
 # Interactor
 

--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/interactor.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/interactor.yml
@@ -113,6 +113,7 @@
     - AltInteract
     - UseInHand
     - HarmMode
+    - ToolLocked
   - type: DeviceLinkSource
     ports:
     - Started

--- a/Resources/Prototypes/_Trauma/DeviceLink/sink_ports.yml
+++ b/Resources/Prototypes/_Trauma/DeviceLink/sink_ports.yml
@@ -65,3 +65,10 @@
   id: Text
   name: signal-port-name-text
   description: signal-port-description-text
+
+# Interactor
+
+- type: sinkPort
+  id: ToolLocked
+  name: signal-port-name-tool-locked
+  description: signal-port-description-tool-locked


### PR DESCRIPTION
resolves #4470

<img width="233" height="186" alt="14:37:22" src="https://github.com/user-attachments/assets/332fb125-5fc5-47b0-b7fb-1061ae1f5880" />

:cl:
- tweak: Interactors now have a tool lock mode that prevents its tool being picked up or dropped.
- tweak: Interactor/constructor's auto start port is now called repeating to be less confusing.