### PR TITLE
add plant produce limit

### DIFF
--- a/Content.Trauma.Shared/Botany/PlantHarvestLimitComponent.cs
+++ b/Content.Trauma.Shared/Botany/PlantHarvestLimitComponent.cs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Content.Trauma.Shared.Botany;
+
+/// <summary>
+/// Prevents this plant from being harvested if there are too many produce entities on the server.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class PlantHarvestLimitComponent : Component
+{
+    [DataField(required: true)]
+    public int Limit;
+}

--- a/Content.Trauma.Shared/Botany/PlantHarvestLimitSystem.cs
+++ b/Content.Trauma.Shared/Botany/PlantHarvestLimitSystem.cs
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Shared.Botany.Events;
+using Content.Shared.Botany.Items.Components;
+using Content.Shared.Popups;
+
+namespace Content.Trauma.Shared.Botany;
+
+public sealed partial class PlantHarvestLimitSystem : EntitySystem
+{
+    [Dependency] private SharedPopupSystem _popup = default!;
+
+    [SubscribeLocalEvent]
+    private void OnHarvestAttempt(Entity<PlantHarvestLimitComponent> ent, ref PlantHarvestAttemptEvent args)
+    {
+        if (Count<ProduceComponent>() <= ent.Comp.Limit)
+            return; // halal
+
+        // haram
+        _popup.PopupEntity("There are too many plants!", ent, args.User);
+        args.Cancelled = true;
+    }
+}

--- a/Resources/Prototypes/_Trauma/Partials/Hydroponics/plants.yml
+++ b/Resources/Prototypes/_Trauma/Partials/Hydroponics/plants.yml
@@ -1,6 +1,13 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 - type: entity
+  abstract: true
+  id: BasePlant
+  components:
+  - type: PlantHarvestLimit
+    limit: 500 # if you make more than this time to automate the industrial grinder
+
+- type: entity
   id: WheatPlants
   components:
   - type: PlantData


### PR DESCRIPTION
plants cant be harvested if there are more than 500 produce entities on the server

botany can now be ddosed by rogue hydro trays :rocket: 