### PR TITLE
slop crusher changes

### DIFF
--- a/Resources/Prototypes/_Lavaland/Entities/Structures/Storage/Crates/necropolis.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Structures/Storage/Crates/necropolis.yml
@@ -30,7 +30,6 @@
     - id: ClothingOuterArmorCult
     - id: LavalandVampirismCrystal
     # TODO add more interesting obtain methods for crusher upgrades (from megafauna, ruins, etc.)
-    - id: CrusherUpgradeMainRudeBuster
 
     - !type:NestedSelector
       weight: 2

--- a/Resources/Prototypes/_Lavaland/Recipes/Construction/upgrades.yml
+++ b/Resources/Prototypes/_Lavaland/Recipes/Construction/upgrades.yml
@@ -7,7 +7,7 @@
   targetNode: crystal
   objectType: Item
   theory:
-    WeaponsKnowledge: 2
+    WeaponsKnowledge: 1
 
 - type: construction
   id: CrusherUpgradeLavaCrystalConstruction
@@ -16,7 +16,7 @@
   targetNode: crystal
   objectType: Item
   theory:
-    WeaponsKnowledge: 2
+    WeaponsKnowledge: 1
 
 - type: construction
   id: CrusherUpgradeIceCrystalConstruction
@@ -25,4 +25,4 @@
   targetNode: crystal
   objectType: Item
   theory:
-    WeaponsKnowledge: 2
+    WeaponsKnowledge: 1


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->
Removed rude buster from necropolis chest and lowered skill requirement for crafting salvage crusher upgrades 
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
removed rude buster from necropolis chest, it isnt interesting or special enough to feel like it deserves its spot here it can still be found where other crushers and crusher upgrades are found

Skill requirement lowered for crusher upgrades because I never see anyone make them, and it's a pain finding someone with advanced weapon crafting knowledge. The hard part of trying to craft the upgrade should be finding 5 of the same watchers not finding a dwarf on station.
## Test plan

Gave myself crafting database skillchip and the required materials. Crafted then inserted the upgrade into a crusher to see works like expected.

Spawned necropolis crates and no longer get rude buster from it.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- remove: Rude buster upgrade from necropolis chest drops
- tweak: Lowered crafting skill requirements on crusher upgrades

