### PR TITLE
fix ore bag not having a toggle

### DIFF
--- a/Resources/Prototypes/_Trauma/Partials/Entities/Objects/Specific/Salvage/ore_bag.yml
+++ b/Resources/Prototypes/_Trauma/Partials/Entities/Objects/Specific/Salvage/ore_bag.yml
@@ -15,6 +15,12 @@
         enum.ToggleableVisuals.Layer:
           True: { state: orebag_on }
           False: { state: orebag_off }
+  - type: ItemToggle
+    soundActivate: &sound
+      collection: sparks
+      params:
+        variation: 0.250
+    soundDeactivate: *sound
   - type: Item
     size: Huge # lets it fit in conscription bag
     inhandVisuals:


### PR DESCRIPTION
fixes #4463

it still worked you just couldnt turn it off

:cl:
- fix: Fixed not being able to turn off the magnet of ore bags.