### PR TITLE
Fixes coscult spawning with less people than needed

### DIFF
--- a/Resources/Prototypes/_DV/CosmicCult/roundstart.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/roundstart.yml
@@ -19,7 +19,7 @@
     - !type:LinearAntagCount
       proto: CosmicCultist
       range:
-        min: 3
+        min: 5
         max: 8
       playerRatio: 7
   - type: AntagPlayerEffects


### PR DESCRIPTION
<!-- Guidelines: https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.  -->
## About the PR
<!-- What did you change? -->

## Why / Balance
coscult needs 5 people to go to the next stage, to be able to convert more people, if they spawned with less than 5, they were locked out

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Contributing Guidelines](https://github.com/Trauma-Station/Trauma-Station/blob/master/CONTRIBUTING.md).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at a maintainer's discretion -->

## Changelog

:cl: TechnicFighter

- fix: Fixed Cosmic Cultists being unable to progress if at low pop
