### PR TITLE
Double Bladed Energy Sword Nerfs

### DIFF
--- a/Resources/Prototypes/_Trauma/Entities/StatusEffects/combat.yml
+++ b/Resources/Prototypes/_Trauma/Entities/StatusEffects/combat.yml
@@ -22,8 +22,8 @@
   name: flip and dodge
   components:
   - type: MovementModStatusEffect
-    sprintSpeedModifier: 1.2
-    walkSpeedModifier: 1.2
+    sprintSpeedModifier: 1.1
+    walkSpeedModifier: 1.1
 
 - type: entity
   parent: StatusEffectBase

--- a/Resources/Prototypes/_Trauma/Partials/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/_Trauma/Partials/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -1,0 +1,13 @@
+﻿- type: entity
+  id: EnergySwordDoubleBase
+  components:
+  - type: Parry
+    reflectExhaustionCost: 0.125
+  - type: ItemToggleMeleeWeapon
+    activatedDamage:
+      types:
+        Slash: 13
+        Heat: 13
+      woundSeverityMultipliers:
+        Slash: 2
+        Heat: 2

--- a/Resources/Prototypes/_Trauma/Partials/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/_Trauma/Partials/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -1,4 +1,6 @@
-﻿- type: entity
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+- type: entity
   id: EnergySwordDoubleBase
   components:
   - type: Parry


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->
Reduced the walkspeed/sprint speed you got from landing m1's with double bladed energy sword
Reduced the damage from 15 slash, 15 heat to 13 slash, 13 heat (With relevant skill chip you do 30 damage per hit instead of 35)
Reduced the limb severity multiplier from 4x to 2x 
Made it so double energy sword has 2x less energy reflects

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
These were changed so double energy sword isn't as oppressive as it is so you can actually shoot it now and you now have a proper chance of fighting them in melee combat instead of having to rely on disarming the double energy sword to not risk dying instantly

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Went ingame and inspected the item tooltip made sure all the relevant changes were included

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="376" height="222" alt="Screenshot 2026-09-07 214548" src="https://github.com/user-attachments/assets/82808686-548a-4932-a02d-32ccead4a340" />
<img width="377" height="317" alt="Screenshot 2026-09-07 214259" src="https://github.com/user-attachments/assets/150d1ed3-8327-4c3c-910a-8075c8695dbb" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Wizard25671
- tweak: Double-bladed energy sword now only has 8 total reflects instead of 16
- tweak: Double-bladed energy sword now only gives +10% speed for landing a light attack on someone
- tweak: Double-bladed energy sword now does 13 slash, 13 heat which is 30 damage total if you include the skill chip
- tweak: Double-bladed energy sword now only has 2x limb severity multiplier for heat and slash damage
