### PR TITLE
buff zombie prying ability 5x

### DIFF
--- a/Content.Server/Zombies/ZombieSystem.Transform.cs
+++ b/Content.Server/Zombies/ZombieSystem.Transform.cs
@@ -245,7 +245,7 @@ public sealed partial class ZombieSystem
 
             // humanoid zombies get to pry open doors and shit
             var pryComp = EnsureComp<PryingComponent>(target);
-            pryComp.SpeedModifier = 0.75f;
+            pryComp.SpeedModifier = 3.75f;// </Trauma>
             pryComp.PryPowered = true;
             pryComp.Force = true;
 

--- a/Content.Server/Zombies/ZombieSystem.Transform.cs
+++ b/Content.Server/Zombies/ZombieSystem.Transform.cs
@@ -245,7 +245,7 @@ public sealed partial class ZombieSystem
 
             // humanoid zombies get to pry open doors and shit
             var pryComp = EnsureComp<PryingComponent>(target);
-            pryComp.SpeedModifier = 3.75f;// </Trauma>
+            pryComp.SpeedModifier = 3.75f; // Trauma - was 0.75f 
             pryComp.PryPowered = true;
             pryComp.Force = true;
 

--- a/Content.Server/Zombies/ZombieSystem.Transform.cs
+++ b/Content.Server/Zombies/ZombieSystem.Transform.cs
@@ -245,7 +245,7 @@ public sealed partial class ZombieSystem
 
             // humanoid zombies get to pry open doors and shit
             var pryComp = EnsureComp<PryingComponent>(target);
-            pryComp.SpeedModifier = 3.75f; // Trauma - was 0.75f 
+            pryComp.SpeedModifier = 3.75f; // Trauma - was 0.75f
             pryComp.PryPowered = true;
             pryComp.Force = true;
 


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->
I change the zombie prying ability to 5x from original state
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
closes #4465
## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X ] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X ] I have tested this pull request and written instructions on how to test it
- [X ] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Made zombies prying doors 5x faster